### PR TITLE
add don't loss ur stuff search feature to landing page

### DIFF
--- a/components/landingPage-components/FeaturesSection.tsx
+++ b/components/landingPage-components/FeaturesSection.tsx
@@ -20,6 +20,12 @@ const featureVideos: Record<string, { video: string; poster: string }> = {
     poster:
       "https://res.cloudinary.com/dkbwj5yyg/video/upload/q_80,w_900/v1774032089/notevo-workingspace_vq80uc.jpg",
   },
+  "Don't Loss Ur Stuff": {
+    video:
+      "https://res.cloudinary.com/dkbwj5yyg/video/upload/q_80,w_900/v1777131625/notevo-search_dd7jou.mp4",
+    poster:
+      "https://res.cloudinary.com/dkbwj5yyg/video/upload/q_80,w_900/v1777131625/notevo-search_dd7jou.jpg",
+  },
   "Publish Your Notes": {
     video:
       "https://res.cloudinary.com/dkbwj5yyg/video/upload/q_80,w_900/v1774029719/notevo-Publish_xvq0mm.mp4",

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -8,6 +8,7 @@ import {
   Activity,
   FileDown,
   FileSymlink,
+  FolderSearch,
 } from "lucide-react";
 
 export const NavLinks = [
@@ -97,6 +98,12 @@ export const Features = [
     description:
       "Organize your thoughts, manage your workspaces, and boost your productivity with Notevo's intuitive organization system.",
     icon: LayoutGrid,
+  },
+  {
+    title: "Don't Loss Ur Stuff",
+    description:
+      "Sometimes you forget the name of your note but still remember the name of the folder or table. With Notevo, you can search the full hierarchy.",
+    icon: FolderSearch,
   },
   {
     title: "Publish Your Notes",


### PR DESCRIPTION
added a new feature entry for the hierarchical search functionality, with the trailing space in the title fixed so the video lookup works correctly.

### what changed

**`lib/data.ts`**
added a new entry to `Features`  "Don't Loss Ur Stuff" with a `FolderSearch` icon and a description about being able to search by workspace, folder, or table name even when you can't remember the note title.

**`FeaturesSection.tsx`**
added the matching `video` and `poster` to `featureVideos` using the new cloudinary-hosted search demo, keyed to `"Don't Loss Ur Stuff"` (no trailing space) so it correctly maps to the feature.