### PR TITLE
fix the bounsing of the sidebar when the state is closed

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -19,7 +19,7 @@ const DashboardContent = memo(({ children }: { children: ReactNode }) => {
       <main
         className={`relative flex flex-col flex-1 min-h-svh transition-all duration-300 ease-in-out border-primary/20 ${
           open && !isMobile ? `rounded-t-xl border-t border-l mt-3` : ''
-        } rounded-none bg-background`}
+        } rounded-none bg-background `}
       >
 
         <div className="w-full flex items-center justify-start px-5 gap-3  mx-auto py-2.5">


### PR DESCRIPTION
 using the last value the user set (persisted in cookies). before when the user closes the sidebar and it make it in the cookie as false , then when the user refresh the page the sidebar bonuses cuz it did not know that the value in the cookie is false yet so :

**what needed to change :**
1. Initialize the sidebar open state as null (not true/false). 
2. On client mount (useEffect), read the cookie and set the real value.
3. Render nothing (or a skeleton) until the open state is known.
4. When the user toggles the sidebar, update both state and cookie.

