### PR TITLE
global ui consistency pass

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,7 +6,7 @@
   or use the "Copy code" button at https://ui.shadcn.com/themes */
 @layer base {
   :root {
-    --placeholder: #644a40;
+    --placeholder: 0 0% 93.7255%;
     --selection-background: #94c4e270;
     --selection-color: #000000;
     --background: 0 0% 97.6471%;
@@ -94,7 +94,7 @@
   }
 
   .dark {
-    --placeholder: #ffe0c2;
+    --placeholder: 0 0% 93.7255%;
     --selection-background: #3b7ba370;
     --selection-color: #ffffff;
     --background: 0 0% 6.6667%;
@@ -183,7 +183,7 @@
 
 /* Force light mode on any element regardless of .dark on <html> */
 .force-light {
-  --placeholder: #644a40;
+  --placeholder: 0 0% 93.7255%;
   --selection-background: #644a403c;
   --selection-color: #000000;
   --background: 0 0% 97.6471%;
@@ -363,7 +363,7 @@ hr {
 .ProseMirror p.is-empty:not(.is-editor-empty)::before {
   content: attr(data-placeholder);
   float: left;
-  color: var(--placeholder) !important;
+  color: hsl(var(--placeholder)) !important;
   opacity: 0.6;
   pointer-events: none;
   height: 0;

--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -140,7 +140,7 @@ export default function HomePageClient() {
   return (
     <MaxWContainer className="relative my-5">
       {/* Hero Section */}
-      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
+      <div className="overflow-hidden border border-border rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <header className="relative max-w-3xl mx-auto text-center">
           <h1 className="text-3xl sm:text-4xl font-bold mb-4 text-primary">
             {viewer?.name ? (

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -287,7 +287,7 @@ function TableTab({ table }: { table: any }) {
             "h-7 px-2 py-0 text-sm font-medium bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 min-w-[80px]",
             nameError
               ? "border border-destructive"
-              : "border border-primary/20",
+              : "border border-primary/50",
           )}
         />
         {nameError && (
@@ -686,7 +686,7 @@ export default function WorkingSpacePageClient({
                       "text-3xl md:text-5xl font-bold h-auto py-0 px-2 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
                       nameError
                         ? "border border-destructive"
-                        : "border border-primary/20",
+                        : "border border-primary/50",
                     )}
                   />
                   {nameError && (
@@ -697,7 +697,7 @@ export default function WorkingSpacePageClient({
                 <span
                   onDoubleClick={handleNameDoubleClick}
                   title="Double-click to rename"
-                  className="cursor-text rounded-md border border-transparent px-2 hover:border-primary/20 transition-colors duration-150"
+                  className="cursor-text rounded-md border border-transparent px-2 hover:border-primary/50 transition-colors duration-150"
                 >
                   {workspace.name}
                 </span>
@@ -837,7 +837,7 @@ export function NotesDroppableContainer({
               onClick={() => setViewMode("grid")}
             >
               <LayoutGrid
-                className={`h-3.5 w-3.5 ${viewMode === "grid" && "text-primary"}`}
+                className={`h-3.5 w-3.5 ${viewMode === "grid" && "text-foreground"}`}
               />
             </Button>
             <Button
@@ -850,7 +850,7 @@ export function NotesDroppableContainer({
               onClick={() => setViewMode("list")}
             >
               <List
-                className={`h-3.5 w-3.5 ${viewMode === "list" && "text-primary"}`}
+                className={`h-3.5 w-3.5 ${viewMode === "list" && "text-foreground"}`}
               />
             </Button>
           </div>
@@ -1042,7 +1042,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                   "text-base font-semibold min-h-0 py-1 px-2 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
                   titleError
                     ? "border border-destructive"
-                    : "border border-primary/20",
+                    : "border border-primary/50",
                 )}
               />
               {titleError && (
@@ -1051,7 +1051,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
             </div>
           ) : (
             <CardTitle
-              className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text rounded-md border border-transparent hover:border-primary/20 transition-all duration-300 pr-2 "
+              className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text rounded-md border border-transparent hover:border-primary/50 transition-all duration-300 pr-2 "
               onDoubleClick={handleDoubleClick}
               title="Double-click to rename"
             >
@@ -1219,7 +1219,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                     "text-base font-semibold h-auto py-1 px-1 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 mb-1",
                     titleError
                       ? "border border-destructive"
-                      : "border border-primary/20",
+                      : "border border-primary/50",
                   )}
                 />
                 {titleError && (
@@ -1228,7 +1228,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
               </>
             ) : (
               <h3
-                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text rounded-md border border-transparent hover:border-primary/20 transition-all duration-300 hover:px-2 w-fit mb-1"
+                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text rounded-md border border-transparent hover:border-primary/50 transition-all duration-300 hover:px-2 w-fit mb-1"
                 onDoubleClick={handleDoubleClick}
                 title="Double-click to rename"
               >

--- a/components/PublicNote.tsx
+++ b/components/PublicNote.tsx
@@ -140,56 +140,59 @@ export default function PublicNote({
           side="bottom"
           alignOffset={1}
           align="end"
-          className="min-w-[20rem] pb-1.5 px-1.5 pt-2 space-y-4 text-muted-foreground z-[10000]"
+          className=" min-w-[18.5rem] px-3 pb-3 pt-2 space-y-4 text-muted-foreground z-[10000]"
         >
           <DropdownMenuGroup className="relative">
             {getNote?.published ? (
-              <header className="w-full text-start px-5 pb-2 pt-2 flex flex-col justify-center items-start gap-3">
-                <span className="space-y-2">
-                  <h1 className="flex justify-start items-center gap-2 text-base text-primary font-bold">
-                    <CheckSquare size={14} className="text-primary" />
+              <header className="w-full text-start flex flex-col justify-center items-start gap-3">
+                <span className="px-1 space-y-2">
+                  <h1 className="flex justify-start items-center gap-2 text-base text-foreground font-bold">
+                    <CheckSquare
+                      size={16}
+                      className="text-muted-foreground mt-px"
+                    />
                     Published to the web
                   </h1>
-                  <p className="text-xs text-muted-foreground">
-                    Copy the link and share your notes with the world
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Copy the link, share notes with the world
                   </p>
                 </span>
-                <span className="w-full">
-                  <p className="text-xs text-green-600 p-0.5">
-                    <span className="text-base animate-pulse">•</span> This page
-                    is live check the link below
-                  </p>
-                  <span className="relative">
-                    <Input
-                      type="text"
-                      value={`https://notevo.me/public/document/${noteId}`}
-                      className="h-9 truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-85% to-transparent to-80% text-transparent bg-clip-text"
-                      disabled
-                    />
-                    <Tooltip
-                      open={isCopyTooltipOpen}
-                      onOpenChange={setIsCopyTooltipOpen}
-                      delayDuration={200}
+                <span className="w-full relative">
+                  <Input
+                    type="text"
+                    value={`https://notevo.me/public/document/${noteId}`}
+                    className="h-9 truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-85% to-transparent to-80% text-transparent bg-clip-text"
+                    disabled
+                  />
+                  <Tooltip
+                    open={isCopyTooltipOpen}
+                    onOpenChange={setIsCopyTooltipOpen}
+                    delayDuration={200}
+                  >
+                    <TooltipTrigger asChild>
+                      <Button
+                        onMouseDown={handleCopy}
+                        onPointerMove={(e) => e.stopPropagation()}
+                        onMouseEnter={() => setIsCopyTooltipOpen(true)}
+                        onMouseLeave={() => setIsCopyTooltipOpen(false)}
+                        className={`w-fit h-8 absolute top-1/2 -translate-y-1/2 right-0  text-primary hover:text-primary`}
+                        disabled={isCopied && true}
+                        variant="Trigger"
+                      >
+                        {isCopied ? (
+                          "Copied!"
+                        ) : (
+                          <Copy size={14} className="text-primary" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      className=" rounded-sm px-1.5"
+                      side="bottom"
                     >
-                      <TooltipTrigger asChild>
-                        <Button
-                          onMouseDown={handleCopy}
-                          onPointerMove={(e) => e.stopPropagation()}
-                          onMouseEnter={() => setIsCopyTooltipOpen(true)}
-                          onMouseLeave={() => setIsCopyTooltipOpen(false)}
-                          className={`w-fit h-8 absolute top-1/2 -translate-y-1/2 right-0 ${isCopied && "text-primary hover:text-primary"}`}
-                          variant="Trigger"
-                        >
-                          {isCopied ? (
-                            "Copied!"
-                          ) : (
-                            <Copy size={14} className="text-primary" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Copy link</TooltipContent>
-                    </Tooltip>
-                  </span>
+                      Copy link
+                    </TooltipContent>
+                  </Tooltip>
                 </span>
                 <span className="w-full flex justify-between items-center gap-2">
                   <Button
@@ -197,7 +200,7 @@ export default function PublicNote({
                     className="w-full h-8 gap-2 bg-transparent"
                     variant="outline"
                   >
-                    <EyeClosed size={14} className="text-primary" />
+                    <EyeClosed size={14} />
                     Unpublish
                   </Button>
                   <Button className="w-full h-8" variant="secondary">
@@ -213,13 +216,16 @@ export default function PublicNote({
                 </span>
               </header>
             ) : (
-              <header className="w-full text-start px-5 pb-2 pt-2 flex flex-col justify-center items-center gap-6">
-                <span className="space-y-2">
-                  <h1 className="flex justify-start items-center gap-2 text-base text-primary font-bold">
-                    <Globe2Icon size={14} className="text-primary" />
+              <header className="w-full text-start flex flex-col justify-center items-center gap-6">
+                <span className="px-1 space-y-2">
+                  <h1 className="flex justify-start items-center gap-2 text-base text-foreground font-bold">
+                    <Globe2Icon
+                      size={16}
+                      className="text-muted-foreground mt-px"
+                    />
                     Publish to the web
                   </h1>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs font-medium text-muted-foreground">
                     Publish a static webpage of this document, read only
                     <br />
                     and anyone with the link can view or duplicate it.

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -33,21 +33,21 @@ export function ThemeToggle() {
         aria-label="Light"
         className="flex-1 px-1 h-6 rounded-md"
       >
-        <SunIcon className="h-3 w-3 text-primary" />
+        <SunIcon className="h-3 w-3 text-muted-foreground" />
       </ToggleGroupItem>
       <ToggleGroupItem
         value="dark"
         aria-label="Dark"
         className="flex-1 px-1 h-6 rounded-md"
       >
-        <MoonIcon className="h-3 w-3 text-primary " />
+        <MoonIcon className="h-3 w-3 text-muted-foreground " />
       </ToggleGroupItem>
       <ToggleGroupItem
         value="system"
         aria-label="System"
         className="flex-1 px-1 h-6 rounded-md"
       >
-        <DesktopIcon className="h-3 w-3 text-primary " />
+        <DesktopIcon className="h-3 w-3 text-muted-foreground " />
       </ToggleGroupItem>
     </ToggleGroup>
   );

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -59,9 +59,9 @@ const TailwindAdvancedEditor = ({
 
   useEffect(() => {
     if (resolvedTheme !== "dark") {
-      setDragHandleColor("#644a40");
+      setDragHandleColor("#B4B4B4");
     } else {
-      setDragHandleColor("#ffe0c2");
+      setDragHandleColor("#646464");
     }
   }, [resolvedTheme]);
 
@@ -108,7 +108,7 @@ const TailwindAdvancedEditor = ({
     Placeholder.configure({
       placeholder: "Press '/' for commands, or start writing...",
       emptyEditorClass:
-        "is-editor-empty before:content-[attr(data-placeholder)] before:float-left before:text-primary/60 before:pointer-events-none before:cursor-text before:h-0",
+        "is-editor-empty before:content-[attr(data-placeholder)] before:float-left before:text-muted-foreground/80 before:pointer-events-none before:cursor-text before:h-0",
       showOnlyWhenEditable: true,
       includeChildren: true,
     }),
@@ -128,7 +128,7 @@ const TailwindAdvancedEditor = ({
                   fill="none"
                   viewBox="0 0 24 24"
                   strokeWidth="3"
-                  className=" w-4 h-4 opacity-50"
+                  className=" w-4 h-4 opacity-80"
                   stroke={dragHandleColor}
                 >
                   <path
@@ -186,7 +186,7 @@ const TailwindAdvancedEditor = ({
                   <EditorCommandItem
                     value={item.title}
                     onCommand={(val) => item.command(val)}
-                    className="flex w-full items-center space-x-2.5 rounded-lg mb-1.5 px-1 py-1 text-left text-sm text-foreground hover:bg-primary/10 aria-selected:bg-primary/10"
+                    className="flex w-full items-center space-x-2.5 rounded-lg my-1.5 px-1 py-1 text-left text-sm text-foreground hover:bg-primary/10 aria-selected:bg-primary/10"
                     key={item.title}
                   >
                     <div className="flex h-8 w-8 items-center justify-center border border-primary/10 rounded-lg text-primary">

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -487,11 +487,7 @@ const PinnedNoteItem = memo(
                       </IntentPrefetchLink>
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent
-                    side="right"
-                    className="font-medium"
-                    sideOffset={5}
-                  >
+                  <TooltipContent side="right" sideOffset={5}>
                     {note.title || "Untitled"}
                   </TooltipContent>
                 </Tooltip>
@@ -500,7 +496,7 @@ const PinnedNoteItem = memo(
           </SidebarMenuItem>
         </SidebarMenu>
         <div
-          className={`absolute right-0 transition-all duration-200 ease-in-out ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
+          className={`absolute right-0 ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
         >
           <NoteSettingsSidbar
             noteId={note._id}
@@ -778,11 +774,7 @@ const WorkspaceItem = memo(
                       </IntentPrefetchLink>
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent
-                    side="right"
-                    className="font-medium"
-                    sideOffset={5}
-                  >
+                  <TooltipContent side="right" sideOffset={5}>
                     {workingSpace.name || "Untitled"}
                   </TooltipContent>
                 </Tooltip>{" "}
@@ -791,7 +783,7 @@ const WorkspaceItem = memo(
           </SidebarMenuItem>
         </SidebarMenu>
         <div
-          className={`absolute right-0 transition-opacity duration-150 ${isHovered && !isEditing ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          className={`absolute right-0 ${isHovered && !isEditing ? "opacity-100" : "opacity-0 pointer-events-none"}`}
         >
           <WorkingSpaceSettingsSidbar
             workingSpaceId={workingSpace._id}
@@ -971,14 +963,19 @@ const UserAccountSection = memo(function UserAccountSection({
               <DropdownMenuSeparator />
               <div className="w-full p-1">
                 <div className=" flex items-center justify-between">
-                  <p className=" text-sm flex items-center flex-1">Theme :</p>
+                  <p className=" text-sm flex items-center flex-1 text-nowrap truncate">
+                    Theme :
+                  </p>
                   <ThemeToggle />
                 </div>
               </div>
               <DropdownMenuSeparator />
               <Feedback />
               <DropdownMenuItem onClick={handleSignOut}>
-                <LogOut size="16" className="mr-2 h-4 w-4 text-primary" />
+                <LogOut
+                  size="16"
+                  className="mr-2 h-4 w-4 text-muted-foreground"
+                />
                 Sign out
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/components/home-components/Feedback.tsx
+++ b/components/home-components/Feedback.tsx
@@ -77,7 +77,10 @@ export default function Feedback() {
     <Dialog>
       <DialogTrigger asChild>
         <Button variant="SidebarMenuButton" className=" px-2 h-8 ">
-          <MessageCircleHeart size="16" className="mr-2 h-4 w-4 text-primary" />
+          <MessageCircleHeart
+            size="16"
+            className="mr-2 h-4 w-4 text-muted-foreground"
+          />
           Feedback
         </Button>
       </DialogTrigger>

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -77,7 +77,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         }}
       />
       <main
-        className={`relative flex flex-col flex-1 h-auto border-primary/20 bg-background transition-[margin,border-radius] duration-300 ease-linear motion-reduce:transition-none ${
+        className={`relative flex flex-col flex-1 h-auto border-border bg-background transition-[margin,border-radius] duration-300 ease-linear motion-reduce:transition-none ${
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -261,7 +261,7 @@ export default function NoteSettings({
               className="w-full h-8 px-2 text-sm"
               onClick={handleFavoritePin}
             >
-              <Pin size={14} className="text-primary" />
+              <Pin size={14} className="text-muted-foreground" />
               {getNote?.favorite ? "Unpin Note" : "Pin Note"}
             </Button>
 
@@ -270,13 +270,13 @@ export default function NoteSettings({
               className="w-full h-8 px-2 text-sm"
               onClick={handleMoveDialogOpen}
             >
-              <FileOutput size={14} className="text-primary" />
+              <FileOutput size={14} className="text-muted-foreground" />
               Move Note
             </Button>
 
             <DropdownMenuSub>
               <DropdownMenuSubTrigger className="w-full h-8 px-2 text-sm flex items-center gap-2 text-foreground hover:bg-primary/10">
-                <Download size={14} className="text-primary" />
+                <Download size={14} className="text-muted-foreground" />
                 Download
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="w-48">
@@ -322,13 +322,16 @@ export default function NoteSettings({
                     <>
                       <ChevronsLeftRightEllipsis
                         size={14}
-                        className="text-primary"
+                        className="text-muted-foreground"
                       />
                       Full width
                     </>
                   ) : (
                     <>
-                      <ChevronsRightLeft size={14} className="text-primary" />
+                      <ChevronsRightLeft
+                        size={14}
+                        className="text-muted-foreground"
+                      />
                       Max width
                     </>
                   )}
@@ -342,7 +345,7 @@ export default function NoteSettings({
               className="w-full h-8 px-2 text-sm"
               onClick={initiateDelete}
             >
-              <FaRegTrashCan size={14} className="text-primary" />
+              <FaRegTrashCan size={14} className="text-muted-foreground" />
               Delete
             </Button>
           </DropdownMenuGroup>

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -437,10 +437,10 @@ export default function SearchDialog({
             <div className="w-full flex items-center justify-between gap-1">
               Search
               <span className="inline-flex gap-1">
-                <kbd className="pointer-events-none border border-primary/10 ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-mute px-1.5 font-mono text-[10px] font-medium text-primary">
+                <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
                   <span className="text-xs">Ctrl</span>
                 </kbd>
-                <kbd className="pointer-events-none border border-primary/10 ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-mute px-1.5 font-mono text-[10px] font-medium text-primary">
+                <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
                   <span className="text-xs">K</span>
                 </kbd>
               </span>

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -201,7 +201,7 @@ export default function TableSettings({
                 className="w-full h-8 px-2 text-sm"
                 onClick={initiateDelete}
               >
-                <FaRegTrashCan size="14" />
+                <FaRegTrashCan size={14} className="text-primary" />
                 Delete
               </Button>
             </DropdownMenuContent>

--- a/components/selectors/text-buttons.tsx
+++ b/components/selectors/text-buttons.tsx
@@ -126,7 +126,11 @@ export const TextButtons = () => {
                   />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={6}>
+              <TooltipContent
+                side="top"
+                className=" flex justify-center items-center px-1"
+                sideOffset={6}
+              >
                 <span>{item.label}</span>
                 <ShortcutBadge keys={item.shortcut} />
               </TooltipContent>
@@ -155,7 +159,11 @@ export const TextButtons = () => {
                 />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={6}>
+            <TooltipContent
+              side="top"
+              className=" flex justify-center items-center px-1"
+              sideOffset={6}
+            >
               <span>{item.label}</span>
               <ShortcutBadge keys={item.shortcut} />
             </TooltipContent>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-border/80 text-primary bg-background hover:bg-muted hover:border-border",
+          "border border-border/80 text-muted-foreground bg-background hover:bg-muted hover:border-border",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: " hover:bg-primary/10 hover:text-foreground",

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "text-xs font-medium m-1 text-primary/80 leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  "text-xs font-medium m-1 text-muted-foreground leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 const Label = React.forwardRef<

--- a/components/ui/shortcut-badge.tsx
+++ b/components/ui/shortcut-badge.tsx
@@ -1,5 +1,5 @@
 export const ShortcutBadge = ({ keys }: { keys: string }) => (
-  <span className="ml-2 rounded-lg bg-accent-foreground px-1.5 py-0.5 text-[10px] font-mono font-semibold text-accent">
+  <span className="ml-2 rounded-sm bg-secondary px-1.5 py-0.5 text-[10px] font-mono font-semibold text-secondary-foreground">
     {keys}
   </span>
 );

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors hover:bg-card/80 hover:text-primary focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-card data-[state=on]:text-primary [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors hover:bg-card/80 hover:text-primary focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 border border-transparent data-[state=on]:border-border data-[state=on]:bg-card data-[state=on]:text-primary [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[10001] overflow-hidden rounded-md bg-accent px-3 py-[3px] text-[13px] text-primary border border-primary/10 animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        "z-[10001] overflow-hidden rounded-md bg-muted px-3 py-[3px] text-[13px] text-muted-foreground font-semibold border border-border animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
         className,
       )}
       {...props}


### PR DESCRIPTION
large cleanup pr  swapping hardcoded colors and inconsistent token usage for proper semantic tokens throughout the app.


### what changed

**`globals.css`**
- `--placeholder` changed from hex values to HSL (`0 0% 93.7255%`) in all three contexts (`:root`, `.dark`, `.force-light`) so it works with `hsl(var(--placeholder))`
- ProseMirror paragraph placeholder now uses `hsl(var(--placeholder))` instead of `var(--placeholder)` raw

**`button.tsx`**
- outline variant text changed from `text-primary` to `text-muted-foreground`

**`label.tsx`**
- label text changed from `text-primary/80` to `text-muted-foreground`

**`toggle.tsx`**
- active toggle gets `border-border` and `border border-transparent` on inactive for a cleaner border-based active indicator

**`tooltip.tsx`**
- tooltip background `bg-accent` to `bg-muted`, text `text-primary` to `text-muted-foreground font-semibold`, border `border-primary/10` to `border-border`

**`shortcut-badge.tsx`**
- badge changed from `bg-accent-foreground text-accent` to `bg-secondary text-secondary-foreground`

**`advanced-editor.tsx`**
- drag handle colors neutralized (was warm brand tints, now neutral greys)
- editor empty placeholder changed from `text-primary/60` to `text-muted-foreground/80`
- slash command item changed from `mb-1.5` to `my-1.5` for consistent vertical spacing

**`AppSidebar.tsx`**
- tooltip `font-medium` class removed (tooltip component handles that now)
- hover transition classes removed from settings overlay  let the parent handle it
- sign out icon: `text-primary` to `text-muted-foreground`

**`Feedback.tsx`**
- feedback icon: `text-primary` to `text-muted-foreground`

**`HomeClientLayout.tsx`**
- main content border changed from `border-primary/20` to `border-border`

**`HomePageClient.tsx`**
- hero card gets a `border border-border`

**`NoteSettings.tsx`**
- all action icons changed from `text-primary` to `text-muted-foreground`

**`SearchDialog.tsx`**
- `Ctrl + K` kbd badges use `border-border bg-card text-muted-foreground` instead of `border-primary/10 text-primary`

**`TableSettings.tsx`**
- delete icon now explicitly gets `text-primary` (intentional for destructive action visibility)

**`ThemeToggle.tsx`**
- toggle icons changed from `text-primary` to `text-muted-foreground`

**`PublicNote.tsx`**
- title and description icons changed from `text-primary` to `text-muted-foreground`
- title text changed from `text-primary` to `text-foreground`
- unpublish button icon drops `text-primary`
- copy button always shows `text-primary hover:text-primary`
- layout padding adjusted

**`WorkingSpacePageClient.tsx`**
- inline edit borders bumped from `border-primary/20` to `border-primary/50`
- hover edit borders from `hover:border-primary/20` to `hover:border-primary/50`
- view mode icons changed from `text-primary` to `text-foreground` when active

**`text-buttons.tsx`**
- tooltip content gets `flex justify-center items-center px-1` for better shortcut badge layout

---

lots of places were using `text-primary` for decorative icons and secondary ui elements that should use `text-muted-foreground`. this pr normalizes the semantic token usage so the visual hierarchy is consistent and easier to maintain.