### PR TITLE
make the sidebar more semantic

### DIFF
--- a/components/dashboard-components/AppSidebar.tsx
+++ b/components/dashboard-components/AppSidebar.tsx
@@ -290,38 +290,44 @@ const PinnedNoteItem = memo(function PinnedNoteItem({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className="flex w-full items-center relative">
-        <TooltipProvider>
-          <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
-            <TooltipTrigger onMouseLeave={handleContentMouseEnter} asChild>
-              <Button
-                variant="SidebarMenuButton"
-                className="px-2 h-8 group flex-1"
-                asChild
-              >
-                <Link
-                  href={`/dashboard/${note.workingSpaceId}/${note.slug}?id=${note._id}`}
+      <SidebarGroupContent className="flex w-full items-center relative">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <TooltipProvider>
+              <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
+                <TooltipTrigger onMouseLeave={handleContentMouseEnter} asChild>
+                  <Button
+                    variant="SidebarMenuButton"
+                    className="px-2 h-8 group flex-1"
+                    asChild
+                  >
+                    <Link
+                      href={`/dashboard/${note.workingSpaceId}/${note.slug}?id=${note._id}`}
+                    >
+                      <Pin size="16" className="text-purple-500" />
+                      {note.title
+                        ? formatWorkspaceName(note.title)
+                        : "Untitled"}
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="rounded-lg bg-brand_fourthary border border-solid border-brand_tertiary/20 text-brand_tertiary text-xs pointer-events-none select-none"
                 >
-                  <Pin size="16" className="text-purple-500" />
-                  {note.title ? formatWorkspaceName(note.title) : "Untitled"}
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent
-              side="bottom"
-              className="rounded-lg bg-brand_fourthary border border-solid border-brand_tertiary/20 text-brand_tertiary text-xs pointer-events-none select-none"
-            >
-              {note.title || "Untitled"}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+                  {note.title || "Untitled"}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </SidebarMenuItem>
+        </SidebarMenu>
         <NoteSettings
           noteId={note._id}
           noteTitle={note.title}
           IconVariant="horizontal_icon"
           BtnClassName={`absolute right-2 invisible ${isHovered && "visible"}`}
         />
-      </div>
+      </SidebarGroupContent>
     </SidebarGroupContent>
   );
 });
@@ -368,35 +374,39 @@ const WorkspaceItem = memo(function WorkspaceItem({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className="flex w-full items-center relative">
-        <TooltipProvider>
-          <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
-            <TooltipTrigger onMouseLeave={handleContentMouseEnter} asChild>
-              <Button
-                variant="SidebarMenuButton"
-                className="px-2 h-8 group flex-1"
-                asChild
-              >
-                <Link href={`/dashboard/${workingSpace._id}`}>
-                  <Notebook size="16" />
-                  {formatWorkspaceName(workingSpace.name)}
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent
-              side="bottom"
-              className="rounded-lg bg-brand_fourthary border border-solid border-brand_tertiary/20 text-brand_tertiary text-xs pointer-events-none select-none"
-            >
-              {workingSpace.name || "Untitled"}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      <SidebarGroupContent className="flex w-full items-center relative">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <TooltipProvider>
+              <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
+                <TooltipTrigger onMouseLeave={handleContentMouseEnter} asChild>
+                  <Button
+                    variant="SidebarMenuButton"
+                    className="px-2 h-8 group flex-1"
+                    asChild
+                  >
+                    <Link href={`/dashboard/${workingSpace._id}`}>
+                      <Notebook size="16" />
+                      {formatWorkspaceName(workingSpace.name)}
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="rounded-lg bg-brand_fourthary border border-solid border-brand_tertiary/20 text-brand_tertiary text-xs pointer-events-none select-none"
+                >
+                  {workingSpace.name || "Untitled"}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </SidebarMenuItem>
+        </SidebarMenu>
         <WorkingSpaceSettings
           workingSpaceId={workingSpace._id}
           workingspaceName={workingSpace.name}
           className={`absolute right-2  invisible ${isHovered && "visible"}`}
         />
-      </div>
+      </SidebarGroupContent>
     </SidebarGroupContent>
   );
 });


### PR DESCRIPTION
usign this examble from shadcnui
```
    <Sidebar {...props}>
      <SidebarHeader>
        <VersionSwitcher
          versions={data.versions}
          defaultVersion={data.versions[0]}
        />
        <SearchForm />
      </SidebarHeader>
      <SidebarContent>
        {/* We create a SidebarGroup for each parent. */}
        {data.navMain.map((item) => (
          <SidebarGroup key={item.title}>
            <SidebarGroupLabel>{item.title}</SidebarGroupLabel>
            <SidebarGroupContent>
              <SidebarMenu>
                {item.items.map((item) => (
                  <SidebarMenuItem key={item.title}>
                    <SidebarMenuButton asChild isActive={item.isActive}>
                      <a href={item.url}>{item.title}</a>
                    </SidebarMenuButton>
                  </SidebarMenuItem>
                ))}
              </SidebarMenu>
            </SidebarGroupContent>
          </SidebarGroup>
        ))}
      </SidebarContent>
      <SidebarRail />
    </Sidebar>
  )
}
```