### PR TITLE
persist read-only warning dismissal across sessions 

### DIFF
--- a/components/readOnly-warning.tsx
+++ b/components/readOnly-warning.tsx
@@ -9,14 +9,14 @@ export function ReadOnlyWarning() {
   const [showWarning, setShowWarning] = useState(false);
 
   useEffect(() => {
-    const hasSeenWarning = sessionStorage.getItem("ReadOnlySeen");
+    const hasSeenWarning = localStorage.getItem("ReadOnlySeen");
     if (!hasSeenWarning) {
       setShowWarning(true);
     }
   }, []);
 
   const handleDismiss = () => {
-    sessionStorage.setItem("ReadOnlySeen", "true");
+    localStorage.setItem("ReadOnlySeen", "true");
     setShowWarning(false);
   };
 


### PR DESCRIPTION
AKA make it localStorage

swapped `sessionStorage` for `localStorage` in `ReadOnlyWarning`. the warning was reappearing every time the user opened a new tab or closed and reopened the browser. now once dismissed it stays dismissed.