### PR TITLE
home loading skeleton overhaul + slider nav redesign + misc fixes

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -36,7 +36,7 @@ import {
 } from "@/lib/parse-tiptap-content";
 import { cn } from "@/lib/utils";
 import { z } from "zod";
-
+import { Skeleton } from "@/components/ui/skeleton";
 const homeMemoryCache: {
   viewer?: any;
   recentWorkspaces?: any;
@@ -246,16 +246,16 @@ function WorkspaceCardSkeleton() {
   return (
     <Card className="relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-fit">
       <CardHeader className="pb-3 relative">
-        <div className="h-5 bg-primary/20 rounded-lg w-3/4 animate-pulse"></div>
+        <Skeleton className="h-5 w-3/4" />
       </CardHeader>
       <CardContent className="pb-3">
         <div className="h-20 flex items-center justify-center">
-          <div className="h-14 w-14 bg-primary/20 rounded-full animate-pulse"></div>
+          <Skeleton className="h-8 w-8 rounded-md" />
         </div>
       </CardContent>
-      <CardFooter className="pt-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
-        <div className="h-4 bg-primary/20 rounded-lg w-24 animate-pulse"></div>
-        <div className="h-7 bg-primary/20 rounded-lg w-16 animate-pulse"></div>
+      <CardFooter className="pt-3 flex justify-between items-center border-t border-border">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-7 w-16" />
       </CardFooter>
     </Card>
   );
@@ -263,23 +263,23 @@ function WorkspaceCardSkeleton() {
 
 function NoteCardSkeleton() {
   return (
-    <Card className="relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-[225px]">
+    <Card className="relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-[225px] flex flex-col">
       <CardHeader className="pb-2">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 space-y-2">
-            <div className="h-5 bg-primary/20 rounded-lg w-3/4 animate-pulse"></div>
-            <div className="h-3 bg-primary/20 rounded-lg w-1/2 animate-pulse"></div>
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
           </div>
         </div>
       </CardHeader>
       <CardContent className="pb-3 space-y-2">
-        <div className="h-3 bg-primary/20 rounded-lg w-full animate-pulse"></div>
-        <div className="h-3 bg-primary/20 rounded-lg w-5/6 animate-pulse"></div>
-        <div className="h-3 bg-primary/20 rounded-lg w-4/6 animate-pulse"></div>
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-5/6" />
+        <Skeleton className="h-3 w-4/6" />
       </CardContent>
-      <CardFooter className="pt-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
-        <div className="h-4 bg-primary/20 rounded-lg w-24 animate-pulse"></div>
-        <div className="h-7 bg-primary/20 rounded-lg w-16 animate-pulse"></div>
+      <CardFooter className="pt-3 flex justify-between items-center border-t border-border mt-auto">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-7 w-16" />
       </CardFooter>
     </Card>
   );
@@ -342,16 +342,6 @@ function Slider({ children }: { children: React.ReactNode }) {
       {canScrollLeft && (
         <div className="absolute -left-1 top-0 bottom-0 w-16 sm:w-20 bg-gradient-to-r from-background via-background/80 to-transparent z-[5] pointer-events-none" />
       )}
-      {canScrollLeft && (
-        <Button
-          size="icon"
-          variant="ghost"
-          className="absolute left-0 top-[40%] -translate-y-1/2 z-10 h-8 w-8 sm:h-10 sm:w-10 rounded-full shadow-lg opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={() => scroll("left")}
-        >
-          <ChevronLeft className="h-4 w-4 sm:h-5 sm:w-5" />
-        </Button>
-      )}
 
       <div
         ref={scrollContainerRef}
@@ -364,20 +354,30 @@ function Slider({ children }: { children: React.ReactNode }) {
       {canScrollRight && (
         <div className="absolute -right-1 top-0 bottom-0 w-16 sm:w-20 bg-gradient-to-l from-background via-background/80 to-transparent z-[5] pointer-events-none" />
       )}
-      {canScrollRight && (
-        <Button
-          size="icon"
-          variant="ghost"
-          className="absolute right-0 top-[40%] -translate-y-1/2 z-10 h-8 w-8 sm:h-10 sm:w-10 rounded-full shadow-lg opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={() => scroll("right")}
-        >
-          <ChevronRight className="h-4 w-4 sm:h-5 sm:w-5" />
-        </Button>
+
+      {(canScrollRight || canScrollLeft) && (
+        <div className="z-10 absolute -bottom-10 right-0 flex justify-center items-center gap-2">
+          <Button
+            size="icon"
+            variant={canScrollLeft ? "default" : "outline"}
+            className=" h-8 w-8 sm:h-10 sm:w-10 "
+            onClick={() => scroll("left")}
+          >
+            <ChevronLeft className="h-4 w-4 sm:h-5 sm:w-5" />
+          </Button>
+          <Button
+            size="icon"
+            variant={canScrollRight ? "default" : "outline"}
+            className="h-8 w-8 sm:h-10 sm:w-10 "
+            onClick={() => scroll("right")}
+          >
+            <ChevronRight className="h-4 w-4 sm:h-5 sm:w-5" />
+          </Button>
+        </div>
       )}
     </div>
   );
 }
-
 interface Workspace {
   _id: Id<"workingSpaces">;
   name: string;

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -1,36 +1,69 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />;
+  return (
+    <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />
+  );
 }
 
-function SliderRow({ count }: { count: number }) {
+function WorkspaceCardSkeleton() {
   return (
-    <div className="flex gap-4 overflow-hidden">
-      {Array.from({ length: count }).map((_, i) => (
-        <div
-          key={i}
-          className="flex-shrink-0 w-[300px] h-[225px] rounded-xl border border-border bg-card/70 backdrop-blur-sm p-4"
-        >
-          <Skeleton className="h-5 w-2/3 mb-3" />
-          <Skeleton className="h-3 w-1/2 mb-6" />
-          <Skeleton className="h-4 w-full mb-2" />
-          <Skeleton className="h-4 w-5/6 mb-2" />
-          <Skeleton className="h-4 w-4/6" />
-          <div className="mt-8 flex items-center justify-between">
-            <Skeleton className="h-3 w-24" />
-            <Skeleton className="h-7 w-16" />
-          </div>
+    <div className="flex-shrink-0 w-[300px] h-fit rounded-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden">
+      {/* CardHeader */}
+      <div className="p-6 pb-3">
+        <Skeleton className="h-5 w-3/4" />
+      </div>
+      {/* CardContent — folder icon area */}
+      <div className="px-6 pb-3">
+        <div className="h-20 flex items-center justify-center">
+          <Skeleton className="h-8 w-8 rounded-md" />
         </div>
-      ))}
+      </div>
+      {/* CardFooter */}
+      <div className="px-6 pt-3 pb-6 flex justify-between items-center border-t border-border">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-7 w-16" />
+      </div>
     </div>
   );
 }
 
+function NoteCardSkeleton() {
+  return (
+    <div className="flex-shrink-0 w-[300px] h-[225px] rounded-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden flex flex-col">
+      {/* CardHeader */}
+      <div className="p-6 pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      </div>
+      {/* CardContent */}
+      <div className="px-6 pb-3 flex-1 space-y-2">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-5/6" />
+        <Skeleton className="h-3 w-4/6" />
+      </div>
+      {/* CardFooter */}
+      <div className="px-6 pt-3 pb-6 flex justify-between items-center border-t border-border mt-auto">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-7 w-16" />
+      </div>
+    </div>
+  );
+}
+
+function SliderRow({ children }: { children: React.ReactNode }) {
+  return <div className="flex gap-4 overflow-hidden h-[250px]">{children}</div>;
+}
+
 export default function Loading() {
   return (
-    <MaxWContainer className="relative my-8">
-      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-10">
+    <MaxWContainer className="relative my-5">
+      {/* Hero Section */}
+      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <div className="max-w-3xl mx-auto text-center">
           <Skeleton className="h-10 w-56 mx-auto mb-4" />
           <Skeleton className="h-4 w-full max-w-xl mx-auto mb-2" />
@@ -38,20 +71,41 @@ export default function Loading() {
         </div>
       </div>
 
-      <div className="mb-10">
-        <div className="flex items-center justify-between mb-5">
-          <Skeleton className="h-6 w-40" />
+      {/* Workspaces Slider */}
+      <div className="mb-12">
+        <div className="mb-6 flex justify-between items-center">
+          <Skeleton className="h-7 w-44" />
           <Skeleton className="h-9 w-36" />
         </div>
-        <SliderRow count={4} />
+        <SliderRow>
+          {[1, 2, 3, 4].map((i) => (
+            <WorkspaceCardSkeleton key={i} />
+          ))}
+        </SliderRow>
       </div>
 
-      <div className="mb-10">
-        <div className="flex items-center justify-between mb-5">
-          <Skeleton className="h-6 w-36" />
-          <Skeleton className="h-6 w-10" />
+      {/* Pinned Notes Slider */}
+      <div className="mb-12">
+        <div className="mb-6">
+          <Skeleton className="h-7 w-36" />
         </div>
-        <SliderRow count={3} />
+        <SliderRow>
+          {[1, 2, 3].map((i) => (
+            <NoteCardSkeleton key={i} />
+          ))}
+        </SliderRow>
+      </div>
+
+      {/* Recent Notes Slider */}
+      <div className="mb-12">
+        <div className="mb-6">
+          <Skeleton className="h-7 w-36" />
+        </div>
+        <SliderRow>
+          {[1, 2, 3].map((i) => (
+            <NoteCardSkeleton key={i} />
+          ))}
+        </SliderRow>
       </div>
     </MaxWContainer>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default async function HomePage() {
     // Force light mode for the entire landing page regardless of user theme
     <div className="force-light">
       <div className="relative flex flex-col min-h-screen bg-background text-foreground">
-        <div className=" fixed bottom-0 left-0 h-16 Desktop:h-[4.2rem] bg-transparent frosted-area w-full z-[9000000]" />
+        <div className="pointer-events-none fixed bottom-0 left-0 h-16 Desktop:h-[4.2rem] bg-transparent frosted-area w-full z-[9000000]" />
         <Navbar />
         <div className="flex-grow flex-1">
           <HeroSection />


### PR DESCRIPTION
### what changed

**`HomePageClient.tsx`  skeletons use `Skeleton` component**
replaced all the hand-rolled `bg-primary/20 rounded-lg animate-pulse` divs in `WorkspaceCardSkeleton` and `NoteCardSkeleton` with the shared `Skeleton` component. shapes updated to better match the real cards (smaller icon area, adjusted footer sizes). `NoteCardSkeleton` gets `flex flex-col` and `mt-auto` on the footer for correct vertical layout.

**`HomePageClient.tsx`  slider scroll buttons redesigned**
removed the hover-reveal overlay arrows and replaced them with a persistent pair of left/right buttons anchored below the slider (`absolute -bottom-10 right-0`). the active direction button uses `variant="default"` and the disabled direction uses `variant="outline"`, giving clear visual feedback on which direction is scrollable.

**`app/home/loading.tsx` rewritten to match real layout**
the page loading skeleton now has three distinct sections matching the real page: workspaces slider, pinned notes slider, and recent notes slider. each uses proper `WorkspaceCardSkeleton` and `NoteCardSkeleton` components instead of the old generic `SliderRow`. spacing and header skeletons updated to match real heading sizes.

**`app/page.tsx`**
added `pointer-events-none` to the frosted bottom bar so it doesn't accidentally block clicks on content below it.

so that now =>

the loading skeleton was a rough approximation that didn't match the real page shape. the slider arrows were hidden until hover which made them hard to discover. the frosted bar was intercepting pointer events.