### PR TITLE
swap workspace hover icon: ChevronRight to FolderOpen

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronUp,
   FolderClosed,
+  FolderOpen,
 } from "lucide-react";
 import { TbSelector } from "react-icons/tb";
 import {
@@ -759,7 +760,7 @@ const WorkspaceItem = memo(
                         className="flex items-center gap-2 flex-grow min-w-0"
                       >
                         {isHovered || isActive ? (
-                          <ChevronRight
+                          <FolderOpen
                             size="16"
                             className="flex-shrink-0 text-primary"
                           />


### PR DESCRIPTION
before : 
<img width="147" height="33" alt="image" src="https://github.com/user-attachments/assets/b0a4c506-c375-42f4-b9ac-a42f378c74ef" />

now : 
<img width="135" height="52" alt="image" src="https://github.com/user-attachments/assets/5ac5c632-20d0-4fd1-8755-4a8aac66f0d0" />

changed the icon shown when hovering or selecting a workspace item in the sidebar from `ChevronRight` to `FolderOpen`. gives a more intuitive visual cue that the item is a workspace/folder rather than a navigation arrow.

it just looks better