### PR TITLE
sidebar text gradient + sidebar group content hover fix

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -214,7 +214,7 @@ const SidebarNavigation = memo(function SidebarNavigation({
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Navigation</SidebarGroupLabel>
-      <SidebarGroupContent>
+      <SidebarGroupContent className=" hover:bg-transparent">
         <SidebarMenu>
           <SidebarMenuItem>
             <Button
@@ -336,7 +336,7 @@ const PinnedNoteItem = memo(
     );
 
     const textClassName = isHovered
-      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-65% to-transparent to-90% text-transparent bg-clip-text"
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
 
     return (
@@ -623,7 +623,7 @@ const WorkspaceItem = memo(
     );
 
     const textClassName = isHovered
-      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-65% to-transparent to-90% text-transparent bg-clip-text"
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-75% via-transparent via-85% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
 
     return (

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -51,7 +51,10 @@ function SearchLoadingSkeleton() {
   return (
     <div className="space-y-1 p-2">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-3 py-2.5 px-3 app-radius-lg">
+        <div
+          key={i}
+          className="flex items-center gap-3 py-2.5 px-3 app-radius-lg"
+        >
           <div className="h-8 w-8 bg-border app-radius-lg shrink-0 animate-pulse" />
           <div className="flex-1 space-y-2">
             <div className="h-3.5 bg-border app-radius-md w-2/3 animate-pulse" />

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -647,7 +647,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-tl-lg p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-border hover:text-muted-foreground focus-visible:ring-0 [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center app-radius-lg p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-border hover:text-muted-foreground focus-visible:ring-0 [&>svg]:size-4 [&>svg]:shrink-0",
         "after:absolute after:-inset-2 after:md:hidden",
         "group-data-[collapsible=icon]:hidden",
         className,
@@ -665,7 +665,7 @@ const SidebarGroupContent = React.forwardRef<
   <div
     ref={ref}
     data-sidebar="group-content"
-    className={cn("w-full text-sm", className)}
+    className={cn("w-full text-sm app-radius-lg hover:bg-border ", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
### what changed

**`AppSidebar.tsx` sidebar item text gradient**
widened the fade-out stop points on the truncated text gradient for both pinned notes and workspace items:
- pinned notes: `via-65% to-90%` to `via-75% to-100%`
- workspace items: `via-65% to-90%` to `via-85% to-100%`

this keeps text visible longer before fading out, which looks better for longer titles.

also added `hover:bg-transparent` to `SidebarGroupContent` in the navigation section to prevent the group from lighting up on hover (individual items handle their own hover states).

**`sidebar.tsx`  `SidebarGroupContent` and `SidebarGroupAction`**
- `SidebarGroupContent` now gets `app-radius-lg hover:bg-border` by default in the base component  note: this will apply globally to all sidebar group content, not just navigation. might want to check if this is intentional.
- `SidebarGroupAction` changed from `rounded-tl-lg` back to `app-radius-lg`

**`SearchDialog.tsx`**
formatted the skeleton row div onto multiple lines for readability.