### PR TITLE
workspace page ui polish, heights, borders,ico sizes, input styling

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -392,8 +392,8 @@ function SliderTabsList({
   };
 
   return (
-    <div className=" relative py-5">
-      <div className="absolute -top-6 left-0 w-full Desktop:w-[80rem] Desktop:max-w-full">
+    <div className=" relative py-4">
+      <div className="absolute -top-6 left-0 w-full">
         <Button
           variant="ghost"
           size="icon"
@@ -660,7 +660,7 @@ export default function WorkingSpacePageClient({
     <MaxWContainer className="my-5">
       <header className="pt-6">
         <div className=" relative flex justify-between items-end w-full Desktop:w-[80rem] Desktop:max-w-full">
-          <div className="flex-1  p-0.5 max-w-xl border border-border bg-muted rounded-lg rounded-b-none ">
+          <div className="flex-1  py-1 px-1.5 border border-border bg-muted rounded-lg rounded-b-none ">
             <h1 className="text-3xl md:text-5xl font-bold my-2">
               {!workspace ? (
                 <div className="text-primary/20 rounded-md animate-pulse h-10 w-64 inline-block" />
@@ -708,7 +708,7 @@ export default function WorkingSpacePageClient({
             <CreateTableBtn
               label="New Table"
               workingSpaceId={workingSpaceId}
-              className=" absolute bottom-0 right-0 h-9 bg-gradient-to-b from-primary from-90% to-100% to-border border-b-0 border-r-0 rounded-b-none hover:translate-x-[0px] hover:translate-y-[-3px] hover:rounded-b-none hover:shadow-[0px_3px_0px] hover:shadow-border"
+              className=" absolute bottom-0 right-0 h-9 bg-gradient-to-b from-primary from-90% to-100% rounded-tr-none to-border border-b-0 border-r-0 rounded-b-none hover:translate-x-[0px] hover:translate-y-[-3px] hover:rounded-b-none hover:rounded-tr-none hover:shadow-[0px_3px_0px] hover:shadow-border"
             />
           )}
         </div>
@@ -820,13 +820,13 @@ export function NotesDroppableContainer({
               placeholder="Search Notes..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 border-border"
+              className="pl-10 border-border h-9"
             />
           </div>
         </div>
 
         <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
-          <div className="hidden sm:flex items-center border border-border rounded-lg overflow-hidden">
+          <div className="hidden sm:flex h-9 items-center border border-border rounded-lg overflow-hidden">
             <Button
               variant="SidebarMenuButton"
               size="sm"
@@ -834,7 +834,7 @@ export function NotesDroppableContainer({
               onClick={() => setViewMode("grid")}
             >
               <LayoutGrid
-                className={`h-4 w-4 ${viewMode === "grid" && "text-primary"}`}
+                className={`h-3.5 w-3.5 ${viewMode === "grid" && "text-primary"}`}
               />
             </Button>
             <Button
@@ -844,7 +844,7 @@ export function NotesDroppableContainer({
               onClick={() => setViewMode("list")}
             >
               <List
-                className={`h-4 w-4 ${viewMode === "list" && "text-primary"}`}
+                className={`h-3.5 w-3.5 ${viewMode === "list" && "text-primary"}`}
               />
             </Button>
           </div>

--- a/components/home-components/CreateNoteBtn.tsx
+++ b/components/home-components/CreateNoteBtn.tsx
@@ -68,13 +68,13 @@ export default function CreateNoteBtn({
   return (
     <Button
       className={cn(
-        "flex items-center justify-between gap-2 h-9 px-2",
+        "flex items-center justify-between gap-1 h-9 px-2",
         className,
       )}
       variant="outline"
       onClick={handleCreateNote}
     >
-      <Plus size="20" />
+      <Plus className="mt-[0.06rem]" size={14} />
       <p>New Note</p>
     </Button>
   );

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -171,7 +171,7 @@ export default function TableSettings({
               <TooltipTrigger asChild>
                 <Button
                   variant="Trigger"
-                  className="px-0.5 h-10 opacity-80"
+                  className="pl-0.5 pr-0 h-9 mb-0.5 opacity-80"
                   onMouseEnter={handleTooltipMouseEnter}
                   onMouseLeave={handleTooltipMouseLeave}
                 >

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-primary/30 bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-primary/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-lg border border-border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}


### PR DESCRIPTION
## brfore the new lol 
<img width="1259" height="238" alt="image" src="https://github.com/user-attachments/assets/7dfa8ee4-00c9-4f4e-89f2-c312e1878d49" />

## new the new 
<img width="1241" height="411" alt="image" src="https://github.com/user-attachments/assets/af61a32f-c434-40a0-9d15-df9e7cd5c7f0" />

a batch of small visual consistency fixes across the workspace page and shared components.

### what changed
**`WorkingSpacePageClient.tsx`**
- tab list container `py-5` → `py-4` and removed the fixed `Desktop:w-[80rem]` constraint from the scroll wrapper
- header card padding changed from `p-0.5` to `py-1 px-1.5` for better spacing
- `CreateTableBtn` gets `rounded-tr-none` added (and `hover:rounded-tr-none`) so the top-right corner stays square when it's flush against the header card corner
- search input height set to `h-9` to match the view mode toggle
- view mode toggle container gets `h-9` and icons reduced from `h-4 w-4` to `h-3.5 w-3.5`

**`CreateNoteBtn.tsx`**
- `Plus` icon reduced from `size="20"` to `size={14}` with slight vertical alignment nudge
- gap reduced from `gap-2` to `gap-1`

**`TableSettings.tsx`**
- trigger button height changed from `h-10` to `h-9` and padding adjusted (`pl-0.5 pr-0`) to align with the row height

**`input.tsx`**
- input border changed from `border-primary/30` to `border-border` for consistency with the rest of the ui
- placeholder color changed from `text-primary/50` to `text-primary/90` for better readability

---

small inconsistencies in heights (`h-10` vs `h-9`), borders, and icon sizes were making the workspace page feel unpolished. this pass normalizes them.