### PR TITLE
move auth guard to layout + convert pages to server components,cleanup

### DIFF
--- a/app/home/[id]/[slug]/loading.tsx
+++ b/app/home/[id]/[slug]/loading.tsx
@@ -19,7 +19,7 @@ function ParagraphSkeleton() {
 
 export default function Loading() {
   return (
-    <MaxWContainer className="relative my-8 space-y-5">
+    <MaxWContainer className="relative w-[900px] my-8 space-y-5">
       <div className="mb-6">
         <Skeleton className="h-8 w-2/3 mb-3" />
         <Skeleton className="h-4 w-48" />

--- a/app/home/[id]/[slug]/page.tsx
+++ b/app/home/[id]/[slug]/page.tsx
@@ -1,37 +1,18 @@
-"use client";
-
+import { redirect } from "next/navigation";
 import type { Id } from "@/convex/_generated/dataModel";
 import NotePageClient from "./NotePageClient";
-import { useSearchParams, useRouter } from "next/navigation";
-import { useEffect, useMemo } from "react";
-import { useConvexAuth } from "convex/react";
 
-export default function NotePage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const { isAuthenticated, isLoading } = useConvexAuth();
+export default async function NotePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ id?: string | string[] }>;
+}) {
+  const { id } = await searchParams;
+  const noteId = typeof id === "string" ? id : Array.isArray(id) ? id[0] : null;
 
-  const noteId = useMemo(() => {
-    const id = searchParams.get("id");
-    return (id ?? null) as Id<"notes"> | null;
-  }, [searchParams]);
+  if (!noteId) {
+    redirect("/home");
+  }
 
-  useEffect(() => {
-    if (isLoading) return;
-    if (!isAuthenticated) {
-      router.replace("/signup");
-      router.refresh();
-    }
-  }, [isAuthenticated, isLoading, router]);
-
-  useEffect(() => {
-    if (noteId === null) {
-      router.replace("/home");
-      router.refresh();
-    }
-  }, [noteId, router]);
-
-  if (noteId === null || isLoading || !isAuthenticated) return null;
-
-  return <NotePageClient noteId={noteId} />;
+  return <NotePageClient noteId={noteId as Id<"notes">} />;
 }

--- a/app/home/[id]/page.tsx
+++ b/app/home/[id]/page.tsx
@@ -1,40 +1,19 @@
-"use client";
-
+import { redirect } from "next/navigation";
 import type { Id } from "@/convex/_generated/dataModel";
 import WorkingSpacePageClient from "./WorkingSpacePageClient";
-import { useConvexAuth } from "convex/react";
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useMemo } from "react";
 
-export default function WorkingSpacePage() {
-  const router = useRouter();
-  const params = useParams();
-  const { isAuthenticated, isLoading } = useConvexAuth();
+export default async function WorkingSpacePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
 
-  const workingSpaceId = useMemo(() => {
-    const raw = (params as any)?.id;
-    if (typeof raw === "string") return raw as Id<"workingSpaces">;
-    if (Array.isArray(raw) && typeof raw[0] === "string")
-      return raw[0] as Id<"workingSpaces">;
-    return null;
-  }, [params]);
+  if (!id) {
+    redirect("/home");
+  }
 
-  useEffect(() => {
-    if (isLoading) return;
-    if (!isAuthenticated) {
-      router.replace("/signup");
-      router.refresh();
-    }
-  }, [isAuthenticated, isLoading, router]);
-
-  useEffect(() => {
-    if (workingSpaceId === null) {
-      router.replace("/home");
-      router.refresh();
-    }
-  }, [router, workingSpaceId]);
-
-  if (isLoading || !isAuthenticated || workingSpaceId === null) return null;
-
-  return <WorkingSpacePageClient workingSpaceId={workingSpaceId} />;
+  return (
+    <WorkingSpacePageClient workingSpaceId={id as Id<"workingSpaces">} />
+  );
 }

--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { isAuthenticatedNextjs } from "@convex-dev/auth/nextjs/server";
 import HomeClientLayout from "@/components/home-components/HomeClientLayout";
 import { generateMetadata as generateSEOMetadata } from "@/lib/seo";
 
@@ -10,10 +12,14 @@ export const metadata: Metadata = generateSEOMetadata({
   noindex: true, // Private pages should not be indexed
 });
 
-export default function HomeLayout({
+export default async function HomeLayout({
   children,
 }: {
   children: ReactNode;
 }) {
+  if (!(await isAuthenticatedNextjs())) {
+    redirect("/signup");
+  }
+
   return <HomeClientLayout>{children}</HomeClientLayout>;
 }

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,23 +1,5 @@
-"use client";
-
 import HomePageClient from "./HomePageClient";
-import { useConvexAuth } from "convex/react";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 
 export default function HomePage() {
-  const router = useRouter();
-  const { isAuthenticated, isLoading } = useConvexAuth();
-
-  useEffect(() => {
-    if (isLoading) return;
-    if (!isAuthenticated) {
-      router.replace("/signup");
-      router.refresh();
-    }
-  }, [isAuthenticated, isLoading, router]);
-
-  if (isLoading || !isAuthenticated) return null;
-
   return <HomePageClient />;
 }

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -2,20 +2,6 @@
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import MaxWContainer from "@/components/ui/MaxWContainer";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import {
-  Home,
-  Calendar,
-  Shield,
-  Database,
-  Link as LinkIcon,
-  Globe,
-  Cookie,
-  Lock,
-  RefreshCw,
-  FileSymlink,
-} from "lucide-react";
 import { NOISE_PNG } from "@/lib/data";
 import { useMediaQuery } from "react-responsive";
 function SubSection({
@@ -88,7 +74,7 @@ export default function PrivacyPage() {
           zIndex: 5,
         }}
       />
-    
+
       <div className="flex-grow">
         <MaxWContainer className="max-w-[760px] mx-auto px-6 pb-44">
           {/* Hero */}
@@ -266,53 +252,6 @@ export default function PrivacyPage() {
             </SubSection>
           </SectionBlock>
         </MaxWContainer>
-      </div>
-
-      {/* Sticky footer pill */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 flex justify-center pb-6 pointer-events-none">
-        <div
-          className={cn(
-            "pointer-events-auto flex items-center gap-3.5 rounded-lg  px-5 pr-2.5 py-2",
-            "bg-gradient-to-r from-50% from-[rgba(26,22,20,0.95)] to-80% to-transparent ",
-            "transition-all duration-500",
-            scrolled ? "translate-y-0 opacity-100" : "translate-y-16 opacity-0",
-          )}
-        >
-          <div className="flex items-center gap-2.5">
-            <div className="w-7 h-7 rounded-lg bg-[rgba(255,223,181,0.1)] grid place-items-center flex-shrink-0">
-              <Calendar className="w-3 h-3 text-secondary" />
-            </div>
-            <div className="leading-tight">
-              <span className="block text-[0.62rem] text-muted/80 uppercase tracking-widest">
-                Last Modified
-              </span>
-              <span className="text-[0.78rem] font-medium text-secondary">
-                December 2, 2025
-              </span>
-            </div>
-            <div className="w-px h-5 bg-muted/50 mx-1" />
-          </div>
-          <div className=" gap-2 flex justify-between items-center">
-            <Button asChild size="sm" className="gap-1.5 h-8 px-2 text-xs">
-              <Link href="/">
-                <Home className="w-3 h-3" />
-                Home
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="gap-1.5 h-8 px-2 text-xs"
-            >
-              <Link prefetch={true} href="/terms-of-service">
-                <FileSymlink className="w-3 h-3" />
-
-                {isMobile ? `Terms...` : "Terms of Service"}
-              </Link>
-            </Button>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -2,20 +2,6 @@
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import MaxWContainer from "@/components/ui/MaxWContainer";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import {
-  Home,
-  Calendar,
-  Shield,
-  User,
-  Server,
-  Copyright,
-  Wrench,
-  Bot,
-  RefreshCw,
-  FileSymlink,
-} from "lucide-react";
 import { NOISE_PNG } from "@/lib/data";
 import { useMediaQuery } from "react-responsive";
 function SubSection({
@@ -291,53 +277,6 @@ export default function TermsPage() {
             </SubSection>
           </SectionBlock>
         </MaxWContainer>
-      </div>
-
-      {/* Sticky footer pill */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 flex justify-center pb-6 pointer-events-none">
-        <div
-          className={cn(
-            "pointer-events-auto flex items-center gap-3.5 rounded-lg  px-5 pr-2.5 py-2",
-            "bg-gradient-to-r from-50% from-[rgba(26,22,20,0.95)] to-80% to-transparent ",
-            "transition-all duration-500",
-            scrolled ? "translate-y-0 opacity-100" : "translate-y-16 opacity-0",
-          )}
-        >
-          <div className="flex items-center gap-2.5">
-            <div className="w-7 h-7 rounded-lg bg-[rgba(255,223,181,0.1)] grid place-items-center flex-shrink-0">
-              <Calendar className="w-3 h-3 text-secondary" />
-            </div>
-            <div className="leading-tight">
-              <span className="block text-[0.62rem] text-muted/80 uppercase tracking-widest">
-                last modified
-              </span>
-              <span className="text-[0.78rem] font-medium text-secondary">
-                March 6, 2025
-              </span>
-            </div>
-            <div className="w-px h-5 bg-muted/50 mx-1" />
-          </div>
-          <div className=" gap-2 flex justify-between items-center">
-            <Button asChild size="sm" className="gap-1.5 h-8 px-2 text-xs">
-              <Link href="/">
-                <Home className="w-3 h-3" />
-                Home
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="gap-1.5 h-8 px-2 text-xs"
-            >
-              <Link prefetch={true} href="/privacy-policy">
-                <FileSymlink className="w-3 h-3" />
-
-                {isMobile ? `Privacy...` : "Privacy Policy"}
-              </Link>
-            </Button>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/components/ui/NoteLoadingSkeletonUI.tsx
+++ b/components/ui/NoteLoadingSkeletonUI.tsx
@@ -1,21 +1,32 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
-export default function NoteLoadingSkeletonUI() {
+function Skeleton({ className = "" }: { className?: string }) {
   return (
-    <MaxWContainer>
-      <div className="animate-pulse my-10">
-        <div className="h-6 bg-primary/20 rounded-lg mb-4 w-1/2"></div>
-        <div className="h-4 bg-primary/20 rounded-lg mb-2 w-3/4"></div>
-        <div className="h-32 bg-primary/20 rounded-lg mb-4 w-full"></div>
-        <div className="h-4 bg-primary/20 rounded-lg mb-2 w-5/6"></div>
-        <div className="h-4 bg-primary/20 rounded-lg mb-2 w-2/3"></div>
-        <div className="h-4 bg-primary/20 rounded-lg mb-2 w-1/4"></div>
+    <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />
+  );
+}
+
+function ParagraphSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-11/12" />
+      <Skeleton className="h-4 w-10/12" />
+      <Skeleton className="h-4 w-9/12" />
+    </div>
+  );
+}
+
+export default function Loading() {
+  return (
+    <MaxWContainer className="relative w-[900px] my-8 space-y-5">
+      <div className="mb-6">
+        <Skeleton className="h-8 w-2/3 mb-3" />
+        <Skeleton className="h-4 w-48" />
       </div>
-      <div className="animate-pulse my-10">
-        <div className="h-6 bg-primary/20 rounded-lg mb-4 w-1/2"></div>
-        <div className="h-4 bg-primary/20 rounded-lg mb-2 w-3/4"></div>
-        <div className="h-4 bg-primary/20 rounded-lg mb-2 w-1/4"></div>
-      </div>
+      <ParagraphSkeleton />
+      <div className="h-40 rounded-lg bg-primary/10 animate-pulse" />
+      <ParagraphSkeleton />
     </MaxWContainer>
   );
 }


### PR DESCRIPTION
solid architectural improvement auth checks moved out of individual client pages and into the layout where they belong.

### what changed

**`app/home/layout.tsx`  server-side auth guard**
added `isAuthenticatedNextjs()` check at the layout level. any unauthenticated request to any `/home/*` route now redirects to `/signup` before rendering anything. this replaces the per-page client-side `useConvexAuth` + `useEffect` + `router.replace` pattern.

**`app/home/page.tsx`, `app/home/[id]/page.tsx`, `app/home/[id]/[slug]/page.tsx`**
all three converted from client components to server components. removed `useConvexAuth`, `useRouter`, `useEffect`, and `useMemo` from each. they now just read params server-side and pass them down to the existing client components.

**`app/home/[id]/[slug]/loading.tsx` + `NoteLoadingSkeletonUI.tsx`**
both updated to use `w-[900px]` to match the note page content width. `NoteLoadingSkeletonUI` was also rewritten with a proper `Skeleton` + `ParagraphSkeleton` component structure instead of the old flat div approach.

**`app/privacy-policy/page.tsx` + `app/terms-of-service/page.tsx`**
removed the sticky footer pill from both pages  it had unused imports, relied on a `scrolled` state not shown in context, and was dead ui.


#### why

the old pattern had a flash of `null` while waiting for auth to resolve on the client. the layout-level server check is instant and cleaner. also makes the page files much smaller.

#### now

- no auth flash on protected pages
- home pages are now proper server components
- loading skeleton matches actual content width
- legal pages are simpler with dead ui removed