### PR TITLE
app-radius- utility classes + apply globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -299,6 +299,28 @@ html {
   }
 }
 
+@layer utilities {
+  .app-radius-sm {
+    @apply rounded-none rounded-tl-sm;
+  }
+
+  .app-radius-md {
+    @apply rounded-none rounded-tl-md;
+  }
+
+  .app-radius-lg {
+    @apply rounded-none rounded-tl-lg;
+  }
+
+  .app-radius-xl {
+    @apply rounded-none rounded-tl-xl;
+  }
+
+  .app-radius-2xl {
+    @apply rounded-none rounded-tl-2xl;
+  }
+}
+
 /* Add this to your CSS file */
 .hljs-comment,
 .hljs-quote {

--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -140,7 +140,7 @@ export default function HomePageClient() {
   return (
     <MaxWContainer className="relative my-5">
       {/* Hero Section */}
-      <div className="overflow-hidden border border-border rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
+      <div className="overflow-hidden border border-border app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <header className="relative max-w-3xl mx-auto text-center">
           <h1 className="text-3xl sm:text-4xl font-bold mb-4 text-primary">
             {viewer?.name ? (
@@ -250,7 +250,7 @@ function WorkspaceCardSkeleton() {
       </CardHeader>
       <CardContent className="pb-3">
         <div className="h-20 flex items-center justify-center">
-          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 app-radius-md" />
         </div>
       </CardContent>
       <CardFooter className="pt-3 flex justify-between items-center border-t border-border">
@@ -475,7 +475,7 @@ function WorkspaceCard({
   );
 
   return (
-    <Card className="group relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-fit hover:shadow-lg transition-shadow">
+    <Card className="group relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-fit transition-shadow">
       <CardHeader className="pb-3 relative">
         {isEditingName ? (
           <div className="flex flex-col gap-1 pr-8">
@@ -493,7 +493,7 @@ function WorkspaceCard({
               onBlur={handleNameBlur}
               onKeyDown={handleNameKeyDown}
               className={cn(
-                "text-base font-semibold h-auto py-1 px-1 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 w-full",
+                "text-base font-semibold h-auto py-1 px-1 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 w-full",
                 nameError
                   ? "border border-destructive"
                   : "border border-primary/20",
@@ -505,7 +505,7 @@ function WorkspaceCard({
           </div>
         ) : (
           <CardTitle
-            className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text rounded-md border border-transparent hover:border-primary/20 transition-all duration-300 pr-8"
+            className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-primary/20 transition-all duration-300 pr-8"
             onDoubleClick={handleNameDoubleClick}
             title="Double-click to rename"
           >
@@ -526,7 +526,7 @@ function WorkspaceCard({
         </div>
       </CardContent>
 
-      <CardFooter className="pt-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
+      <CardFooter className="py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
         <div className="flex items-center gap-1.5">
           <Clock className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
@@ -535,12 +535,7 @@ function WorkspaceCard({
             <SkeletonTextAnimation className="w-20" />
           )}
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          asChild
-          className="h-7 px-2 text-xs hover:bg-primary/10"
-        >
+        <Button variant="ghost" size="sm" asChild className="h-7 px-2 text-xs">
           <IntentPrefetchLink href={`/home/${workspace._id}`}>
             Open
           </IntentPrefetchLink>
@@ -619,7 +614,7 @@ function NoteCard({ note }: { note: Note }) {
         </p>
       </CardContent>
 
-      <CardFooter className="pt-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
+      <CardFooter className="py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
         <div className="flex items-center gap-1.5">
           <Clock className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -303,7 +303,7 @@ function TableTab({ table }: { table: any }) {
     <TabsTrigger
       value={table._id}
       data-tab-id={table._id}
-      className=" relative group/tab px-5 py-2.5 rounded-lg whitespace-nowrap flex-shrink-0 flex items-center gap-1.5 rounded-b-none border border-transparent data-[state=active]:border-border"
+      className="relative group/tab px-5 py-2.5 rounded-none rounded-tl-lg whitespace-nowrap flex-shrink-0 flex items-center gap-1.5 border border-transparent border-b-0 data-[state=active]:border-border"
       onDoubleClick={handleDoubleClick}
       title="Double-click to rename"
     >
@@ -400,7 +400,7 @@ function SliderTabsList({
           onClick={() => scroll("left")}
           aria-label="Scroll tabs left"
           className={cn(
-            "absolute left-2 top-1/2 -translate-y-1/2 z-20 h-10 rounded-md w-7 shadow-sm transition-all duration-200",
+            "absolute left-2 top-1/2 -translate-y-1/2 z-20 h-10 app-radius-md w-7 shadow-sm transition-all duration-200",
             canScrollLeft
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none",
@@ -415,7 +415,7 @@ function SliderTabsList({
           onClick={() => scroll("right")}
           aria-label="Scroll tabs right"
           className={cn(
-            "absolute right-2 top-1/2 -translate-y-1/2 z-20 h-10 rounded-md w-7 shadow-sm transition-all duration-200",
+            "absolute right-2 top-1/2 -translate-y-1/2 z-20 h-10 app-radius-md w-7 shadow-sm transition-all duration-200",
             canScrollRight
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none",
@@ -442,7 +442,7 @@ function SliderTabsList({
         />
 
         <TabsList
-          className="flex justify-start items-center px-1 pt-6 pb-5 bg-muted rounded-none border border-border border-b-0 w-full"
+          className="flex justify-start items-center px-1 pt-6 pb-5 bg-muted !rounded-none border border-border border-b-0 w-full"
           style={{ overflow: "clip" } as React.CSSProperties}
         >
           <div
@@ -660,10 +660,10 @@ export default function WorkingSpacePageClient({
     <MaxWContainer className="my-5">
       <header>
         <div className=" relative flex justify-between items-end w-full">
-          <div className="flex-1  py-1 px-1.5 border border-border bg-muted rounded-lg rounded-b-none ">
+          <div className="flex-1 py-1 px-1.5 border border-border bg-muted rounded-none rounded-tl-lg rounded-br-lg">
             <h1 className="text-3xl md:text-5xl font-bold my-2">
               {!workspace ? (
-                <div className="text-primary/20 rounded-md animate-pulse h-10 w-64 inline-block" />
+                <div className="bg-border app-radius-md animate-pulse h-10 w-64 inline-block" />
               ) : isEditingName ? (
                 <div
                   ref={nameContainerRef}
@@ -683,7 +683,7 @@ export default function WorkingSpacePageClient({
                     onBlur={handleNameBlur}
                     onKeyDown={handleNameKeyDown}
                     className={cn(
-                      "text-3xl md:text-5xl font-bold h-auto py-0 px-2 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
+                      "text-3xl md:text-5xl font-bold h-auto py-0 px-2 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
                       nameError
                         ? "border border-destructive"
                         : "border border-primary/50",
@@ -697,7 +697,7 @@ export default function WorkingSpacePageClient({
                 <span
                   onDoubleClick={handleNameDoubleClick}
                   title="Double-click to rename"
-                  className="cursor-text rounded-md border border-transparent px-2 hover:border-primary/50 transition-colors duration-150"
+                  className="cursor-text app-radius-md border border-transparent px-2 hover:border-primary/50 transition-colors duration-150"
                 >
                   {workspace.name}
                 </span>
@@ -826,7 +826,7 @@ export function NotesDroppableContainer({
         </div>
 
         <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
-          <div className="hidden sm:flex h-9 items-center border border-border rounded-lg overflow-hidden">
+          <div className="hidden sm:flex h-9 items-center border border-border app-radius-lg overflow-hidden">
             <Button
               variant="SidebarMenuButton"
               size="sm"
@@ -1039,7 +1039,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                 rows={1}
                 style={{ resize: "none", overflow: "hidden" }}
                 className={cn(
-                  "text-base font-semibold min-h-0 py-1 px-2 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
+                  "text-base font-semibold min-h-0 py-1 px-2 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
                   titleError
                     ? "border border-destructive"
                     : "border border-primary/50",
@@ -1051,7 +1051,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
             </div>
           ) : (
             <CardTitle
-              className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text rounded-md border border-transparent hover:border-primary/50 transition-all duration-300 pr-2 "
+              className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-primary/50 transition-all duration-300 pr-2 "
               onDoubleClick={handleDoubleClick}
               title="Double-click to rename"
             >
@@ -1083,7 +1083,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
         )}
       </CardContent>
 
-      <CardFooter className="pt-3 flex items-center justify-between border-t border-border">
+      <CardFooter className="py-3 flex items-center justify-between border-t border-border">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Calendar className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
@@ -1216,7 +1216,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                   onBlur={handleTitleBlur}
                   onKeyDown={handleTitleKeyDown}
                   className={cn(
-                    "text-base font-semibold h-auto py-1 px-1 rounded-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 mb-1",
+                    "text-base font-semibold h-auto py-1 px-1 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 mb-1",
                     titleError
                       ? "border border-destructive"
                       : "border border-primary/50",
@@ -1228,7 +1228,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
               </>
             ) : (
               <h3
-                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text rounded-md border border-transparent hover:border-primary/50 transition-all duration-300 hover:px-2 w-fit mb-1"
+                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text app-radius-md border border-transparent hover:border-primary/50 transition-all duration-300 hover:px-2 w-fit mb-1"
                 onDoubleClick={handleDoubleClick}
                 title="Double-click to rename"
               >
@@ -1354,20 +1354,20 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
           >
             <CardHeader className="pb-3">
               <div className="flex items-start justify-between gap-2">
-                <div className="h-5 w-3/4 bg-primary/20 rounded animate-pulse" />
-                <div className="h-5 w-5 bg-primary/20 rounded animate-pulse" />
+                <div className="h-5 w-3/4 bg-border rounded animate-pulse" />
+                <div className="h-5 w-5 bg-border rounded animate-pulse" />
               </div>
             </CardHeader>
             <CardContent className="pb-3">
               <div className="space-y-2">
-                <div className="h-4 w-full bg-primary/20 rounded animate-pulse" />
-                <div className="h-4 w-5/6 bg-primary/20 rounded animate-pulse" />
-                <div className="h-4 w-4/6 bg-primary/20 rounded animate-pulse" />
+                <div className="h-4 w-full bg-border rounded animate-pulse" />
+                <div className="h-4 w-5/6 bg-border rounded animate-pulse" />
+                <div className="h-4 w-4/6 bg-border rounded animate-pulse" />
               </div>
             </CardContent>
             <CardFooter className="pt-3 flex items-center justify-between border-t border-border">
-              <div className="h-4 w-24 bg-primary/20 rounded animate-pulse" />
-              <div className="h-7 w-16 bg-primary/20 rounded animate-pulse" />
+              <div className="h-4 w-24 bg-border rounded animate-pulse" />
+              <div className="h-7 w-16 bg-border rounded animate-pulse" />
             </CardFooter>
           </Card>
         ))}
@@ -1381,15 +1381,15 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
         <Card key={index} className="bg-card/90 backdrop-blur-sm border-border">
           <CardContent className="p-4">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 rounded-full bg-primary/20 animate-pulse flex-shrink-0" />
+              <div className="h-10 w-10 rounded-full bg-border animate-pulse flex-shrink-0" />
               <div className="flex-1 min-w-0 space-y-2">
-                <div className="h-5 w-2/3 bg-primary/20 rounded animate-pulse" />
-                <div className="h-4 w-full bg-primary/20 rounded animate-pulse" />
+                <div className="h-5 w-2/3 bg-border rounded animate-pulse" />
+                <div className="h-4 w-full bg-border rounded animate-pulse" />
               </div>
               <div className="flex items-center gap-3">
-                <div className="h-4 w-24 bg-primary/20 rounded animate-pulse" />
-                <div className="h-5 w-5 bg-primary/20 rounded animate-pulse" />
-                <div className="h-7 w-16 bg-primary/20 rounded animate-pulse" />
+                <div className="h-4 w-24 bg-border rounded animate-pulse" />
+                <div className="h-5 w-5 bg-border rounded animate-pulse" />
+                <div className="h-7 w-16 bg-border rounded animate-pulse" />
               </div>
             </div>
           </CardContent>
@@ -1405,16 +1405,16 @@ function TablesSkeleton() {
       {Array.from({ length: 8 }).map((_, index) => (
         <Card key={index} className="bg-card/50 backdrop-blur-sm border-border">
           <CardHeader className="pb-3">
-            <div className="h-5 w-3/4 bg-primary/20 rounded animate-pulse" />
+            <div className="h-5 w-3/4 bg-border rounded animate-pulse" />
           </CardHeader>
           <CardContent className="pb-3">
             <div className="space-y-2">
-              <div className="h-4 w-full bg-primary/20 rounded animate-pulse" />
-              <div className="h-4 w-5/6 bg-primary/20 rounded animate-pulse" />
+              <div className="h-4 w-full bg-border rounded animate-pulse" />
+              <div className="h-4 w-5/6 bg-border rounded animate-pulse" />
             </div>
           </CardContent>
           <CardFooter className="pt-3 border-t border-border">
-            <div className="h-4 w-24 bg-primary/20 rounded animate-pulse" />
+            <div className="h-4 w-24 bg-border rounded animate-pulse" />
           </CardFooter>
         </Card>
       ))}

--- a/app/home/[id]/[slug]/loading.tsx
+++ b/app/home/[id]/[slug]/loading.tsx
@@ -1,9 +1,7 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />
-  );
+  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
 }
 
 function ParagraphSkeleton() {
@@ -25,7 +23,7 @@ export default function Loading() {
         <Skeleton className="h-4 w-48" />
       </div>
       <ParagraphSkeleton />
-      <div className="h-40 rounded-lg bg-primary/10 animate-pulse" />
+      <div className="h-40 app-radius-lg bg-border animate-pulse" />
       <ParagraphSkeleton />
     </MaxWContainer>
   );

--- a/app/home/[id]/loading.tsx
+++ b/app/home/[id]/loading.tsx
@@ -1,19 +1,17 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />
-  );
+  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
 }
 
 function TabsSkeleton({ count }: { count: number }) {
   return (
     <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-      <div className="inline-flex items-center gap-3 p-1 bg-card/90 backdrop-blur-sm rounded-lg border border-border">
+      <div className="inline-flex items-center gap-3 p-1 bg-card/90 backdrop-blur-sm app-radius-lg border border-border">
         {Array.from({ length: count }).map((_, i) => (
           <div
             key={i}
-            className="px-6 py-2.5 rounded-lg bg-muted/30"
+            className="px-6 py-2.5 app-radius-lg bg-muted/30"
           >
             <Skeleton className="h-5 w-24" />
           </div>
@@ -29,7 +27,7 @@ function NotesGridSkeleton({ count }: { count: number }) {
       {Array.from({ length: count }).map((_, i) => (
         <div
           key={i}
-          className="rounded-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden"
+          className="app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden"
         >
           <div className="p-4 pb-2">
             <div className="flex items-start justify-between gap-3">
@@ -60,7 +58,7 @@ export default function Loading() {
     <MaxWContainer className="my-5">
       {/* Header (match WorkingSpacePageClient layout) */}
       <header className="pb-5">
-        <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8">
+        <div className="relative overflow-hidden app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8">
           <div className="relative flex flex-col gap-4">
             <div className="flex items-center justify-between gap-4">
               <div className="flex-1">
@@ -71,7 +69,7 @@ export default function Loading() {
                   </span>
                 </div>
               </div>
-              <Skeleton className="h-10 w-36 rounded-lg" />
+              <Skeleton className="h-10 w-36 app-radius-lg" />
             </div>
           </div>
         </div>
@@ -92,12 +90,12 @@ export default function Loading() {
           </div>
 
           <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
-            <div className="hidden sm:flex items-center border border-border rounded-lg overflow-hidden">
+            <div className="hidden sm:flex items-center border border-border app-radius-lg overflow-hidden">
               <Skeleton className="h-9 w-10 rounded-none" />
               <Skeleton className="h-9 w-10 rounded-none" />
             </div>
-            <Skeleton className="h-9 w-28 rounded-lg" />
-            <Skeleton className="h-9 w-10 rounded-lg" />
+            <Skeleton className="h-9 w-28 app-radius-lg" />
+            <Skeleton className="h-9 w-10 app-radius-lg" />
           </div>
         </div>
 
@@ -106,7 +104,7 @@ export default function Loading() {
 
         {/* Show more */}
         <div className="flex justify-center pt-2">
-          <Skeleton className="h-10 w-28 rounded-lg" />
+          <Skeleton className="h-10 w-28 app-radius-lg" />
         </div>
       </div>
     </MaxWContainer>

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -1,14 +1,12 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />
-  );
+  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
 }
 
 function WorkspaceCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[300px] h-fit rounded-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden">
+    <div className="flex-shrink-0 w-[300px] h-fit app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden">
       {/* CardHeader */}
       <div className="p-6 pb-3">
         <Skeleton className="h-5 w-3/4" />
@@ -16,7 +14,7 @@ function WorkspaceCardSkeleton() {
       {/* CardContent — folder icon area */}
       <div className="px-6 pb-3">
         <div className="h-20 flex items-center justify-center">
-          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 app-radius-md" />
         </div>
       </div>
       {/* CardFooter */}
@@ -30,7 +28,7 @@ function WorkspaceCardSkeleton() {
 
 function NoteCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[300px] h-[225px] rounded-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden flex flex-col">
+    <div className="flex-shrink-0 w-[300px] h-[225px] app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden flex flex-col">
       {/* CardHeader */}
       <div className="p-6 pb-2">
         <div className="flex items-start justify-between gap-2">
@@ -63,7 +61,7 @@ export default function Loading() {
   return (
     <MaxWContainer className="relative my-5">
       {/* Hero Section */}
-      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
+      <div className="overflow-hidden app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <div className="max-w-3xl mx-auto text-center">
           <Skeleton className="h-10 w-56 mx-auto mb-4" />
           <Skeleton className="h-4 w-full max-w-xl mx-auto mb-2" />

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -25,7 +25,7 @@ export function ThemeToggle() {
         }
       }}
       value={theme}
-      className="w-full border border-border bg-muted rounded-md px-[3px] h-[31px] justify-center items-center flex-1 gap-1"
+      className="w-full border border-border bg-muted rounded-tl-md px-[3px] h-[31px] justify-center items-center flex-1 gap-1"
       variant="SidebarMenuButton"
     >
       <ToggleGroupItem

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -186,10 +186,10 @@ const TailwindAdvancedEditor = ({
                   <EditorCommandItem
                     value={item.title}
                     onCommand={(val) => item.command(val)}
-                    className="flex w-full items-center space-x-2.5 rounded-lg my-1.5 px-1 py-1 text-left text-sm text-foreground hover:bg-primary/10 aria-selected:bg-primary/10"
+                    className="flex w-full items-center space-x-2.5 rounded-lg my-1.5 px-1 py-1 text-left text-sm text-foreground hover:bg-border aria-selected:bg-primary/10"
                     key={item.title}
                   >
-                    <div className="flex h-8 w-8 items-center justify-center border border-primary/10 rounded-lg text-primary">
+                    <div className="flex h-8 w-8 items-center justify-center border border-border rounded-lg text-muted-foreground">
                       {item.icon}
                     </div>
                     <div>

--- a/components/generative/generative-menu-switch.tsx
+++ b/components/generative/generative-menu-switch.tsx
@@ -33,7 +33,7 @@ const GenerativeMenuSwitch = ({
           editor?.chain().unsetHighlight().run();
         },
       }}
-      className="flex w-fit max-w-[80vw] h-fit p-0.5 overflow-hidden rounded-lg bg-muted border border-border shadow-xl"
+      className="flex w-fit max-w-[80vw] h-fit p-0.5 overflow-hidden rounded-tl-lg bg-muted border border-border shadow-xl"
     >
       {open && <AISelector open={open} onOpenChange={onOpenChange} />}
       {!open && (

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -76,105 +76,7 @@ import { usePaginatedQuery } from "@/cache/usePaginatedQuery";
 import { date } from "zod";
 import { generateSlug } from "@/lib/generateSlug";
 import { useQuery } from "@/cache/useQuery";
-// --- Skeleton Sidebar Component ---
-const SkeletonSidebar = ({
-  sidebarWidth,
-  open,
-}: {
-  sidebarWidth: number;
-  open: boolean;
-}) => {
-  return (
-    <Sidebar
-      variant="inset"
-      className="group bg-muted"
-      style={{
-        width: `${sidebarWidth}px`,
-      }}
-    >
-      <SidebarHeader className=" text-foreground border-b border-border">
-        <div className=" w-full flex items-center justify-between p-1.5">
-          <div className="flex items-center justify-start gap-2">
-            {open ? (
-              <>
-                <SkeletonTextAnimation className="w-20 h-4 mx-0" />
-                <SkeletonTextAnimation className="w-8 h-3 mx-0" />
-              </>
-            ) : (
-              <SkeletonSmImgAnimation className="h-6 w-6" />
-            )}
-          </div>
-          <SkeletonTextAnimation className="w-full mx-0 h-6" />
-        </div>
-        <div className="my-1">
-          {open ? (
-            <SkeletonTextAnimation className="w-full mx-0 h-8" />
-          ) : (
-            <SkeletonTextAnimation className="w-8 mx-0 h-8" />
-          )}
-        </div>
-      </SidebarHeader>
-      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent group-hover:scrollbar-thumb-primary/20">
-        <SidebarGroup>
-          <SidebarGroupLabel className="text-primary/20">
-            <SkeletonTextAnimation className="w-24 h-3" />
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SkeletonTextAndIconAnimation
-                  text_className={open ? "w-full h-5" : "hidden"}
-                />
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SkeletonTextAndIconAnimation
-                  text_className={open ? "w-full h-5" : "hidden"}
-                />
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel className="text-primary/20">
-            <SkeletonTextAnimation className="w-24 h-3" />
-          </SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SkeletonTextAndIconAnimation
-                  text_className={open ? "w-full h-5" : "hidden"}
-                />
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SkeletonTextAndIconAnimation
-                  text_className={open ? "w-full h-5" : "hidden"}
-                />
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-      <SidebarFooter className="text-foreground">
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <div className="my-2">
-              <div className="border-none w-full h-15 flex items-center justify-between">
-                <SkeletonSmImgAnimation className="h-8 w-8" />
-                {open ? (
-                  <div className="flex flex-col items-start justify-center">
-                    <SkeletonTextAnimation className="w-28 h-4 mx-0" />
-                    <SkeletonTextAnimation className="w-20 h-3 mt-1 mx-0" />
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarFooter>
-    </Sidebar>
-  );
-};
-
+import SkeletonSidebar from "../ui/skeleton-sidebar";
 interface SidebarHeaderSectionProps {
   getWorkingSpaces: Doc<"workingSpaces">[] | undefined;
   handleCreateNote: (
@@ -252,7 +154,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             side="bottom"
-            className="rounded-lg m-2 p-1.5 bg-background/90 backdrop-blur border border-solid border-border w-[--radix-popper-anchor-width]"
+            className="app-radius-lg m-2 p-1.5 bg-background/90 backdrop-blur border border-solid border-border w-[--radix-popper-anchor-width]"
           >
             <DropdownMenuLabel className="px-2 py-1 text-sm font-medium opacity-50">
               {getWorkingSpaces?.length
@@ -264,7 +166,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
                 getWorkingSpaces.map((workingSpace) => (
                   <DropdownMenuItem
                     key={workingSpace._id}
-                    className="relative flex-1 px-2 py-1.5 data-[highlighted]:bg-foreground rounded-lg"
+                    className="relative flex-1 px-2 py-1.5 data-[highlighted]:bg-foreground app-radius-lg"
                     onSelect={() =>
                       handleCreateNote(
                         workingSpace._id as any,
@@ -319,11 +221,11 @@ const SidebarNavigation = memo(function SidebarNavigation({
               asChild
               variant="SidebarMenuButton"
               className={`px-2 h-8 group ${
-                pathname === "/home" ? "bg-primary/10" : ""
+                pathname === "/home" ? "bg-border" : ""
               }`}
             >
               <IntentPrefetchLink href="/home">
-                <HomeIcon className=" text-primary" size="16" />
+                <HomeIcon className=" text-muted-foreground" size="16" />
                 <span>Home</span>
               </IntentPrefetchLink>
             </Button>
@@ -452,7 +354,7 @@ const PinnedNoteItem = memo(
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
-                className="flex-1 h-8 px-2 py-1.5 text-sm focus:outline-none focus:ring-0 focus:border-foreground rounded-lg"
+                className="flex-1 h-8 px-2 py-1.5 text-sm focus:outline-none focus:ring-0 focus:border-foreground app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>
@@ -461,7 +363,7 @@ const PinnedNoteItem = memo(
                     <Button
                       variant="SidebarMenuButton"
                       className={`px-2 my-0.5 h-8 group flex-1 ${
-                        isActive ? "bg-primary/10" : ""
+                        isActive ? "bg-border" : ""
                       }`}
                       asChild
                       onDoubleClick={handleDoubleClick}
@@ -473,12 +375,12 @@ const PinnedNoteItem = memo(
                         {isHovered || isActive ? (
                           <ChevronRight
                             size="16"
-                            className="text-primary flex-shrink-0"
+                            className="text-muted-foreground flex-shrink-0"
                           />
                         ) : (
                           <Pin
                             size="16"
-                            className="text-primary flex-shrink-0"
+                            className="text-muted-foreground flex-shrink-0"
                           />
                         )}
                         <span className={textClassName}>
@@ -739,7 +641,7 @@ const WorkspaceItem = memo(
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
-                className="flex-1 h-8 px-2 py-1.5 text-sm focus:outline-none focus:ring-0 focus:border-foreground  rounded-lg"
+                className="flex-1 h-8 px-2 py-1.5 text-sm focus:outline-none focus:ring-0 focus:border-foreground app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>
@@ -748,7 +650,7 @@ const WorkspaceItem = memo(
                     <Button
                       variant="SidebarMenuButton"
                       className={`px-2 my-0.5 h-8 group flex-1 justify-start ${
-                        isActive ? "bg-primary/10" : ""
+                        isActive ? "bg-border" : ""
                       }`}
                       asChild
                       onDoubleClick={handleDoubleClick}
@@ -760,12 +662,12 @@ const WorkspaceItem = memo(
                         {isHovered || isActive ? (
                           <FolderOpen
                             size="16"
-                            className="flex-shrink-0 text-primary"
+                            className="flex-shrink-0 text-muted-foreground"
                           />
                         ) : (
                           <FolderClosed
                             size="16"
-                            className="flex-shrink-0 text-primary"
+                            className="flex-shrink-0 text-muted-foreground"
                           />
                         )}
                         <span className={textClassName}>
@@ -826,7 +728,7 @@ const WorkspacesList = memo(function WorkspacesList({
         <Tooltip>
           <TooltipTrigger asChild>
             <SidebarGroupAction onClick={handleCreateWorkingSpace}>
-              <Plus size={16} className=" text-primary" />{" "}
+              <Plus size={16} className=" text-muted-foreground" />{" "}
               <span className="sr-only">Add Workspace</span>
             </SidebarGroupAction>
           </TooltipTrigger>
@@ -900,7 +802,7 @@ const UserAccountSection = memo(function UserAccountSection({
                   <Avatar className="h-8 w-8">
                     <AvatarImage
                       src={User?.image || "/placeholder.svg"}
-                      className=" rounded-lg"
+                      className=" app-radius-lg"
                       alt={User ? User.name?.charAt(0) : "..."}
                     />
                     <AvatarFallback className="bg-foreground text-foreground">
@@ -929,7 +831,7 @@ const UserAccountSection = memo(function UserAccountSection({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               side="top"
-              className="rounded-lg m-2 p-1.5 bg-background backdrop-blur w-[--radix-popper-anchor-width]"
+              className="app-radius-lg m-2 p-1.5 bg-background backdrop-blur w-[--radix-popper-anchor-width]"
             >
               <DropdownMenuItem
                 className=" cursor-default hover:bg-transparent"

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -71,7 +71,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           backgroundImage: `url(${NOISE_PNG})`,
           backgroundRepeat: "repeat",
           backgroundSize: "128px 128px",
-          opacity: isDark ? 0.05 : 0.02,
+          opacity: isDark ? 0.05 : 0.03,
           mixBlendMode: "multiply",
           zIndex: 90000,
         }}

--- a/components/home-components/MoveNoteDialog.tsx
+++ b/components/home-components/MoveNoteDialog.tsx
@@ -260,7 +260,7 @@ export default function MoveNoteDialog({
               {Array.from({ length: 6 }).map((_, index) => (
                 <div
                   key={index}
-                  className="h-10 rounded-lg bg-primary/10 animate-pulse"
+                  className="h-10 app-radius-lg bg-border animate-pulse"
                 />
               ))}
             </div>
@@ -285,7 +285,7 @@ export default function MoveNoteDialog({
                 return (
                   <div
                     key={workspace._id}
-                    className="overflow-hidden rounded-lg transition-colors"
+                    className="overflow-hidden app-radius-lg transition-colors"
                   >
                     <Button
                       variant="ghost"
@@ -315,7 +315,7 @@ export default function MoveNoteDialog({
                     {isExpanded && (
                       <div className="space-y-0.5 px-1 py-1">
                         {tables.length === 0 ? (
-                          <div className=" flex flex-col justify-center items-center gap-2 rounded-lg mx-2 py-3 bg-card text-xs text-muted-foreground/60 text-center">
+                          <div className=" flex flex-col justify-center items-center gap-2 app-radius-lg mx-2 py-3 bg-card text-xs text-muted-foreground/60 text-center">
                             No tables in this workspace yet.
                             <CreateTableBtn
                               workingSpaceId={workspace._id}
@@ -349,7 +349,7 @@ export default function MoveNoteDialog({
                                 }
                                 disabled={isCurrentTarget || isMoving}
                                 className={cn(
-                                  "flex w-full items-center justify-between rounded-lg px-3 py-2 text-left transition-colors",
+                                  "flex w-full items-center justify-between app-radius-lg px-3 py-2 text-left transition-colors",
                                   isCurrentTarget
                                     ? "cursor-not-allowed bg-primary/10"
                                     : " hover:bg-primary/10",
@@ -370,7 +370,7 @@ export default function MoveNoteDialog({
                                   {isMoving ? (
                                     <LoadingAnimation className="h-4 w-4 text-primary" />
                                   ) : isCurrentTarget ? (
-                                    <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 rounded-md">
+                                    <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
                                       current
                                     </span>
                                   ) : (

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -126,9 +126,9 @@ export default function NoteSettingsSidbar({
                 className="px-2 h-7"
               >
                 {getNote?.favorite ? (
-                  <PinOff size={16} className="text-primary" />
+                  <PinOff size={16} className="text-muted-foreground" />
                 ) : (
-                  <Pin size={16} className="text-primary" />
+                  <Pin size={16} className="text-muted-foreground" />
                 )}
               </Button>
             </TooltipTrigger>
@@ -144,7 +144,7 @@ export default function NoteSettingsSidbar({
                 variant="SidebarMenuButton_destructive"
                 className="px-2 h-7"
               >
-                <X size={16} className=" text-primary" />
+                <X size={16} className=" text-muted-foreground" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={5}>

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -51,13 +51,13 @@ function SearchLoadingSkeleton() {
   return (
     <div className="space-y-1 p-2">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-3 py-2.5 px-3 rounded-lg">
-          <div className="h-8 w-8 bg-primary/10 rounded-lg shrink-0 animate-pulse" />
+        <div key={i} className="flex items-center gap-3 py-2.5 px-3 app-radius-lg">
+          <div className="h-8 w-8 bg-border app-radius-lg shrink-0 animate-pulse" />
           <div className="flex-1 space-y-2">
-            <div className="h-3.5 bg-primary/10 rounded-md w-2/3 animate-pulse" />
-            <div className="h-2.5 bg-primary/10 rounded-md w-1/3 animate-pulse" />
+            <div className="h-3.5 bg-border app-radius-md w-2/3 animate-pulse" />
+            <div className="h-2.5 bg-border app-radius-md w-1/3 animate-pulse" />
           </div>
-          <div className="h-2.5 bg-primary/10 rounded-md w-16 animate-pulse" />
+          <div className="h-2.5 bg-border app-radius-md w-16 animate-pulse" />
         </div>
       ))}
     </div>
@@ -96,37 +96,20 @@ function NoteItem({
       onFocus={() => onIntentPrefetch?.(href)}
       onTouchStart={() => onIntentPrefetch?.(href)}
       className={cn(
-        "flex items-center gap-3 mb-px py-1.5 px-2 cursor-pointer rounded-lg transition-all",
+        "flex items-center gap-3 mb-px py-1.5 px-2 cursor-pointer app-radius-lg transition-all",
         indented && "ml-7",
-        isSelected ? "bg-primary/10" : "hover:bg-primary/10",
+        isSelected ? "bg-border" : "hover:bg-border",
       )}
     >
-      <div
-        className={cn(
-          "flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border transition-colors",
-          isSelected
-            ? "border-primary/30 bg-primary/10 text-primary"
-            : "border-muted-foreground/30 bg-muted text-muted-foreground",
-        )}
-      >
+      <div className="border-border bg-muted text-muted-foreground flex h-7 w-7 shrink-0 items-center justify-center app-radius-lg border transition-colors">
         <FileText size={14} />
       </div>
       <div className="flex-1 overflow-hidden">
-        <p
-          className={cn(
-            "text-sm font-medium truncate transition-colors",
-            isSelected ? "text-primary" : "text-foreground",
-          )}
-        >
+        <p className="text-sm text-foreground font-medium truncate transition-colors">
           <HighlightedText text={note.title || "Untitled"} query={query} />
         </p>
       </div>
-      <div
-        className={cn(
-          "flex items-center gap-1 text-xs shrink-0",
-          isSelected ? "text-primary/70" : "text-muted-foreground/60",
-        )}
-      >
+      <div className="flex items-center gap-1 text-xs shrink-0 text-muted-foreground">
         <Clock className="h-3 w-3" />
         <span>{getRelativeTime(new Date(note.createdAt))}</span>
       </div>
@@ -228,23 +211,23 @@ function WorkspaceTree({
         );
 
         return (
-          <div key={workspace._id} className="overflow-hidden rounded-lg">
+          <div key={workspace._id} className="overflow-hidden app-radius-lg">
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-primary/10 hover:border-2 hover:bg-transparent"
+              className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-border/50 hover:border-2 hover:bg-transparent"
               onClick={() => toggleWorkspace(workspaceId)}
             >
               <ChevronRight
                 className={cn(
-                  "h-3.5 w-3.5 shrink-0 transition-transform text-primary/60",
+                  "h-3.5 w-3.5 shrink-0 transition-transform text-muted-foreground",
                   isExpanded && "rotate-90",
                 )}
               />
               {isExpanded ? (
-                <FolderOpen className="h-3.5 w-3.5 shrink-0 text-primary/80" />
+                <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
               ) : (
-                <Folder className="h-3.5 w-3.5 shrink-0 text-primary/60" />
+                <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
               )}
               <span className="truncate text-sm font-medium text-foreground">
                 <HighlightedText
@@ -432,7 +415,7 @@ export default function SearchDialog({
           size="sm"
           className="px-2 h-8 group outline-none border-none"
         >
-          <Search className="text-primary" size={iconSize} />
+          <Search className="text-muted-foreground" size={iconSize} />
           {showTitle && (
             <div className="w-full flex items-center justify-between gap-1">
               Search
@@ -457,9 +440,9 @@ export default function SearchDialog({
 
         <div className="flex items-center border-b border-border px-4 py-2">
           {isDebouncing ? (
-            <LoadingAnimation className="h-4 w-4 mr-3 text-primary/70 shrink-0" />
+            <LoadingAnimation className="h-4 w-4 mr-3 text-muted-foreground shrink-0" />
           ) : (
-            <Search className="h-5 w-5 mr-3 text-primary/70 shrink-0" />
+            <Search className="h-5 w-5 mr-3 text-muted-foreground shrink-0" />
           )}
           <Input
             ref={inputRef}
@@ -534,20 +517,20 @@ export default function SearchDialog({
           <div className="w-full flex justify-between items-center">
             <span className="flex justify-center items-center gap-2 space-x-2">
               <span className="flex justify-center items-center gap-2">
-                <kbd className="pointer-events-none border border-primary/20 inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-muted px-2 font-mono text-[11px] font-medium text-primary/80">
+                <kbd className="pointer-events-none border border-border inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-background px-2 font-mono text-[11px] font-medium text-muted-foreground">
                   <ArrowDownUp size={14} />
                 </kbd>
                 <p className="text-foreground font-mono text-xs">Navigate</p>
               </span>
               <span className="flex justify-center items-center gap-2">
-                <kbd className="pointer-events-none border border-primary/20 inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-muted px-2 font-mono text-[11px] font-medium text-primary/80">
+                <kbd className="pointer-events-none border border-border inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-background px-2 font-mono text-[11px] font-medium text-muted-foreground">
                   <Undo2 size={14} />
                 </kbd>
                 <p className="text-foreground font-mono text-xs">Open</p>
               </span>
             </span>
             <span className="flex justify-center items-center gap-2">
-              <kbd className="pointer-events-none border border-primary/20 inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-muted px-2 font-mono text-[11px] font-medium text-primary/80">
+              <kbd className="pointer-events-none border border-border inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-background px-2 font-mono text-[11px] font-medium text-muted-foreground">
                 ESC
               </kbd>
               <p className="text-foreground font-mono text-xs">Close</p>

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -201,7 +201,7 @@ export default function TableSettings({
                 className="w-full h-8 px-2 text-sm"
                 onClick={initiateDelete}
               >
-                <FaRegTrashCan size={14} className="text-primary" />
+                <FaRegTrashCan size={14} className="text-muted-foreground" />
                 Delete
               </Button>
             </DropdownMenuContent>

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -113,7 +113,7 @@ export default function WorkingSpaceSettingsSidbar({
                 variant="SidebarMenuButton_destructive"
                 className="px-2 h-7"
               >
-                <X size={16} className=" text-primary" />
+                <X size={16} className=" text-muted-foreground" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={5}>

--- a/components/landingPage-components/FeaturesSection.tsx
+++ b/components/landingPage-components/FeaturesSection.tsx
@@ -162,12 +162,12 @@ export default function FeaturesSection() {
                 >
                   <div className="relative">
                     <div
-                      className={`relative ${isEven ? "bg-gradient-to-br" : "bg-gradient-to-bl"} from-primary/50 from-20% to-transparent border-border rounded-lg p-1 Desktop:p-2 overflow-hidden`}
+                      className={`relative ${isEven ? "bg-gradient-to-br" : "bg-gradient-to-bl"} from-primary/50 from-20% to-transparent border-border rounded-tl-lg p-1 Desktop:p-2 overflow-hidden`}
                     >
                       <LazyVideo
                         video={video}
                         poster={poster}
-                        className="w-full h-full object-cover rounded-lg"
+                        className="w-full h-full object-cover rounded-tl-lg"
                         style={{ pointerEvents: "none" }}
                       />
                     </div>
@@ -179,7 +179,7 @@ export default function FeaturesSection() {
                 >
                   <div className="Desktop:h-80 flex flex-col justify-end items-start">
                     <div className="flex items-start gap-4 mb-4">
-                      <div className="relative bg-primary/10 rounded-lg p-3">
+                      <div className="relative bg-primary/10 rounded-tl-lg p-3">
                         <feature.icon className="w-8 h-8 text-primary" />
                       </div>
                     </div>

--- a/components/landingPage-components/HeroSection.tsx
+++ b/components/landingPage-components/HeroSection.tsx
@@ -334,7 +334,7 @@ export default function HeroSection() {
           initial={{ opacity: 0, y: 20, filter: "blur(16px)" }}
           animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
           transition={{ duration: 0.55, delay: 0.38 }}
-          className="relative w-full p-1 Desktop:p-2 rounded-lg bg-primary/50 backdrop-blur-lg"
+          className="relative w-full p-1 Desktop:p-2 rounded-tl-lg bg-primary/50 backdrop-blur-lg"
         >
           <p className="absolute -top-9 right-12 font-extrabold text-primary/80 leading-relaxed">
             yep its that fast
@@ -358,7 +358,7 @@ export default function HeroSection() {
           <HeroVideo
             src="https://res.cloudinary.com/dkbwj5yyg/video/upload/q_80,w_1200/v1774021286/notevo-homepage_irogrs.mp4"
             poster="https://res.cloudinary.com/dkbwj5yyg/video/upload/q_80,w_1200/v1774021286/notevo-homepage_irogrs.jpg"
-            className="w-full h-full object-cover rounded-lg"
+            className="w-full h-full object-cover rounded-tl-lg"
             style={{ pointerEvents: "none" }}
           />
         </motion.div>

--- a/components/landingPage-components/HowToStartSection.tsx
+++ b/components/landingPage-components/HowToStartSection.tsx
@@ -9,7 +9,6 @@ import SectionHeading from "./SectionHeading";
 import Section from "@/components/ui/Section";
 import Link from "next/link";
 import { FolderClosed, FolderX, Clock } from "lucide-react";
-import { cn } from "@/lib/utils";
 interface Step {
   id: string;
   StepNum: string;
@@ -149,7 +148,7 @@ function SignUpPreview() {
 
   return (
     <div className="flex flex-col gap-2.5 p-5 w-full">
-      <div className="bg-background rounded-lg px-3.5 py-2.5 border border-border">
+      <div className="bg-background app-radius-lg px-3.5 py-2.5 border border-border">
         <p className="text-[10px] text-muted-foreground uppercase tracking-widest mb-1">
           Email
         </p>
@@ -160,12 +159,12 @@ function SignUpPreview() {
             <span className="text-muted-foreground">name@email.com</span>
           )}
           {!done && (
-            <span className="inline-block w-0.5 h-3 bg-primary rounded-sm cursor-blink" />
+            <span className="inline-block w-0.5 h-3 bg-primary app-radius-sm cursor-blink" />
           )}
         </p>
       </div>
       <motion.div
-        className={`bg-primary text-primary-foreground text-center text-sm rounded-lg px-4 py-2 text-[11px] mt-1 transition-all duration-300 border-r border-b border-muted/50 translate-x-[0px] translate-y-[0px]${done ? " border-muted/50 translate-x-[-3px] translate-y-[-3px] rounded-lg shadow-[3px_3px_0px] shadow-primary " : ""}`}
+        className={`bg-primary text-primary-foreground text-center text-sm app-radius-lg px-4 py-2 text-[11px] mt-1 transition-all duration-300 border-r border-b border-muted/50 translate-x-[0px] translate-y-[0px]${done ? " border-muted/50 translate-x-[-3px] translate-y-[-3px] app-radius-lg shadow-[3px_3px_0px] shadow-primary " : ""}`}
         transition={{ delay: 0.3, duration: 0.12 }}
       >
         Send sign-in link
@@ -181,7 +180,7 @@ function SignUpPreview() {
         {["GitHub", "Google"].map((label) => (
           <div
             key={label}
-            className="flex-1 bg-background border border-border rounded-lg py-2 text-center text-[11px] text-foreground font-medium"
+            className="flex-1 bg-background border border-border app-radius-lg py-2 text-center text-[11px] text-foreground font-medium"
           >
             {label}
           </div>
@@ -228,10 +227,10 @@ function WorkspacePreview() {
 
   return (
     <div className="p-5 w-full">
-      <div className="bg-background rounded-lg border border-border p-4 flex flex-col items-center gap-2.5 relative overflow-hidden">
+      <div className="bg-background app-radius-lg border border-border p-4 flex flex-col items-center gap-2.5 relative overflow-hidden">
         {phase !== "created" ? (
           <>
-            <div className="w-11 h-11 rounded-lg bg-muted border border-border flex items-center justify-center text-xl">
+            <div className="w-11 h-11 app-radius-lg bg-muted border border-border flex items-center justify-center text-xl">
               <FolderX size={24} className=" text-primary" />
             </div>
             <p className="text-sm font-bold text-foreground">
@@ -241,7 +240,7 @@ function WorkspacePreview() {
               You don't have any workspaces yet.
             </p>
             <motion.div
-              className={`bg-primary text-primary-foreground rounded-lg px-4 py-2 text-[11px] mt-1 transition-all duration-300 border-r border-b border-muted/50 translate-x-[0px] translate-y-[0px]${phase === "clicked" ? " border-muted/50 translate-x-[-3px] translate-y-[-3px] rounded-lg shadow-[3px_3px_0px] shadow-primary " : ""}`}
+              className={`bg-primary text-primary-foreground app-radius-lg px-4 py-2 text-[11px] mt-1 transition-all duration-300 border-r border-b border-muted/50 translate-x-[0px] translate-y-[0px]${phase === "clicked" ? " border-muted/50 translate-x-[-3px] translate-y-[-3px] app-radius-lg shadow-[3px_3px_0px] shadow-primary " : ""}`}
               transition={{ duration: 0.12 }}
             >
               Create a new workspace
@@ -254,7 +253,7 @@ function WorkspacePreview() {
             className="w-full"
           >
             {/* Notebook card */}
-            <div className="bg-background rounded-lg border border-border overflow-hidden">
+            <div className="bg-background app-radius-lg border border-border overflow-hidden">
               <div className="flex items-center justify-between px-3 py-2.5">
                 <span className="text-sm font-bold text-foreground">
                   Untitled
@@ -357,7 +356,7 @@ function WritingPreview() {
 
   return (
     <div className="p-5 w-full">
-      <div className="bg-background rounded-lg border border-border overflow-hidden">
+      <div className="bg-background app-radius-lg border border-border overflow-hidden">
         {/* Editor line */}
         <div className="px-4 py-3 border-b border-muted flex items-center gap-2 min-h-[48px]">
           {showPlaceholder ? (
@@ -370,7 +369,7 @@ function WritingPreview() {
               <span className="text-base font-bold text-foreground">
                 {displayed}
               </span>
-              <span className="inline-block w-0.5 h-4 bg-foreground/50 rounded-sm cursor-blink align-middle" />
+              <span className="inline-block w-0.5 h-4 bg-foreground/50 app-radius-sm cursor-blink align-middle" />
             </>
           )}
         </div>
@@ -405,7 +404,7 @@ function WritingPreview() {
               className={`flex items-center gap-2.5 px-3.5 py-1.5 ${item.active ? "bg-accent" : ""} ${i < 4 ? "border-b border-muted" : ""}`}
             >
               <span
-                className={`w-6 h-6 rounded-md flex items-center justify-center text-[10px] font-bold flex-shrink-0 border ${item.active ? "bg-primary text-primary-foreground border-primary" : "bg-muted text-muted-foreground border-border"}`}
+                className={`w-6 h-6 app-radius-md flex items-center justify-center text-[10px] font-bold flex-shrink-0 border ${item.active ? "bg-primary text-primary-foreground border-primary" : "bg-muted text-muted-foreground border-border"}`}
               >
                 {item.icon}
               </span>
@@ -437,14 +436,7 @@ export default function HowToStartSection() {
   }, []);
 
   return (
-    <section
-      id="how-to-start"
-      className={cn(
-        "px-4 sm:px-6 md:px-8",
-        "py-12 sm:py-16 md:py-20 Desktop:py-24",
-        "relative",
-      )}
-    >
+    <Section sectionId="how-to-start" className="relative">
       <div className="container relative z-10 mx-auto px-4">
         <SectionHeading
           SectionTitle="How To Start"
@@ -460,7 +452,7 @@ export default function HowToStartSection() {
                   ref={(el) => {
                     nodeRefs.current[i] = el;
                   }}
-                  className="z-10 w-8 h-8 rounded-full border-2 border-primary/30 bg-background flex items-center justify-center text-xs font-bold text-primary flex-shrink-0"
+                  className="z-10 w-8 h-8 rounded-tl-md border-2 border-primary/30 bg-background flex items-center justify-center text-xs font-bold text-primary flex-shrink-0"
                 >
                   {i + 1}
                 </div>
@@ -480,7 +472,7 @@ export default function HowToStartSection() {
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.5, delay: index * 0.1 }}
-                  className="group relative bg-card rounded-lg border border-border overflow-hidden hover:border-primary/50 flex flex-col"
+                  className="group relative bg-card app-radius-lg border border-border overflow-hidden hover:border-primary/50 flex flex-col"
                 >
                   {/* Preview area */}
                   <div className="bg-muted border-b border-border h-72 overflow-hidden flex items-center justify-center">
@@ -489,12 +481,12 @@ export default function HowToStartSection() {
 
                   {/* Card content */}
                   <div className="p-5 flex flex-col flex-1">
-                    <span className="absolute top-2 left-2 inline-flex items-center bg-secondary text-secondary-foreground rounded-md px-2.5 py-0.5 text-[11px] font-bold mb-3">
+                    <span className="absolute top-2 left-2 inline-flex items-center bg-secondary text-secondary-foreground app-radius-md px-2.5 py-0.5 text-[11px] font-bold mb-3">
                       {step.StepNum}
                     </span>
 
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+                      <div className="w-7 h-7 app-radius-sm bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
                         <Icon className="w-4 h-4 text-primary" />
                       </div>
                       <h3 className="text-base font-bold text-foreground">
@@ -547,6 +539,6 @@ export default function HowToStartSection() {
           </p>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -32,7 +32,7 @@ export default function Navbar() {
     >
       <motion.div
         className={cn(
-          "container mx-auto flex justify-between items-center border-solid border p-4 my-2 rounded-2xl transition-all duration-300",
+          "container mx-auto flex justify-between items-center border-solid border p-4 my-2 rounded-tl-2xl transition-all duration-300",
           inView
             ? "border-border bg-background/50 backdrop-blur-xl"
             : "border-transparent bg-transparent",

--- a/components/selectors/color-selector.tsx
+++ b/components/selectors/color-selector.tsx
@@ -116,7 +116,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
           variant="SidebarMenuButton"
         >
           <span
-            className="rounded-lg px-1"
+            className="rounded-tl-lg px-1"
             style={{
               color: activeColorItem?.color,
               backgroundColor: activeHighlightItem?.color,
@@ -129,7 +129,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
       </PopoverTrigger>
       <PopoverContent
         sideOffset={5}
-        className="my-1 rounded-lg border border-border bg-muted px-1 py-2 transition-all scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
+        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
         align="start"
       >
         <div className="flex flex-col">
@@ -144,10 +144,10 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
                   editor.commands.setColor(color);
                   onOpenChange(false);
                 }}
-                className="cursor-pointer flex items-center justify-center px-2 py-1 text-md rounded-lg text-foreground group "
+                className="cursor-pointer flex items-center justify-center px-2 py-1 text-md rounded-tl-lg text-foreground group "
               >
                 <div
-                  className="rounded-lg border text-base border-primary/20 px-2 py-px font-medium group-hover:border-primary/50"
+                  className="rounded-tl-lg border text-base border-border px-2 py-px font-medium group-hover:border-muted-foreground"
                   style={{ color }}
                 >
                   A
@@ -170,7 +170,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
                 className="flex cursor-pointer items-center justify-between px-2 py-1 text-md rounded-lg text-foreground group"
               >
                 <div
-                  className="rounded-lg border text-secondary-foreground border-primary/20 px-2 py-px font-medium group-hover:border-primary/50"
+                  className="rounded-tl-lg border text-base border-border px-2 py-px font-medium group-hover:border-muted-foreground"
                   style={{ backgroundColor: color }}
                 >
                   A

--- a/components/selectors/node-selector.tsx
+++ b/components/selectors/node-selector.tsx
@@ -128,14 +128,14 @@ export const NodeSelector = ({ open, onOpenChange }: NodeSelectorProps) => {
               item.command(editor);
               onOpenChange(false);
             }}
-            className="flex cursor-pointer items-center justify-between rounded-lg px-2 py-1 text-sm text-primary hover:bg-primary/10"
+            className="flex cursor-pointer items-center justify-between rounded-tl-lg px-2 py-1 text-sm text-foreground hover:bg-border"
           >
             <div className="flex items-center text-foreground space-x-2">
-              <item.icon className="h-4 w-4 text-primary" />
+              <item.icon className="h-4 w-4 text-muted-foreground" />
               <span>{item.name}</span>
             </div>
             {activeItem.name === item.name && (
-              <Check className="h-4 w-4 text-primary" />
+              <Check className="h-4 w-4 text-muted-foreground" />
             )}
           </EditorBubbleItem>
         ))}

--- a/components/selectors/text-buttons.tsx
+++ b/components/selectors/text-buttons.tsx
@@ -128,7 +128,7 @@ export const TextButtons = () => {
               </TooltipTrigger>
               <TooltipContent
                 side="top"
-                className=" flex justify-center items-center px-1"
+                className=" flex justify-center items-center px-1.5"
                 sideOffset={6}
               >
                 <span>{item.label}</span>
@@ -161,7 +161,7 @@ export const TextButtons = () => {
             </TooltipTrigger>
             <TooltipContent
               side="top"
-              className=" flex justify-center items-center px-1"
+              className=" flex justify-center items-center px-1.5"
               sideOffset={6}
             >
               <span>{item.label}</span>

--- a/components/ui/NoteLoadingSkeletonUI.tsx
+++ b/components/ui/NoteLoadingSkeletonUI.tsx
@@ -1,9 +1,7 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-primary/20 rounded-md animate-pulse ${className}`} />
-  );
+  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
 }
 
 function ParagraphSkeleton() {
@@ -25,7 +23,7 @@ export default function Loading() {
         <Skeleton className="h-4 w-48" />
       </div>
       <ParagraphSkeleton />
-      <div className="h-40 rounded-lg bg-primary/10 animate-pulse" />
+      <div className="h-40 app-radius-lg bg-border animate-pulse" />
       <ParagraphSkeleton />
     </MaxWContainer>
   );

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -74,7 +74,10 @@ export default function Section({
         opacity: 1,
         marginLeft: 0,
         marginRight: 0,
-        borderRadius: 0,
+        borderTopLeftRadius: 0,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        borderBottomLeftRadius: 0,
       });
       return;
     }
@@ -88,7 +91,10 @@ export default function Section({
           opacity: 1,
           marginLeft: 0,
           marginRight: 0,
-          borderRadius: 0,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
+          borderBottomLeftRadius: 0,
         });
         return;
       }
@@ -99,14 +105,20 @@ export default function Section({
         opacity: 1,
         marginLeft: activeMargin,
         marginRight: activeMargin,
-        borderRadius: activeRadius,
+        borderTopLeftRadius: activeRadius,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        borderBottomLeftRadius: 0,
       });
       controls.start({
         y: 0,
         opacity: 1,
         marginLeft: 0,
         marginRight: 0,
-        borderRadius: 0,
+        borderTopLeftRadius: 0,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        borderBottomLeftRadius: 0,
         transition: { ease: "easeOut", duration: resolvedDuration },
       });
     } else {
@@ -118,7 +130,10 @@ export default function Section({
           opacity: 1,
           marginLeft: activeMargin,
           marginRight: activeMargin,
-          borderRadius: activeRadius,
+          borderTopLeftRadius: activeRadius,
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
+          borderBottomLeftRadius: 0,
         });
         return;
       }
@@ -129,7 +144,10 @@ export default function Section({
         opacity: 1,
         marginLeft: activeMargin,
         marginRight: activeMargin,
-        borderRadius: activeRadius,
+        borderTopLeftRadius: activeRadius,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        borderBottomLeftRadius: 0,
         transition: { ease: "easeIn", duration: resolvedDuration },
       });
     }

--- a/components/ui/SkeletonSmImgAnimation.tsx
+++ b/components/ui/SkeletonSmImgAnimation.tsx
@@ -9,7 +9,7 @@ export default function SkeletonSmImgAnimation({
   return (
     <div className="animate-pulse">
       <div
-        className={cn("h-10 w-10 bg-primary/20 rounded-lg mx-3", className)}
+        className={cn("h-10 w-10 bg-border app-radius-lg mx-3", className)}
       ></div>
     </div>
   );

--- a/components/ui/SkeletonTextAndIconAnimation.tsx
+++ b/components/ui/SkeletonTextAndIconAnimation.tsx
@@ -13,13 +13,13 @@ export default function SkeletonTextAndIconAnimation({
       <div className=" w-full flex justify-start items-center pb-3">
         <div
           className={cn(
-            "h-5 w-5 bg-primary/20 rounded-lg mx-3",
+            "h-5 w-5 bg-border app-radius-lg mx-3",
             Icon_className,
           )}
         ></div>
         <div
           className={cn(
-            "h-4 bg-primary/20 rounded-lg mx-2 w-full",
+            "h-4 bg-border app-radius-lg mx-2 w-full",
             text_className,
           )}
         ></div>

--- a/components/ui/SkeletonTextAnimation.tsx
+++ b/components/ui/SkeletonTextAnimation.tsx
@@ -8,7 +8,7 @@ export default function SkeletonTextAnimation({
   return (
     <div className="animate-pulse">
       <div
-        className={cn("h-7 bg-primary/20 rounded-lg mx-3 w-36", className)}
+        className={cn("h-7 bg-border app-radius-lg mx-3 w-36", className)}
       ></div>
     </div>
   );

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+      "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-none sm:rounded-tl-lg",
         className,
       )}
       {...props}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-lg border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-tl-lg border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,31 +4,31 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils";
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium  transition-colors disabled:pointer-events-none disabled:opacity-50 outline-none ring-0",
+  "inline-flex items-center justify-center whitespace-nowrap app-radius-lg text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 outline-none ring-0",
   {
     // transition-all duration-300 hover:translate-x-[-4px] hover:translate-y-[-4px] hover:rounded-md hover:shadow-[4px_4px_0px_black] active:translate-x-[0px] active:translate-y-[0px] active:rounded-2xl active:shadow-none
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground transition-all duration-300 border-r border-b border-transparent hover:border-muted/50 hover:translate-x-[-3px] hover:translate-y-[-3px] hover:rounded-lg hover:shadow-[3px_3px_0px] hover:shadow-primary active:translate-x-[0px] active:translate-y-[0px]",
+          "bg-primary text-primary-foreground transition-all duration-300 border-r border-b border-transparent hover:border-muted/50 hover:translate-x-[-3px] hover:translate-y-[-3px] hover:rounded-tl-lg hover:shadow-[3px_3px_0px] hover:shadow-primary active:translate-x-[0px] active:translate-y-[0px]",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-border/80 text-muted-foreground bg-background hover:bg-muted hover:border-border",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: " hover:bg-primary/10 hover:text-foreground",
+        ghost: " hover:bg-border hover:text-foreground",
         Trigger: "bg-none text-foreground/70 hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         SidebarMenuButton:
-          "flex justify-start items-center gap-2 bg-none w-full text-foreground hover:bg-primary/10",
+          "flex justify-start items-center gap-2 bg-none w-full text-foreground hover:bg-border",
         SidebarMenuButton_destructive:
-          "flex justify-start items-center gap-2 bg-none w-full text-foreground hover:bg-primary/10 hover:text-destructive",
+          "flex justify-start items-center gap-2 bg-none w-full text-foreground hover:bg-border hover:text-destructive",
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-lg px-3",
-        lg: "h-11 rounded-lg px-8",
+        sm: "h-9 app-radius-lg px-3",
+        lg: "h-11 app-radius-lg px-8",
         icon: "h-10 w-10",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow",
+      "app-radius-lg border bg-card text-card-foreground shadow",
       className,
     )}
     {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -38,14 +38,14 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-2 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+      "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-2 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-none sm:rounded-tl-lg",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-5 top-5 rounded-lg opacity-50 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4 text-primary" />
+      <DialogPrimitive.Close className="absolute right-5 top-5 app-radius-lg opacity-50 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4 text-muted-foreground" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-pointer gap-2 select-none items-center rounded-lg px-2 py-1.5 text-sm outline-none focus:bg-primary/10 data-[state=open]:bg-primary/10 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-pointer gap-2 select-none items-center app-radius-lg px-2 py-1.5 text-sm outline-none focus:bg-primary/10 data-[state=open]:bg-primary/10 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-muted p-1 text-muted-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden app-radius-lg border border-border bg-muted p-1 text-muted-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-full overflow-hidden bg-card border border-border rounded-lg p-1 text-foreground ",
+      "z-50 w-full overflow-hidden bg-card border border-border app-radius-lg p-1 text-foreground ",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
@@ -84,7 +84,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative p-1.5 flex cursor-pointer select-none items-center gap-2 rounded-lg text-sm outline-none transition-colors hover:bg-primary/10 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative p-1.5 flex cursor-pointer select-none items-center gap-2 app-radius-lg text-sm outline-none transition-colors hover:bg-border data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -100,7 +100,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center app-radius-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center app-radius-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-foreground/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full app-radius-lg border border-border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-foreground/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-lg border bg-accent p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 w-72 app-radius-lg border bg-accent p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/components/ui/shortcut-badge.tsx
+++ b/components/ui/shortcut-badge.tsx
@@ -1,5 +1,5 @@
 export const ShortcutBadge = ({ keys }: { keys: string }) => (
-  <span className="ml-2 rounded-sm bg-secondary px-1.5 py-0.5 text-[10px] font-mono font-semibold text-secondary-foreground">
+  <span className="ml-2 rounded-tl-sm bg-secondary px-1.5 py-0.5 text-[10px] font-mono font-semibold text-secondary-foreground">
     {keys}
   </span>
 );

--- a/components/ui/skeleton-sidebar.tsx
+++ b/components/ui/skeleton-sidebar.tsx
@@ -1,0 +1,112 @@
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import SkeletonTextAnimation from "../ui/SkeletonTextAnimation";
+import SkeletonSmImgAnimation from "../ui/SkeletonSmImgAnimation";
+import SkeletonTextAndIconAnimation from "../ui/SkeletonTextAndIconAnimation";
+
+export default function SkeletonSidebar({
+  sidebarWidth,
+  open,
+}: {
+  sidebarWidth: number;
+  open: boolean;
+}) {
+  return (
+    <Sidebar
+      variant="inset"
+      className="group bg-muted"
+      style={{
+        width: `${sidebarWidth}px`,
+      }}
+    >
+      <SidebarHeader className=" text-foreground border-b border-border">
+        <div className=" w-full flex items-center justify-between p-1.5">
+          <div className="flex items-center justify-start gap-2">
+            {open ? (
+              <>
+                <SkeletonTextAnimation className="w-20 h-4 mx-0" />
+                <SkeletonTextAnimation className="w-8 h-3 mx-0" />
+              </>
+            ) : (
+              <SkeletonSmImgAnimation className="h-6 w-6" />
+            )}
+          </div>
+          <SkeletonTextAnimation className="w-full mx-0 h-6" />
+        </div>
+        <div className="my-1">
+          {open ? (
+            <SkeletonTextAnimation className="w-full mx-0 h-8" />
+          ) : (
+            <SkeletonTextAnimation className="w-8 mx-0 h-8" />
+          )}
+        </div>
+      </SidebarHeader>
+      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent group-hover:scrollbar-thumb-primary/20">
+        <SidebarGroup>
+          <SidebarGroupLabel className="text-border">
+            <SkeletonTextAnimation className="w-24 h-3" />
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SkeletonTextAndIconAnimation
+                  text_className={open ? "w-full h-5" : "hidden"}
+                />
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SkeletonTextAndIconAnimation
+                  text_className={open ? "w-full h-5" : "hidden"}
+                />
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel className="text-border">
+            <SkeletonTextAnimation className="w-24 h-3" />
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SkeletonTextAndIconAnimation
+                  text_className={open ? "w-full h-5" : "hidden"}
+                />
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SkeletonTextAndIconAnimation
+                  text_className={open ? "w-full h-5" : "hidden"}
+                />
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter className="text-foreground">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <div className="my-2">
+              <div className="border-none w-full h-15 flex items-center justify-between">
+                <SkeletonSmImgAnimation className="h-8 w-8" />
+                {open ? (
+                  <div className="flex flex-col items-start justify-center">
+                    <SkeletonTextAnimation className="w-28 h-4 mx-0" />
+                    <SkeletonTextAnimation className="w-20 h-3 mt-1 mx-0" />
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-lg bg-primary/10", className)}
+      className={cn("animate-pulse app-radius-lg bg-border", className)}
       {...props}
     />
   );

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg gap-2 bg-accent p-1 px-2 text-foreground ",
+      "inline-flex h-9 items-center justify-center app-radius-lg gap-2 bg-muted p-1 px-2 text-foreground ",
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-3 py-1 text-sm text-foreground/50 font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=inactive]:hover:text-foreground data-[state=inactive]:hover:bg-card/80 data-[state=active]:text-foreground",
+      "inline-flex items-center justify-center whitespace-nowrap app-radius-lg px-3 py-1 text-sm text-foreground/50 font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=inactive]:hover:text-foreground data-[state=inactive]:hover:bg-card/80 data-[state=active]:text-foreground",
       className,
     )}
     {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-lg border border-primary/30 bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-primary/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full app-radius-lg border border-primary/30 bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-primary/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       ref={ref}

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors hover:bg-card/80 hover:text-primary focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 border border-transparent data-[state=on]:border-border data-[state=on]:bg-card data-[state=on]:text-primary [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    "inline-flex items-center justify-center gap-2 app-radius-lg text-sm font-medium transition-colors hover:bg-card/80 hover:text-primary focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 border border-transparent data-[state=on]:border-border data-[state=on]:bg-card data-[state=on]:text-primary [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[10001] overflow-hidden rounded-md bg-muted px-3 py-[3px] text-[13px] text-muted-foreground font-semibold border border-border animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        "z-[10001] overflow-hidden rounded-tl-md bg-muted px-3 py-[3px] text-[13px] text-muted-foreground font-semibold border border-border animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
         className,
       )}
       {...props}


### PR DESCRIPTION
massive design system pass introduced a custom corner radius system and applied it everywhere.

### what changed

**`globals.css`  new `app-radius-*` utilities**
added five utility classes in `@layer utilities`:
- `app-radius-sm` to `rounded-none rounded-tl-sm`
- `app-radius-md` to `rounded-none rounded-tl-md`
- `app-radius-lg` to `rounded-none rounded-tl-lg`
- `app-radius-xl` to `rounded-none rounded-tl-xl`
- `app-radius-2xl` to `rounded-none rounded-tl-2xl`

the design language: elements are only rounded on the top-left corner, giving the app a distinctive asymmetric look rather than fully-rounded cards and buttons.

**ui components updated**
every ui primitive now uses `app-radius-*` instead of `rounded-*`:
- `button.tsx`  base, `sm`, `lg` sizes, default hover effect
- `card.tsx`
- `input.tsx`
- `textarea.tsx`
- `tabs.tsx`  `TabsList` and `TabsTrigger`
- `toggle.tsx`
- `tooltip.tsx`
- `dialog.tsx`  dialog content and close button
- `alert-dialog.tsx`
- `dropdown-menu.tsx`  content, items, sub-trigger, sub-content
- `popover.tsx`
- `skeleton.tsx`
- `shortcut-badge.tsx`

**all skeleton components updated**
- `SkeletonTextAnimation`, `SkeletonSmImgAnimation`, `SkeletonTextAndIconAnimation`
- `NoteLoadingSkeletonUI`
- all `loading.tsx` files across home, workspace, and note pages
- skeleton color changed from `bg-primary/20` to `bg-border` throughout

**app feature components updated**
every place with a hardcoded `rounded-*` class that should follow the design language was changed: dialogs, dropdowns, cards in workspace/home pages, sidebar items, search dialog, move note dialog, editor components, landing page sections.

**ghost/SidebarMenuButton hover updated**
`hover:bg-primary/10` to `hover:bg-border` across all affected components.

**also:**
- `SkeletonSidebar` extracted from `AppSidebar.tsx` into `components/ui/skeleton-sidebar`
- noise overlay opacity slightly bumped (`isDark ? 0.05 : 0.03`)
- `ThemeToggle` toggle group gets `rounded-tl-md`


### why

the design language needed a consistent, distinctive corner radius pattern. `app-radius-*` makes it easy to maintain and change in one place.