### PR TITLE
refactor ui: improve button hover states and dropdown borders

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -830,7 +830,10 @@ export function NotesDroppableContainer({
             <Button
               variant="SidebarMenuButton"
               size="sm"
-              className={cn("rounded-none", viewMode === "grid" && "bg-muted")}
+              className={cn(
+                "rounded-none hover:bg-muted",
+                viewMode === "grid" && "bg-muted",
+              )}
               onClick={() => setViewMode("grid")}
             >
               <LayoutGrid
@@ -840,7 +843,10 @@ export function NotesDroppableContainer({
             <Button
               variant="SidebarMenuButton"
               size="sm"
-              className={cn("rounded-none", viewMode === "list" && "bg-muted")}
+              className={cn(
+                "rounded-none hover:bg-muted",
+                viewMode === "list" && "bg-muted",
+              )}
               onClick={() => setViewMode("list")}
             >
               <List

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-primary/10 bg-muted p-1 text-muted-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-muted p-1 text-muted-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-full overflow-hidden bg-card border border-primary/10 rounded-lg p-1 text-foreground ",
+        "z-50 w-full overflow-hidden bg-card border border-border rounded-lg p-1 text-foreground ",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
@@ -163,7 +163,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-primary/20", className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
updated the view mode toggle buttons (grid/list) in the working space page to show a proper hover state when not active. previously they had no hover feedback.

also cleaned up dropdown menu components by replacing hardcoded border-primary/10 and bg-primary/20 with the standard border-border and bg-border tokens.

changes make the ui more consistent and give better visual feedback on hover. looks cleaner now.