### PR TITLE
improve card layout consistency and spacing

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -470,7 +470,7 @@ function WorkspaceCard({
   );
 
   return (
-    <Card className="group relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-fit transition-shadow">
+    <Card className=" flex flex-col justify-between items-stretch group relative overflow-hidden bg-card border-border w-[330px] min-h-[230px] ">
       <CardHeader className="pb-3 relative">
         {isEditingName ? (
           <div className="flex flex-col gap-1 pr-8 max-w-sm">
@@ -499,15 +499,11 @@ function WorkspaceCard({
           />
         </div>
       </CardHeader>
-
-      <CardContent className="pb-3">
-        <div className="h-20 flex items-center justify-center">
-          <FolderClosed className="h-8 w-8 text-primary" />
-        </div>
+      <CardContent className="flex-grow flex-1">
+        <FolderClosed className="h-8 text-primary text-center w-full" />
       </CardContent>
-
-      <CardFooter className=" relative py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
-        <div className="flex items-center gap-1.5">
+      <CardFooter className="py-4 flex items-center justify-between border-t border-border">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Clock className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
             <span>{new Date(workspace.updatedAt).toLocaleDateString()}</span>
@@ -570,7 +566,7 @@ function NoteCard({ note }: { note: Note }) {
   return (
     <Card
       className={cn(
-        "group relative overflow-hidden bg-card/90 backdrop-blur-sm border transition-all duration-300 flex-shrink-0 w-[300px] h-[225px] flex flex-col",
+        "group relative overflow-hidden bg-card border transition-all duration-300 flex-shrink-0 w-[330px] h-[230px] flex flex-col",
         isEmpty ? "border-dashed border-border" : "border-border",
       )}
     >
@@ -587,7 +583,7 @@ function NoteCard({ note }: { note: Note }) {
         </div>
       </CardHeader>
 
-      <CardContent className="h-full">
+      <CardContent className="flex-grow flex-1">
         <p
           className={cn(
             "text-sm line-clamp-3",
@@ -598,7 +594,7 @@ function NoteCard({ note }: { note: Note }) {
         </p>
       </CardContent>
 
-      <CardFooter className=" relative py-3 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
+      <CardFooter className=" relative py-4 flex justify-between items-center text-xs text-muted-foreground border-t border-border">
         <div className="flex items-center gap-1.5">
           <Clock className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -770,7 +770,7 @@ export function NotesDroppableContainer({
           <div
             className={
               viewMode === "grid"
-                ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4"
+                ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
                 : "flex flex-col gap-3"
             }
           >
@@ -893,7 +893,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   return (
     <Card
       className={cn(
-        "group relative overflow-hidden bg-card backdrop-blur-sm border transition-all duration-300 flex flex-col h-[179px]",
+        "group relative overflow-hidden bg-card border  flex flex-col min-h-[230px]",
         isEmpty
           ? "border-dashed border-border"
           : "border-border hover:border-border",
@@ -936,7 +936,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
         </div>
       </CardHeader>
 
-      <CardContent className="h-full">
+      <CardContent className=" flex-grow flex-1">
         {isEmpty ? (
           <p className="text-sm text-muted-foreground italic">
             No content yet. Click to start writing...
@@ -948,8 +948,8 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
         )}
       </CardContent>
 
-      <CardFooter className="py-3 flex items-center justify-between border-t border-border">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <CardFooter className="py-4 flex items-center justify-between border-t border-border">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground ">
           <Calendar className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
             <span>{new Date(note.updatedAt).toLocaleDateString()}</span>


### PR DESCRIPTION
this pr updates the layout and styling of workspace and note cards to make them more consistent and visually balanced across the app.

**what changed:**

* standardized card widths and heights (increased from ~300px to 330px, added min heights)
* switched card layouts to use flex with `flex-col` and `flex-grow` for better vertical distribution
* removed unnecessary wrappers and simplified content structure (especially around icons and content areas)
* adjusted grid layout from 4 columns to 3 columns on medium screens
* unified spacing in footers (increased padding, consistent gap usage)
* removed backdrop blur and some extra styling for a cleaner look

the previous implementation had inconsistent sizing, uneven spacing, and some layout constraints that made cards feel cramped or misaligned. using fixed heights also limited flexibility when content varied.

**before :**
<img width="644" height="259" alt="image" src="https://github.com/user-attachments/assets/65afc8be-6edd-4c6e-8819-1bd0a3921d48" />

**now:**
<img width="575" height="323" alt="image" src="https://github.com/user-attachments/assets/251eb62f-19d2-4af6-8534-66db58328e66" />


* more consistent card sizing across different components
* improved vertical alignment using flexbox (content naturally fills space)
* cleaner and simpler structure, easier to maintain
* better responsiveness with a more balanced grid (3 columns instead of 4)
* improved readability and spacing, especially in footers and content areas
