### PR TITLE
 replace youtube prompt with dialog, responsive embed styles, width fix

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -929,7 +929,30 @@ html {
 }
 
 
+/* Responsive YouTube Embed */
+[data-youtube-video] {
+  position: relative;
+  width: 100% !important;
+  max-width: 100% !important;
+  margin: 1.5rem 0 !important;
+  padding: 0 !important;
+}
 
+[data-youtube-video] iframe {
+  width: 100% !important;
+  height: auto !important;
+  aspect-ratio: 16 / 9 !important;
+  border-radius: 12px !important;
+  border: 1px solid hsl(var(--muted)) !important;
+  display: block !important;
+  max-width: 100% !important;
+}
+
+@media (max-width: 640px) {
+  [data-youtube-video] iframe {
+    border-radius: 8px !important;
+  }
+}
 
 @layer base {
   body {

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -132,7 +132,7 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   return (
     <div
       className={cn(
-        noteWidth === "false" ? "w-[900px] " : "px-4",
+        noteWidth === "false" ? " Desktop:w-[900px] w-full px-4" : "px-6",
         " pb-28 mx-auto",
       )}
     >

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -64,7 +64,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
-        <div className="z-[10] relative w-full flex items-center justify-start px-5 gap-3 mx-auto rounded-tl-lg border-none py-2.5 ">
+        <div className="z-[10] relative w-full flex items-center justify-start px-4 gap-3 mx-auto rounded-tl-lg border-none py-2.5 ">
           <div className="flex justify-between items-center w-full">
             <div className="flex justify-start items-center gap-3">
               {(!open || isMobile) && <SidebarTrigger />}
@@ -108,19 +108,13 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
 
 HomeContent.displayName = "homeContent";
 
-const HomeClientLayout = memo(
-  ({
-    children,
-  }: {
-    children: ReactNode;
-  }) => {
-    return (
-      <SidebarProvider>
-        <HomeContent>{children}</HomeContent>
-      </SidebarProvider>
-    );
-  },
-);
+const HomeClientLayout = memo(({ children }: { children: ReactNode }) => {
+  return (
+    <SidebarProvider>
+      <HomeContent>{children}</HomeContent>
+    </SidebarProvider>
+  );
+});
 
 HomeClientLayout.displayName = "homeClientLayout";
 

--- a/components/slash-command.tsx
+++ b/components/slash-command.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
 import {
   CheckSquare,
   Code,
@@ -15,7 +17,109 @@ import {
 import { createSuggestionItems } from "novel";
 import { Command, renderItems } from "novel";
 import { uploadFn } from "./image-upload";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { z } from "zod";
 
+const youtubeUrlSchema = z
+  .string()
+  .refine(
+    (url) =>
+      /^(https?:\/\/)?(www\.)?(youtube\.com\/(watch\?v=|embed\/|shorts\/)|youtu\.be\/)[-\w]{11}/.test(
+        url,
+      ),
+    { message: "Please enter a valid YouTube URL." },
+  );
+
+function YoutubeDialog({
+  onConfirm,
+  onClose,
+}: {
+  onConfirm: (url: string) => void;
+  onClose: () => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const validate = (value: string): boolean => {
+    const result = youtubeUrlSchema.safeParse(value);
+    if (!result.success) {
+      setError(result.error.errors[0].message);
+      return false;
+    }
+    setError(null);
+    return true;
+  };
+
+  const handleSubmit = () => {
+    if (validate(url)) {
+      onConfirm(url);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Embed YouTube Video</DialogTitle>
+          <DialogDescription>
+            Paste a YouTube URL to embed it in the editor.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-1">
+          <Input
+            placeholder="https://www.youtube.com/watch?v=..."
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              if (error) validate(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSubmit();
+            }}
+            className={
+              error ? "border-destructive focus-visible:ring-destructive" : ""
+            }
+            autoFocus
+          />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <div className="flex justify-end gap-2 mt-2">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!youtubeUrlSchema.safeParse(url).success}
+            onClick={handleSubmit}
+          >
+            Embed
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function openYoutubeDialog(onConfirm: (url: string) => void) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  const cleanup = () => {
+    root.unmount();
+    container.remove();
+  };
+
+  root.render(<YoutubeDialog onConfirm={onConfirm} onClose={cleanup} />);
+}
 export const suggestionItems = createSuggestionItems([
   {
     title: "Text",
@@ -149,15 +253,10 @@ export const suggestionItems = createSuggestionItems([
     searchTerms: ["youtube", "video", "embed"],
     icon: <Youtube className="w-5 h-5" />,
     command: ({ editor, range }: any) => {
-      const url = prompt("Enter YouTube URL:");
-      if (url) {
-        editor
-          .chain()
-          .focus()
-          .deleteRange(range)
-          .setYoutubeVideo({ src: url })
-          .run();
-      }
+      editor.chain().focus().deleteRange(range).run();
+      openYoutubeDialog((url) => {
+        editor.chain().focus().setYoutubeVideo({ src: url }).run();
+      });
     },
   },
   {

--- a/components/youtube-url-prompt.tsx
+++ b/components/youtube-url-prompt.tsx
@@ -1,0 +1,12 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "./ui/input";
+export default function YoutubeUrlPrompt() {
+  return;
+}


### PR DESCRIPTION
## replace youtube prompt with dialog + responsive embed styles + note width fix

<img width="537" height="234" alt="image" src="https://github.com/user-attachments/assets/24cea69e-ad73-46ed-9a72-c81ffc00ebf6" />

<img width="559" height="272" alt="image" src="https://github.com/user-attachments/assets/56400d9f-426e-4fc4-a13d-cc79bde5a0a1" />

### what changed

**`slash-command.tsx`  youtube embed dialog**
replaced the browser `prompt()` call with a proper `YoutubeDialog` component. the dialog validates the url with zod before allowing submission, shows inline error messages, and supports enter-to-submit. it's mounted imperatively with `createRoot` so it works outside of the react tree where the slash command runs. the embed button stays disabled until the url passes validation.

**`globals.css`  responsive youtube embed styles**
added `[data-youtube-video]` styles so embedded youtube iframes are always full width, use `aspect-ratio: 16/9`, have rounded corners, and a subtle border. slightly less rounded on mobile (8px vs 12px).

**`NotePageClient.tsx`  responsive note width**
changed the fixed-width note layout from a hard `w-[900px]` (which overflowed on smaller screens) to `Desktop:w-[900px] w-full px-4`. now it's full width with padding on anything below the desktop breakpoint.

**`HomeClientLayout.tsx`  minor cleanup**
tightened the header padding from `px-5` to `px-4` and reformatted the `memo` wrapper to be more compact.


`prompt()` is a browser-blocking native dialog with no styling, no validation, and no undo. the new dialog integrates with the rest of the ui and prevents bad urls from being embedded. the note width fix prevents horizontal scroll on tablets.