### PR TITLE
fix `redirect()` in client components to `router.replace()`

### DIFF
--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -24,7 +24,12 @@ import { useQuery } from "@/cache/useQuery";
 import { Button } from "@/components/ui/button";
 import { SquarePen, X, Pin, PinOff } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { redirect, usePathname, useSearchParams } from "next/navigation";
+import {
+  redirect,
+  useRouter,
+  usePathname,
+  useSearchParams,
+} from "next/navigation";
 interface NoteSettingsSidbarProps {
   noteId: Id<"notes"> | any;
   noteTitle: string | any;
@@ -41,6 +46,7 @@ export default function NoteSettingsSidbar({
   const searchParams = useSearchParams();
   const realPathName = `/home/${pathSegments[1]}/${pathSegments[2]}?id=${searchParams.get("id")}`;
   const noteHref = `/home/${pathSegments[1]}/${pathSegments[2]}?id=${noteId}`;
+  const router = useRouter();
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
     (local, args) => {
@@ -84,7 +90,7 @@ export default function NoteSettingsSidbar({
     try {
       if (realPathName === noteHref) {
         await deleteNote({ _id: noteId });
-        redirect(`/home`);
+        router.replace(`/home`);
       } else {
         await deleteNote({ _id: noteId });
       }

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -80,9 +80,8 @@ export default function WorkingSpaceSettingsSidbar({
     setIsDeleting(true);
     try {
       if (PathName === workspaceHref) {
-        await new Promise((resolve) => setTimeout(resolve, 400));
         await DeleteWorkingSpace({ _id: workingSpaceId });
-        redirect(`/home`);
+        router.replace(`/home`);
       } else {
         await DeleteWorkingSpace({ _id: workingSpaceId });
       }


### PR DESCRIPTION
followed up on the issue flagged in the last pr  `redirect()` is a server-only function and was being called in client components.

**`NoteSettingsSidbar.tsx`**
replaced `redirect("/home")` with `router.replace("/home")`. imported `useRouter` and added the router instance.

**`WorkingSpaceSettingsSidbar.tsx`**
same fix  `redirect("/home")` to `router.replace("/home")`. also removed the `setTimeout(400)` delay that was in the workspace deletion path  it was just a workaround to avoid the broken redirect.