### PR TITLE
remove unused  arrays from legal pages

### DIFF
--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -18,27 +18,6 @@ import {
 } from "lucide-react";
 import { NOISE_PNG } from "@/lib/data";
 import { useMediaQuery } from "react-responsive";
-const sections = [
-  { id: "consent", label: "Consent", icon: Shield, number: "01" },
-  {
-    id: "collection",
-    label: "Information We Collect",
-    icon: Database,
-    number: "02",
-  },
-  { id: "yourdata", label: "Your Data", icon: Lock, number: "03" },
-  { id: "links", label: "Links to Other Sites", icon: LinkIcon, number: "04" },
-  {
-    id: "thirdparty",
-    label: "Third-Party Policies",
-    icon: Globe,
-    number: "05",
-  },
-  { id: "cookies", label: "Cookies", icon: Cookie, number: "06" },
-  { id: "gdpr", label: "GDPR Rights", icon: Shield, number: "07" },
-  { id: "changes", label: "Policy Changes", icon: RefreshCw, number: "08" },
-];
-
 function SubSection({
   title,
   children,

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -18,21 +18,6 @@ import {
 } from "lucide-react";
 import { NOISE_PNG } from "@/lib/data";
 import { useMediaQuery } from "react-responsive";
-const sections = [
-  { id: "liability", label: "Liability", icon: Shield, number: "01" },
-  { id: "account", label: "Account", icon: User, number: "02" },
-  { id: "uptime", label: "Uptime & Security", icon: Server, number: "03" },
-  {
-    id: "copyright",
-    label: "Copyright & Ownership",
-    icon: Copyright,
-    number: "04",
-  },
-  { id: "features", label: "Features & Bugs", icon: Wrench, number: "05" },
-  { id: "ai", label: "AI & Third-Party", icon: Bot, number: "06" },
-  { id: "updates", label: "Updates to Terms", icon: RefreshCw, number: "07" },
-];
-
 function SubSection({
   title,
   children,


### PR DESCRIPTION
deleted the `sections` arrays from `privacy-policy/page.tsx` and `terms-of-service/page.tsx`. these were likely nav sidebar data for a table of contents that was never built or got removed at some point, nothing was consuming them.