### PR TITLE
persist the sidebar width in cookies and restore it on page load

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,89 +1,33 @@
 "use client";
 
-import { type ReactNode, useState, useEffect, useRef, memo } from "react";
+import { type ReactNode, memo } from "react";
 import {
   SidebarProvider,
   SidebarTrigger,
   useSidebar,
-  SidebarInset,
 } from "@/components/ui/sidebar";
 import AppSidebar from "@/components/dashboard-components/AppSidebar";
 import BreadcrumbWithCustomSeparator from "@/components/dashboard-components/BreadcrumbWithCustomSeparator";
 import { MobileWarning } from "@/components/ui/mobile-warning";
 
 const DashboardContent = memo(({ children }: { children: ReactNode }) => {
-  const { open, isMobile, sidebarWidth } = useSidebar();
-  const [isClient, setIsClient] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [shadow, setShadow] = useState(false);
-  const scrollableRef = useRef<HTMLDivElement>(null);
-  const mainRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setIsClient(true);
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 100);
-    return () => clearTimeout(timer);
-  }, []);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      if (scrollableRef.current) {
-        const top = scrollableRef.current.scrollTop;
-        setShadow(top > 0);
-      }
-    };
-
-    const scrollableElement = scrollableRef.current;
-    if (scrollableElement) {
-      scrollableElement.addEventListener("scroll", handleScroll);
-    }
-
-    return () => {
-      if (scrollableElement) {
-        scrollableElement.removeEventListener("scroll", handleScroll);
-      }
-    };
-  }, []);
-
-  if (!isClient || isLoading) {
-    return (
-      <div className="flex h-screen w-full bg-accent overflow-hidden">
-        <div style={{ width: `${sidebarWidth}px` }} />
-        <main className={`relative flex flex-col flex-1 min-h-svh transition-all duration-300 ease-in-out border-border ${
-          open && !isMobile ? `rounded-t-xl border-t border-l mt-3` : ''
-        } rounded-none bg-background`}>
-          <div className="mt-14 flex-1 overflow-auto">
-            {children}
-          </div>
-        </main>
-      </div> 
-    );
-  }
+  const { open, isMobile } = useSidebar();
 
   return (
     <div className="flex h-screen w-full bg-accent overflow-hidden">
       <AppSidebar />
       <main
-        ref={mainRef}
         className={`relative flex flex-col flex-1 min-h-svh transition-all duration-300 ease-in-out border-primary/20 ${
           open && !isMobile ? `rounded-t-xl border-t border-l mt-3` : ''
         } rounded-none bg-background`}
       >
-        <div
-          className={`w-full absolute top-0 mx-auto py-2.5 ${
-            shadow ? "shadow-2xl shadow-border/10" : "shadow-none"
-          }`}
-        >
-        <div className="w-full flex items-center justify-start px-5 gap-3">
+
+        <div className="w-full flex items-center justify-start px-5 gap-3  mx-auto py-2.5">
           {(!open || isMobile) && <SidebarTrigger />}
           <BreadcrumbWithCustomSeparator />
         </div>
-        </div>
         <div
-          className="mt-14 flex-1 overflow-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
-          ref={scrollableRef}
+          className="pt-7 flex-1 overflow-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
         >
           {children}
         </div>

--- a/components/dashboard-components/AppSidebar.tsx
+++ b/components/dashboard-components/AppSidebar.tsx
@@ -61,14 +61,11 @@ import WorkingSpaceSettingsSidbar from "./WorkingSpaceSettingsSidbar";
 import React from "react";
 import { ThemeToggle } from "../ThemeToggle";
 import { UserIcon } from "lucide-react";
-import Image from "next/image";
-import { FolderIcon } from "lucide-react";
 
 // --- Skeleton Sidebar Component ---
-
 const SkeletonSidebar = () => {
   return (
-    <Sidebar variant="inset" className="border-border group">
+    <Sidebar className="border-border group">
       <SidebarHeader className=" text-foreground border-b border-border">
         <div className=" w-full flex items-center justify-between p-1.5">
           <div className="flex items-center justify-start gap-2">


### PR DESCRIPTION
The sidebar width was stored in a cookie and read on the client, but the server-rendered HTML always used a default width (e.g., 240px). this happened after the fact that i tried to store the width of the side bar in the cookie the wrong way

(This caused a hydration error)
The SkeletonSidebar (loading state) did not respect the user's last sidebar width, leading to a jarring UI and further mismatches.

 so we fix it (we mean claude and i 😊) , here's how :
The sidebar width state (sidebarWidth) is now initialized as null.
**Client Sync** : On client mount (useEffect), the sidebar width is read from the cookie and set in state.
 so anyways No more hydration mismatches between SSR and client. Sidebar width is always in sync with user preference, even during loading.
The main content and overlays can use the CSS variable for layout consistency.


