### PR TITLE
navigate before delete to avoid stale query errors

### DIFF
--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -114,7 +114,7 @@ export default function NoteSettings({
   const currentNoteId = searchParams.get("id");
   const isViewingThisNote = currentNoteId === noteId;
 
-  // ── Download hook ────────────────────────────────────────────────
+  // Download hook
   const { handleDownload } = useNoteDownload({
     noteBody: getNote?.body,
     noteTitle,
@@ -170,16 +170,16 @@ export default function NoteSettings({
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     if (!getNote) return;
-
     if (onDelete) onDelete(noteId);
     setIsAlertOpen(false);
-
-    if (isViewingThisNote) {
-      router.push(`/home/${getNote.workingSpaceId}`);
-    }
-
     try {
-      await deleteNote({ _id: noteId });
+      if (isViewingThisNote) {
+        router.push(`/home/${getNote.workingSpaceId}`);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        await deleteNote({ _id: noteId });
+      } else {
+        await deleteNote({ _id: noteId });
+      }
     } catch (error) {
       console.error("Failed to delete note:", error);
     }

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -30,6 +30,7 @@ import {
   usePathname,
   useSearchParams,
 } from "next/navigation";
+import { promise } from "zod";
 interface NoteSettingsSidbarProps {
   noteId: Id<"notes"> | any;
   noteTitle: string | any;
@@ -89,8 +90,9 @@ export default function NoteSettingsSidbar({
     event.preventDefault();
     try {
       if (realPathName === noteHref) {
+        router.push(`/home/${pathSegments[1]}`);
+        await new Promise((resolve) => setTimeout(resolve, 300));
         await deleteNote({ _id: noteId });
-        router.replace(`/home`);
       } else {
         await deleteNote({ _id: noteId });
       }

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -80,8 +80,9 @@ export default function WorkingSpaceSettingsSidbar({
     setIsDeleting(true);
     try {
       if (PathName === workspaceHref) {
+        router.push(`/home`);
+        await new Promise((resolve) => setTimeout(resolve, 300));
         await DeleteWorkingSpace({ _id: workingSpaceId });
-        router.replace(`/home`);
       } else {
         await DeleteWorkingSpace({ _id: workingSpaceId });
       }


### PR DESCRIPTION
updated all three deletion flows to navigate away first, wait briefly, then delete  rather than deleting and then navigating.

**`NoteSettings.tsx`**
reordered the delete flow: `router.push` first, then a 300ms delay, then `deleteNote`. previously navigation happened after deletion which could cause a brief flash of a missing note query.

**`NoteSettingsSidbar.tsx`**
same pattern  navigate to the workspace first, wait 300ms, then delete. also changed the destination from `/home` to `/home/${pathSegments[1]}` (the workspace) for a less jarring redirect.

**`WorkingSpaceSettingsSidbar.tsx`**
same approach  `router.push("/home")` then wait 300ms then delete.

### why

deleting a resource while still on its page could cause query errors or flickering as convex tries to re-fetch something that no longer exists. navigating away first gives the page time to unmount before the deletion fires.