### PR TITLE
simplify note card by removing workspace label

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -601,9 +601,6 @@ function NoteCard({ note }: { note: Note }) {
             <CardTitle className="text-base font-semibold text-foreground truncate">
               {note.title || "Untitled"}
             </CardTitle>
-            <CardDescription className="text-xs text-muted-foreground mt-1">
-              {note.workingSpacesSlug || "Personal Workspace"}
-            </CardDescription>
           </div>
           {note.favorite && (
             <Star className="h-4 w-4 text-primary fill-primary flex-shrink-0" />


### PR DESCRIPTION
the workspace name was adding extra visual noise without providing much value in this context, especially since users are typically already scoped within a workspace or can infer it from navigation.

by removing it, the card becomes cleaner and more focused on the note title, improving readability 
this also helps create a more minimal and consistent card layout across the app.
it just looks better come on 

