### PR TITLE
change the create note btn logic in the sidebar

### DIFF
--- a/app/dashboard/[id]/page.tsx
+++ b/app/dashboard/[id]/page.tsx
@@ -100,6 +100,7 @@ interface NotesDroppableContainerProps {
   searchQuery: string;
   setSearchQuery: (query: string) => void;
   tables: any[];
+  setViewMode: (mode: ViewMode) => void;
 }
 
 interface NoteCardProps {
@@ -288,76 +289,11 @@ export default function WorkingSpacePage() {
               </p>
             </div>
             <div className="flex items-center gap-2 self-end md:self-auto">
-              <div className="relative w-full md:w-auto">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  type="text"
-                  placeholder="Search notes..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-[200px] pl-9 text-foreground border-border"
-                />
-              </div>
-              <div className="flex items-center border border-border rounded-lg overflow-hidden">
-                <Button
-                  variant="Trigger"
-                  size="icon"
-                  className={cn(
-                    "h-9 w-9 rounded-none",
-                    viewMode === "grid" && "bg-background"
-                  )}
-                  onClick={() => setViewMode("grid")}
-                >
-                  <LayoutGrid className="h-4 w-4 text-muted-foreground" />
-                </Button>
-                <Button
-                  variant="Trigger"
-                  size="icon"
-                  className={cn(
-                    "h-9 w-9 rounded-none",
-                    viewMode === "list" && "bg-background"
-                  )}
-                  onClick={() => setViewMode("list")}
-                >
-                  <List className="h-4 w-4 text-muted-foreground" />
-                </Button>
-              </div>
               <CreateTableBtn workingSpaceId={workingSpaceId} />
-              <CreateNoteBtn
-                workingSpaceId={workingSpaceId}
-                workingSpacesSlug={workingSpacesSlug}
-              />
             </div>
           </div>
         </div>
       </header>
-
-      {/* Quick Access Notes Section */}
-      {quickAccessNotes.length > 0 && (
-        <section aria-labelledby="quick-access-title">
-          <header className="w-full py-2 px-1">
-            <h2
-              id="quick-access-title"
-              className="text-base text-foreground font-bold"
-            >
-              Quick Access Notes
-            </h2>
-          </header>
-          <div className={viewMode === "grid" 
-            ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
-            : "flex flex-col gap-3"
-          }>
-            {quickAccessNotes.map((note) => (
-              <QuickAccessNoteCard
-                key={note._id}
-                note={note}
-                workspaceName={workspace?.slug}
-                viewMode={viewMode}
-              />
-            ))}
-          </div>
-        </section>
-      )}
 
       {/* Tables and Notes Content */}
       <DragDropContext onDragEnd={handleDragEnd}>
@@ -390,6 +326,7 @@ export default function WorkingSpacePage() {
                   searchQuery={searchQuery}
                   setSearchQuery={setSearchQuery}
                   tables={tables}
+                  setViewMode={setViewMode}
                 />
               </TabsContent>
             ))}
@@ -434,6 +371,7 @@ function NotesDroppableContainer({
   searchQuery,
   setSearchQuery,
   tables,
+  setViewMode,
 }: NotesDroppableContainerProps): JSX.Element {
   return (
     <div className="py-2">
@@ -447,12 +385,46 @@ function NotesDroppableContainer({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <TableSettings notesTableId={tableId} tableName={tables?.find(t => t._id === tableId)?.name} />
+          <div className="relative w-[200px]">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Search notes..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-9 text-foreground border-border"
+            />
+          </div>
+          <div className="flex items-center border border-border rounded-lg overflow-hidden">
+            <Button
+              variant="Trigger"
+              size="icon"
+              className={cn(
+                "h-9 w-9 rounded-none",
+                viewMode === "grid" && "bg-muted"
+              )}
+              onClick={() => setViewMode("grid")}
+            >
+              <LayoutGrid className="h-4 w-4 text-muted-foreground" />
+            </Button>
+            <Button
+              variant="Trigger"
+              size="icon"
+              className={cn(
+                "h-9 w-9 rounded-none",
+                viewMode === "list" && "bg-muted"
+              )}
+              onClick={() => setViewMode("list")}
+            >
+              <List className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </div>
           <CreateNoteBtn
             workingSpaceId={workspaceId}
             workingSpacesSlug={workspaceSlug}
             notesTableId={tableId}
           />
+          <TableSettings notesTableId={tableId} tableName={tables?.find(t => t._id === tableId)?.name} />
         </div>
       </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
   :root {
     --background: 0 0% 100%;
     --foreground: 0 0% 4%;
-    --card: 0 0% 100%;
+    --card: 0 0% 92%;
     --card-foreground: 0 0% 4%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 4%;
@@ -78,7 +78,7 @@
   .dark {
     --background: 0 0% 4%;
     --foreground: 0 0% 98%;
-    --card: 0 0% 4%;
+    --card: 0 0% 12%;
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 4%;
     --popover-foreground: 0 0% 98%;

--- a/components/dashboard-components/TablesNotFound.tsx
+++ b/components/dashboard-components/TablesNotFound.tsx
@@ -33,7 +33,7 @@ export default function TablesNotFound({
   };
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col items-center justify-center">
+    <div className="flex my-10 flex-col items-center justify-center">
       <div className="mx-auto flex max-w-[420px] flex-col items-center justify-center text-center">
         <div className="flex h-20 w-20 items-center justify-center rounded-full bg-muted">
           <Table className="h-10 w-10 text-muted-foreground" />


### PR DESCRIPTION
modify the handleCreateNote function to first create a table (if it doesn't exist) i mean the new-quick-access-notes table name and then create a note associated with that table. Here's how i did it:
First, we'll check if a table with the name "New Quick Access Notes" exists
If it doesn't exist, we'll create it
Then we'll create the note and associate it with this table

```   const handleCreateNote = useCallback( 
    async (workingSpaceId: any, workingSpacesSlug: string) => {
      setLoading(true);
      try {
        const tableName = "New Quick Access Notes";
        
        // Create or get existing table
        const tableId = await createTable({
          name: tableName,
          workingSpaceId: workingSpaceId,
        });

        // Create note with the table ID
        const newNoteId = await createNote({
          workingSpacesSlug: workingSpacesSlug,
          workingSpaceId: workingSpaceId,
          title: tableName,
          notesTableId: tableId,
        });

        if (newNoteId) {
          const newNoteUrl = `/dashboard/${workingSpaceId}/${`new-quick-access-notes`}?id=${newNoteId}`;
          const newNote = getNotesByUserId?.find(
            (note) => note._id === newNoteId,
          );

          if (newNote) {
            router.push(newNoteUrl);
          } else {
            console.warn(
              "Newly created note not immediately found in getNotesByUserId. Navigating to the expected URL.",
            );
            router.push(newNoteUrl);
          }
        } else {
          console.error("Failed to get the ID of the newly created note.");
          router.push(`/dashboard/${workingSpaceId}`);
        }
      } catch (error) {
        console.error("Error creating note:", error);
        router.push(`/dashboard/${workingSpaceId}`);
      } finally {
        setLoading(false);
      }
    },
    [createNote, createTable, getNotesByUserId, router],
  );
```
