### PR TITLE
fix the hydration error in the AppSidebar

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
         <div className=" w-full fixed top-0 bg-brand_primary/70 backdrop-blur-md [-webkit-backdrop-filter:blur(8px)] [backdrop-filter:blur(8px)] z-50 p-2">
           <div className="flex items-center justify-start gap-2">
             <SidebarTrigger className=" lg:block hidden" />
-            <BreadcrumbWithCustomSeparator />
+            {isClient && <BreadcrumbWithCustomSeparator />}
           </div>
         </div>
         <div className=" mt-16">{children}</div>

--- a/components/dashboard-components/AppSidebar.tsx
+++ b/components/dashboard-components/AppSidebar.tsx
@@ -29,7 +29,7 @@ import {
 } from "@radix-ui/react-dropdown-menu";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { redirect, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import WorkingSpaceSettings from "./WorkingSpaceSettings";
 import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
 import { useAuthActions } from "@convex-dev/auth/react";
@@ -65,7 +65,7 @@ export default function AppSidebar() {
     setLoading(true);
     try {
       await signOut();
-      redirect("/");
+      router.push("/");
     } catch (error) {
       console.error(error);
     } finally {
@@ -121,23 +121,29 @@ export default function AppSidebar() {
               onMouseEnter={() => setHoveredWorkingSpaceId(workingSpace._id)}
               onMouseLeave={() => setHoveredWorkingSpaceId(null)}
             >
-              <Button
-                variant="SidebarMenuButton"
-                className=" px-2 h-8 group"
-                onClick={() =>
-                  workingSpace.slug &&
-                  handlePush(workingSpace.slug, workingSpace._id)
-                }
-              >
-                <Notebook size="16" />
-                {workingSpace.name.length > 20
-                  ? `${workingSpace.name.substring(0, 20)}...`
-                  : workingSpace.name}
+              <div className="flex w-full items-center relative">
+                <Button
+                  variant="SidebarMenuButton"
+                  className="px-2 h-8 group flex-1"
+                  onClick={() =>
+                    workingSpace.slug &&
+                    handlePush(workingSpace.slug, workingSpace._id)
+                  }
+                >
+                  <Notebook size="16" />
+                  {workingSpace.name.length > 20
+                    ? `${workingSpace.name.substring(0, 20)}...`
+                    : workingSpace.name}
+                </Button>
                 <WorkingSpaceSettings
-                  className={`absolute top-0 right-0 transition-opacity duration-200 ${hoveredWorkingSpaceId === workingSpace._id ? "opacity-100" : "opacity-0"}`}
+                  className={`absolute right-2 transition-opacity duration-200 ${
+                    hoveredWorkingSpaceId === workingSpace._id
+                      ? "opacity-100"
+                      : "opacity-0"
+                  }`}
                   workingSpaceId={workingSpace._id}
                 />
-              </Button>
+              </div>
             </SidebarGroupContent>
           ))}
           <SidebarGroupContent />


### PR DESCRIPTION
The problem is that we're using a Button component inside another button element, which is causing the hydration error. This is happening in the WorkingSpace section where we have both a Button component and the WorkingSpaceSettings component (which likely contains another button).

`
<SidebarGroupContent
  className="relative w-full flex justify-between items-center"
  key={workingSpace._id}
  onMouseEnter={() => setHoveredWorkingSpaceId(workingSpace._id)}
  onMouseLeave={() => setHoveredWorkingSpaceId(null)}
>
  <div className="flex w-full items-center relative">
    <Button
      variant="SidebarMenuButton"
      className="px-2 h-8 group flex-1"
      onClick={() =>
        workingSpace.slug &&
        handlePush(workingSpace.slug, workingSpace._id)
      }
    >
      <Notebook size="16" />
      {workingSpace.name.length > 20
        ? `${workingSpace.name.substring(0, 20)}...`
        : workingSpace.name}
    </Button>
    <WorkingSpaceSettings
      className={`absolute right-2 transition-opacity duration-200 ${
        hoveredWorkingSpaceId === workingSpace._id ? "opacity-100" : "opacity-0"
      }`}
      workingSpaceId={workingSpace._id}
    />
  </div>
</SidebarGroupContent>

`
Wrapped the Button and WorkingSpaceSettings in a div container
Moved the WorkingSpaceSettings component outside of the Button component
Adjusted the positioning using absolute and relative classes
Added flex-1 to the Button to maintain proper spacing
This should resolve the hydration error by preventing the nested button structure while maintaining the same visual layout and functionality.