### PR TITLE
note/workspace delete navigation fixes + create note nav removed

### DIFF
--- a/components/home-components/CreateNoteBtn.tsx
+++ b/components/home-components/CreateNoteBtn.tsx
@@ -59,10 +59,6 @@ export default function CreateNoteBtn({
         workingSpacesSlug,
         workingSpaceId,
       });
-      // Navigate to the new note using its real slug-based URL
-      router.push(
-        `/home/${workingSpaceId}/new-quick-access-notes?id=${newNoteId}`,
-      );
     } catch (error) {
       console.error("Failed to create note:", error);
       // Optional: show toast/error if creation fails

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -22,10 +22,9 @@ import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useQuery } from "@/cache/useQuery";
 import { Button } from "@/components/ui/button";
-
 import { SquarePen, X, Pin, PinOff } from "lucide-react";
 import { cn } from "@/lib/utils";
-
+import { redirect, usePathname, useSearchParams } from "next/navigation";
 interface NoteSettingsSidbarProps {
   noteId: Id<"notes"> | any;
   noteTitle: string | any;
@@ -37,12 +36,15 @@ export default function NoteSettingsSidbar({
   noteTitle,
   ContainerClassName,
 }: NoteSettingsSidbarProps) {
+  const pathname = usePathname();
+  const pathSegments = pathname.split("/").filter((segment) => segment);
+  const searchParams = useSearchParams();
+  const realPathName = `/home/${pathSegments[1]}/${pathSegments[2]}?id=${searchParams.get("id")}`;
+  const noteHref = `/home/${pathSegments[1]}/${pathSegments[2]}?id=${noteId}`;
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
     (local, args) => {
       const { _id, favorite } = args;
-
       // Update single note query
       const note = local.getQuery(api.notes.getNoteById, { _id });
       if (note && favorite !== undefined) {
@@ -79,9 +81,15 @@ export default function NoteSettingsSidbar({
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-
     try {
-      await deleteNote({ _id: noteId });
+      if (realPathName === noteHref) {
+        await deleteNote({ _id: noteId });
+        redirect(`/home`);
+      } else {
+        await deleteNote({ _id: noteId });
+      }
+    } catch (error) {
+      console.error("Failed to delete note:", error);
     } finally {
       setIsAlertOpen(false);
     }

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -26,7 +26,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { X } from "lucide-react";
 import { Settings, Users, Trash2 } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, redirect } from "next/navigation";
 
 interface WorkingSpaceSettingsSidbarProps {
   workingSpaceId: Id<"workingSpaces">;
@@ -68,10 +68,7 @@ export default function WorkingSpaceSettingsSidbar({
     const workspace = local.getQuery(api.workingSpaces.getWorkingSpaceById, {
       _id,
     });
-    if (workspace) {
-      // Can't set to null, but server will handle the deletion
-      // The query will update when server confirms deletion
-    }
+    if (workspace) return;
   });
 
   const initiateDelete = () => {
@@ -85,10 +82,9 @@ export default function WorkingSpaceSettingsSidbar({
       if (PathName === workspaceHref) {
         await new Promise((resolve) => setTimeout(resolve, 400));
         await DeleteWorkingSpace({ _id: workingSpaceId });
-        router.push(`/home`);
+        redirect(`/home`);
       } else {
         await DeleteWorkingSpace({ _id: workingSpaceId });
-        router.push(`/home`);
       }
     } catch (error) {
       console.error("Failed to delete workspace:", error);


### PR DESCRIPTION
### what changed

**`NoteSettingsSidbar.tsx`  smart redirect on note delete**
added path/search param detection to figure out if the user is currently viewing the note being deleted. if they are (`realPathName === noteHref`), it redirects to `/home` after deletion. if they're viewing a different note, it just deletes silently. also added an error catch that was missing.

**`WorkingSpaceSettingsSidbar.tsx`  redirect cleanup**
replaced `router.push("/home")` with `redirect("/home")` and removed the duplicate `router.push` in the else branch (the else case no longer navigates at all, which makes sense since the user isn't on that workspace). also cleaned up the empty `if (workspace)` block to `if (workspace) return;`.

**`CreateNoteBtn.tsx`  removed auto-navigation on create**
removed the `router.push` that navigated to the new note immediately after creation. the note is created but the user stays where they are.

---

### why

deletion was always redirecting to `/home` even if the user wasn't on the deleted item. the create note navigation was jumping the user away before they might have wanted to.
