### PR TITLE
card open btns redesigned,inline edit border tokens, misc cleanup

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -496,7 +496,7 @@ function WorkspaceCard({
                 "text-base font-semibold h-auto py-1 px-1 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 w-full",
                 nameError
                   ? "border border-destructive"
-                  : "border border-primary/20",
+                  : "border border-muted-foreground",
               )}
             />
             {nameError && (
@@ -505,7 +505,7 @@ function WorkspaceCard({
           </div>
         ) : (
           <CardTitle
-            className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-primary/20 transition-all duration-300 pr-8"
+            className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-muted-foreground transition-all duration-300 pr-8"
             onDoubleClick={handleNameDoubleClick}
             title="Double-click to rename"
           >
@@ -526,7 +526,7 @@ function WorkspaceCard({
         </div>
       </CardContent>
 
-      <CardFooter className="py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
+      <CardFooter className=" relative py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
         <div className="flex items-center gap-1.5">
           <Clock className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
@@ -535,7 +535,11 @@ function WorkspaceCard({
             <SkeletonTextAnimation className="w-20" />
           )}
         </div>
-        <Button variant="ghost" size="sm" asChild className="h-7 px-2 text-xs">
+        <Button
+          size="sm"
+          asChild
+          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]  absolute bottom-0 right-0 h-9 px-2 text-xs"
+        >
           <IntentPrefetchLink href={`/home/${workspace._id}`}>
             Open
           </IntentPrefetchLink>
@@ -614,7 +618,7 @@ function NoteCard({ note }: { note: Note }) {
         </p>
       </CardContent>
 
-      <CardFooter className="py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
+      <CardFooter className=" relative py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
         <div className="flex items-center gap-1.5">
           <Clock className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
@@ -624,10 +628,9 @@ function NoteCard({ note }: { note: Note }) {
           )}
         </div>
         <Button
-          variant="ghost"
           size="sm"
           asChild
-          className="h-7 px-2 text-xs hover:bg-primary/10"
+          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]  absolute bottom-0 right-0 h-9 px-2 text-xs"
         >
           <IntentPrefetchLink
             href={`/home/${note.workingSpaceId}/${note.slug}?id=${note._id}`}

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -686,7 +686,7 @@ export default function WorkingSpacePageClient({
                       "text-3xl md:text-5xl font-bold h-auto py-0 px-2 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
                       nameError
                         ? "border border-destructive"
-                        : "border border-primary/50",
+                        : "border border-muted-foreground",
                     )}
                   />
                   {nameError && (
@@ -697,7 +697,7 @@ export default function WorkingSpacePageClient({
                 <span
                   onDoubleClick={handleNameDoubleClick}
                   title="Double-click to rename"
-                  className="cursor-text app-radius-md border border-transparent px-2 hover:border-primary/50 transition-colors duration-150"
+                  className="cursor-text app-radius-md border border-transparent px-2 hover:border-muted-foreground transition-colors duration-150"
                 >
                   {workspace.name}
                 </span>
@@ -831,7 +831,7 @@ export function NotesDroppableContainer({
               variant="SidebarMenuButton"
               size="sm"
               className={cn(
-                "rounded-none hover:bg-muted",
+                "!rounded-none hover:bg-muted",
                 viewMode === "grid" && "bg-muted",
               )}
               onClick={() => setViewMode("grid")}
@@ -844,7 +844,7 @@ export function NotesDroppableContainer({
               variant="SidebarMenuButton"
               size="sm"
               className={cn(
-                "rounded-none hover:bg-muted",
+                "!rounded-none hover:bg-muted",
                 viewMode === "list" && "bg-muted",
               )}
               onClick={() => setViewMode("list")}
@@ -1010,7 +1010,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   return (
     <Card
       className={cn(
-        "group relative overflow-hidden bg-card/90 backdrop-blur-sm border transition-all duration-300 flex flex-col h-full",
+        "group relative overflow-hidden bg-card backdrop-blur-sm border transition-all duration-300 flex flex-col h-full",
         isEmpty
           ? "border-dashed border-border"
           : "border-border hover:border-border",
@@ -1042,7 +1042,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                   "text-base font-semibold min-h-0 py-1 px-2 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
                   titleError
                     ? "border border-destructive"
-                    : "border border-primary/50",
+                    : "border border-muted-foreground",
                 )}
               />
               {titleError && (
@@ -1051,7 +1051,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
             </div>
           ) : (
             <CardTitle
-              className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-primary/50 transition-all duration-300 pr-2 "
+              className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-muted-foreground transition-all duration-300 pr-2 "
               onDoubleClick={handleDoubleClick}
               title="Double-click to rename"
             >
@@ -1093,10 +1093,9 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
           )}
         </div>
         <Button
-          variant="ghost"
           size="sm"
           asChild
-          className="h-7 text-xs hover:bg-primary/10"
+          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]  absolute bottom-0 right-0 h-9 px-2 text-xs"
         >
           <IntentPrefetchLink
             href={`/home/${workspaceId}/${note.slug}?id=${note._id}`}
@@ -1219,7 +1218,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                     "text-base font-semibold h-auto py-1 px-1 app-radius-md bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 mb-1",
                     titleError
                       ? "border border-destructive"
-                      : "border border-primary/50",
+                      : "border border-muted-foreground",
                   )}
                 />
                 {titleError && (
@@ -1228,7 +1227,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
               </>
             ) : (
               <h3
-                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text app-radius-md border border-transparent hover:border-primary/50 transition-all duration-300 hover:px-2 w-fit mb-1"
+                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text app-radius-md border border-transparent hover:border-muted-foreground transition-all duration-300 hover:px-2 w-fit mb-1"
                 onDoubleClick={handleDoubleClick}
                 title="Double-click to rename"
               >
@@ -1263,13 +1262,12 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
               DropdownMenuContentAlign="start"
               TooltipContentAlign="start"
               onDelete={onDelete}
-              BtnClassName="pt-0"
+              BtnClassName="pt-0 "
             />
             <Button
-              variant="ghost"
               size="sm"
               asChild
-              className="h-7 text-xs hover:bg-primary/10"
+              className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] h-9 px-2 text-xs"
             >
               <IntentPrefetchLink
                 href={`/home/${workspaceId}/${note.slug}?id=${note._id}`}

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -275,7 +275,7 @@ export default function NoteSettings({
             </Button>
 
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger className="w-full h-8 px-2 text-sm flex items-center gap-2 text-foreground hover:bg-primary/10">
+              <DropdownMenuSubTrigger className="w-full h-8 px-2 text-sm flex items-center gap-2 text-foreground">
                 <Download size={14} className="text-muted-foreground" />
                 Download
               </DropdownMenuSubTrigger>

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -231,7 +231,8 @@ export default function WorkingSpaceSettings({
               </>
             ) : (
               <>
-                <FaRegTrashCan size="14" className=" text-primary" /> Delete
+                <FaRegTrashCan size="14" className=" text-muted-foreground" />{" "}
+                Delete
               </>
             )}
           </Button>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-pointer gap-2 select-none items-center app-radius-lg px-2 py-1.5 text-sm outline-none focus:bg-primary/10 data-[state=open]:bg-primary/10 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-pointer gap-2 select-none items-center app-radius-tl-lg px-2 py-1.5 text-sm outline-none focus:bg-border data-[state=open]:bg-border [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-      "z-50 w-full overflow-hidden bg-card border border-border app-radius-lg p-1 text-foreground ",
+        "z-50 w-full overflow-hidden bg-card border border-border app-radius-lg p-1 text-foreground ",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}


### PR DESCRIPTION
### what changed

**open buttons on workspace/note cards**
replaced the ghost `h-7` open buttons with the default button variant anchored to the bottom-right corner of the card footer — `absolute bottom-0 right-0 h-9` with the same lift-shadow hover effect used elsewhere in the app (`hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]`). applies to `WorkspaceCard`, `NoteCard`, `GridNoteCard`, and `ListNoteCard`.

**inline edit borders**
all inline rename inputs and hover borders changed from `border-primary/20` / `border-primary/50` to `border-muted-foreground` for consistency.

**`GridNoteCard`**
card background changed from `bg-card/90` to `bg-card` (full opacity).

**view mode toggle buttons**
added `!rounded-none` (with `!important`) to override the `app-radius-lg` base class so the grid/list toggle buttons stay truly square.

**`NoteSettings.tsx`**
removed the custom `hover:bg-primary/10` from the Download submenu trigger since the dropdown component now handles hover styles.

**`WorkingSpaceSettings.tsx`**
delete button trash icon changed from `text-primary` to `text-muted-foreground`.

**`dropdown-menu.tsx`**
sub-trigger focus/open state changed from `focus:bg-primary/10 data-[state=open]:bg-primary/10` to `focus:bg-border data-[state=open]:bg-border`. also fixed indentation on `DropdownMenuContent`.

why

the old ghost open buttons were visually weak and didn't feel clickable. anchoring them to the corner with the consistent lift effect makes them feel like part of the card's design language.