### PR TITLE
remove redundant overlay div + strengthen feature video gradient

### DIFF
--- a/components/landingPage-components/FeaturesSection.tsx
+++ b/components/landingPage-components/FeaturesSection.tsx
@@ -162,10 +162,7 @@ export default function FeaturesSection() {
                 >
                   <div className="relative">
                     <div
-                      className={`absolute inset-0 ${isEven ? "bg-gradient-to-br" : "bg-gradient-to-bl"} bg-gradient-to-br from-primary/30 from-30% to-transparent border-border rounded-lg`}
-                    />
-                    <div
-                      className={`relative ${isEven ? "bg-gradient-to-br" : "bg-gradient-to-bl"} from-primary/30 from-30% to-transparent border-border rounded-lg p-1 Desktop:p-2 overflow-hidden`}
+                      className={`relative ${isEven ? "bg-gradient-to-br" : "bg-gradient-to-bl"} from-primary/50 from-20% to-transparent border-border rounded-lg p-1 Desktop:p-2 overflow-hidden`}
                     >
                       <LazyVideo
                         video={video}


### PR DESCRIPTION
removed the extra `absolute inset-0` overlay div that was duplicating the gradient  the `relative` wrapper already handles it. also bumped the gradient from `from-primary/30 from-30%` to `from-primary/50 from-20%` for a stronger, tighter accent.