### PR TITLE
ui cleanup table rename button, create table btn and tabs

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -314,7 +314,7 @@ function TableTab({ table }: { table: any }) {
           e.stopPropagation();
           handleDoubleClick(e as any);
         }}
-        className=" absolute top-0.5 right-0.5 opacity-0 group-hover/tab:opacity-100 hover:!opacity-100 transition-opacity duration-150 p-0.5 rounded-full text-secondary-foreground hover:text-foreground"
+        className=" absolute top-0.5 right-0.5 opacity-0 group-hover/tab:opacity-100 transition-opacity duration-150 p-0.5 rounded-full text-secondary-foreground hover:text-foreground"
         title="Rename"
       >
         <Pencil className="h-3 w-3" />

--- a/components/home-components/CreateTableBtn.tsx
+++ b/components/home-components/CreateTableBtn.tsx
@@ -82,7 +82,7 @@ export default function CreateTableBtn({
       ) : (
         <Plus className=" mb-[0.065rem] text-mutede" size={14} />
       )}
-      <p className=" mb-0.5 text-base sm:text-sm">{label}</p>
+      <p className=" hidden sm:block mb-0.5 text-base sm:text-sm">{label}</p>
     </Button>
   );
 }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=inactive]:hover:bg-card/80 data-[state=active]:text-secondary-foreground",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-3 py-1 text-sm text-foreground/50 font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=inactive]:hover:text-foreground data-[state=inactive]:hover:bg-card/80 data-[state=active]:text-foreground",
       className,
     )}
     {...props}


### PR DESCRIPTION
made a few small ui improvements:

- removed unnecessary `hover:!opacity-100` from the table rename pencil button (it was conflicting with the group-hover)
- hid the label text on the "create table" button on small screens to save space
- improved tabs styling: better inactive state colors, removed focus ring, and smoother hover/active transitions

ui feels cleaner and more consistent now.