### PR TITLE
ui-stuff update text selection color and improve sidebar resize handle style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
 @layer base {
   :root {
     --placeholder: #644a40;
-    --selection-background: #644a403c;
+    --selection-background: #94c4e270;
     --selection-color: #000000;
     --background: 0 0% 97.6471%;
     --foreground: 0 0% 12.5490%;
@@ -95,7 +95,7 @@
 
   .dark {
     --placeholder: #ffe0c2;
-    --selection-background: #ffe1c257;
+    --selection-background: #3b7ba370;
     --selection-color: #ffffff;
     --background: 0 0% 6.6667%;
     --foreground: 0 0% 93.3333%;
@@ -229,17 +229,14 @@ html {
 
 ::selection {
   background: var(--selection-background);
-  color: var(--selection-color);
 }
 
 *::-moz-selection {
   background: var(--selection-background);
-  color: var(--selection-color);
 }
 
 *::-webkit-selection {
   background: var(--selection-background);
-  color: var(--selection-color);
 }
 
 .no-visible-scrollbar {

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -367,9 +367,11 @@ const Sidebar = React.memo(
       const resizeHandle =
         state === "expanded" && !isMobile ? (
           <div
-            className="absolute right-0 top-0 h-full w-1 cursor-col-resize transition-colors"
+            className="group/resize absolute -right-px top-0 h-full w-2.5 cursor-col-resize "
             onMouseDown={handleMouseDown}
-          />
+          >
+            <div className="absolute -right-px top-0 h-full w-px cursor-col-resize bg-gradient-to-t from-transparent from-5% to-95% to-transparent via-50% group-hover/resize:via-primary" />
+          </div>
         ) : null;
 
       if (collapsible === "none") {
@@ -619,17 +621,17 @@ const SidebarGroupLabel = React.forwardRef<
 >(({ className, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "div";
 
-      return (
-        <Comp
-          ref={ref}
-          data-sidebar="group-label"
-          className={cn(
-            "duration-200 flex h-8 shrink-0 items-center rounded-lg px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 motion-reduce:transition-none",
-            "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
-            className,
-          )}
-          {...props}
-        />
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-label"
+      className={cn(
+        "duration-200 flex h-8 shrink-0 items-center rounded-lg px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 motion-reduce:transition-none",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
   );
 });
 SidebarGroupLabel.displayName = "SidebarGroupLabel";


### PR DESCRIPTION
okay this is just awesome
<img width="618" height="854" alt="image" src="https://github.com/user-attachments/assets/397238e4-ca15-4bd7-b952-8465ff37e040" />
 cool stuff
made two small improvements:

- updated the text selection background color in both light and dark mode to something more modern and pleasant (better contrast and less harsh)
- improved the sidebar resize handle: made it wider and easier to grab, with a nice gradient line that appears on hover

also cleaned up some unnecessary duplicated code in `SidebarGroupLabel`.

ui feels more polished now.