### PR TITLE
fix note page content width , minor whitespace

### DIFF
--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -14,11 +14,7 @@ import { useDebouncedCallback } from "use-debounce";
 
 const noteMemoryCache = new Map<string, unknown>();
 
-export default function NotePageClient({
-  noteId,
-}: {
-  noteId: Id<"notes">;
-}) {
+export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const { noteWidth } = useNoteWidth();
   const note = useQuery(api.notes.getNoteById, { _id: noteId });
   const [lastNote, setLastNote] = useState<typeof note>(() => {
@@ -134,7 +130,12 @@ export default function NotePageClient({
   }
 
   return (
-    <div className={cn(noteWidth === "false" ? "container " : "px-4", "pb-28")}>
+    <div
+      className={cn(
+        noteWidth === "false" ? "w-[900px] " : "px-4",
+        " pb-28 mx-auto",
+      )}
+    >
       <TailwindAdvancedEditor
         editorBubblePlacement={false}
         initialContent={content ?? serverContent}

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -88,6 +88,7 @@ export default function PrivacyPage() {
           zIndex: 5,
         }}
       />
+    
       <div className="flex-grow">
         <MaxWContainer className="max-w-[760px] mx-auto px-6 pb-44">
           {/* Hero */}


### PR DESCRIPTION
**`NotePageClient.tsx`**
replaced `container` with `w-[900px] mx-auto` for the fixed-width note layout for better readability. `container` was using the breakpoint-based max widths from tailwind which didn't give the intended fixed reading width. also reformatted the component props and the `cn()` call to be less cramped.

**`privacy-policy/page.tsx`**
added a blank line for readability (no functional change).