### PR TITLE
remove unused imports and note count badges from search dialog

### DIFF
--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -30,7 +30,6 @@ import {
   usePathname,
   useSearchParams,
 } from "next/navigation";
-import { promise } from "zod";
 interface NoteSettingsSidbarProps {
   noteId: Id<"notes"> | any;
   noteTitle: string | any;

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -167,9 +167,6 @@ function TableSection({
         <span className="truncate text-[12px] font-medium text-muted-foreground group-hover:text-foreground transition-colors">
           <HighlightedText text={table.name || "Untitled"} query={query} />
         </span>
-        <span className="ml-auto text-[10px] text-muted-foreground/40 pr-1">
-          {notes.length}
-        </span>
       </Button>
 
       {isExpanded && (
@@ -254,9 +251,6 @@ function WorkspaceTree({
                   text={workspace.name || "Untitled"}
                   query={query}
                 />
-              </span>
-              <span className="ml-auto text-[10px] text-muted-foreground/50 font-normal pr-1">
-                {totalNotes} {totalNotes === 1 ? "note" : "notes"}
               </span>
             </Button>
 

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -11,7 +11,6 @@ import { Input } from "@/components/ui/input";
 import { useMutation } from "convex/react";
 import { useQuery } from "@/cache/useQuery";
 import type { Id } from "@/convex/_generated/dataModel";
-import { redirect } from "next/navigation";
 import { api } from "@/convex/_generated/api";
 import { FaEllipsis, FaRegTrashCan } from "react-icons/fa6";
 import { cn } from "@/lib/utils";


### PR DESCRIPTION
cleaned up unused imports across a few home components and removed the small note count badges from the search dialog.

- `promise` from zod and `redirect` from next/navigation were imported but never used.
- the note count badges (`{notes.length}` and `{totalNotes} notes`) in the search dialog were adding visual noise without much value.

#### so now 

- smaller, cleaner component files
- less clutter in the search results UI
- no dead code hanging around

#### changes

- components/home-components/NoteSettingsSidbar.tsx → removed unused `promise` import from zod
- components/home-components/SearchDialog.tsx → removed the two small note count spans
- components/home-components/WorkingSpaceSettings.tsx → removed unused `redirect` import


simple spring cleaning.