### PR TITLE
redirect to / instead of /signup or/home, sign out cleanup

### DIFF
--- a/app/home/[id]/[slug]/page.tsx
+++ b/app/home/[id]/[slug]/page.tsx
@@ -11,7 +11,7 @@ export default async function NotePage({
   const noteId = typeof id === "string" ? id : Array.isArray(id) ? id[0] : null;
 
   if (!noteId) {
-    redirect("/home");
+    redirect("/");
   }
 
   return <NotePageClient noteId={noteId as Id<"notes">} />;

--- a/app/home/[id]/page.tsx
+++ b/app/home/[id]/page.tsx
@@ -10,10 +10,8 @@ export default async function WorkingSpacePage({
   const { id } = await params;
 
   if (!id) {
-    redirect("/home");
+    redirect("/");
   }
 
-  return (
-    <WorkingSpacePageClient workingSpaceId={id as Id<"workingSpaces">} />
-  );
+  return <WorkingSpacePageClient workingSpaceId={id as Id<"workingSpaces">} />;
 }

--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -18,7 +18,7 @@ export default async function HomeLayout({
   children: ReactNode;
 }) {
   if (!(await isAuthenticatedNextjs())) {
-    redirect("/signup");
+    redirect("/");
   }
 
   return <HomeClientLayout>{children}</HomeClientLayout>;

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -1165,8 +1165,7 @@ const AppSidebar = React.memo(function AppSidebar() {
     setIsSigningOut(true);
     try {
       await signOut();
-      router.replace("/");
-      router.refresh();
+      redirect("/");
     } catch (error) {
       console.error("Error signing out:", error);
     } finally {


### PR DESCRIPTION
## redirect to `/` instead of `/signup` or `/home` + sign out cleanup

small routing consistency pass.

- unauthenticated redirect in `home/layout.tsx` changed from `/signup` to `/`
- missing param redirects in `home/[id]/page.tsx` and `home/[id]/[slug]/page.tsx` changed from `/home` to `/`
- sign out in `AppSidebar.tsx` switched from `router.replace("/") + router.refresh()` to `redirect("/")` — cleaner and consistent with the other redirects

### why

centralizes all fallback routing to `/` so the landing page handles where to send the user from there, rather than having different pages make that decision independently.