### PR TITLE
add consistent hr styling in globals.css

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -357,6 +357,12 @@ html {
   font-weight: bold;
 }
 
+hr {
+  border: none !important;
+  border-top: 2px solid hsl(var(--border)) !important;
+  margin: 2rem 0 !important;
+}
+
 .ProseMirror p.is-empty:not(.is-editor-empty)::before {
   content: attr(data-placeholder);
   float: left;


### PR DESCRIPTION
hr tags were inheriting inconsistent or browser-default styles. now they have a clean, consistent 2px border using the theme's `--border` color with proper spacing.

- uniform horizontal rules across the entire app
- matches the design system (uses hsl(var(--border)))
- better visual separation in content like thoughts or docs
- overrides any conflicting styles with `!important`

#### changes

- app/globals.css
  - added `hr` rule with `border: none`, `border-top: 2px solid hsl(var(--border))`, and `margin: 2rem 0`