### PR TITLE
add a style for the sidebar scrollbar

### DIFF
--- a/components/dashboard-components/AppSidebar.tsx
+++ b/components/dashboard-components/AppSidebar.tsx
@@ -66,7 +66,7 @@ export default function AppSidebar() {
 
   return (
     <Sidebar className=" border-brand_tertiary/20">
-      <SidebarContent className=" bg-brand_fourthary text-brand_tertiary/90 transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-brand_fourthary scrollbar-track-brand_fourthary hover:scrollbar-thumb-brand_tertiary/20">
+      <SidebarContent className="bg-brand_fourthary text-brand_tertiary/90 transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-brand_fourthary scrollbar-track-brand_fourthary hover:scrollbar-thumb-brand_tertiary/20">
         <SidebarGroup>
           <SidebarGroupLabel className=" text-brand_tertiary/50">Notevo</SidebarGroupLabel>
           <SidebarGroupContent>

--- a/components/dashboard-components/AppSidebar.tsx
+++ b/components/dashboard-components/AppSidebar.tsx
@@ -66,7 +66,7 @@ export default function AppSidebar() {
 
   return (
     <Sidebar className=" border-brand_tertiary/20">
-      <SidebarContent className=" bg-brand_fourthary text-brand_tertiary/90">
+      <SidebarContent className=" bg-brand_fourthary text-brand_tertiary/90 transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-brand_fourthary scrollbar-track-brand_fourthary hover:scrollbar-thumb-brand_tertiary/20">
         <SidebarGroup>
           <SidebarGroupLabel className=" text-brand_tertiary/50">Notevo</SidebarGroupLabel>
           <SidebarGroupContent>

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "resend": "^4.1.1",
     "sonner": "^1.7.3",
     "tailwind-merge": "^2.6.0",
+    "tailwind-scrollbar": "^4.0.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.1"
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -80,5 +80,5 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"),require('tailwind-scrollbar')],
 } satisfies Config;


### PR DESCRIPTION
by default, Tailwind CSS doesn't include utilities for custom scrollbars (e.g., scrollbar-thumb, scrollbar-track). You need to enable these utilities by extending the Tailwind configuration if they're not enabled already 
`  plugins: [
    require('tailwind-scrollbar'), // Enable scrollbar utilities
  ],
`
`npm install tailwind-scrollbar`