### PR TITLE
The change I made allows the email field to accept an empty string

### DIFF
--- a/components/dashboard-components/Feedback.tsx
+++ b/components/dashboard-components/Feedback.tsx
@@ -28,7 +28,7 @@ const formSchema = z.object({
     message: "Feedback must be at least 5 characters.",
   }),
   name: z.string().optional(),
-  email: z.string().email({ message: "Invalid email address." }).optional(),
+  email: z.string().email({ message: "Invalid email address." }).optional().or(z.literal("")),
 });
 
 export default function Feedback() {


### PR DESCRIPTION
 in addition to being optional, which prevents validation errors when the field is left empty. The .or(z.literal("")) part tells Zod that an empty string is also a valid value for the email field.