### PR TITLE
align skeleton layouts with updated card design

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -244,18 +244,18 @@ export default function HomePageClient() {
 
 function WorkspaceCardSkeleton() {
   return (
-    <Card className="relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-fit">
+    <Card className="relative overflow-hidden bg-card border-border flex-shrink-0 w-[330px] min-h-[230px] flex flex-col">
       <CardHeader className="pb-3 relative">
         <Skeleton className="h-5 w-3/4" />
       </CardHeader>
-      <CardContent className="pb-3">
-        <div className="h-20 flex items-center justify-center">
+      <CardContent className="flex-grow flex-1">
+        <div className="h-full flex items-center justify-center">
           <Skeleton className="h-8 w-8 app-radius-md" />
         </div>
       </CardContent>
-      <CardFooter className="pt-3 flex justify-between items-center border-t border-border">
+      <CardFooter className="py-4 flex justify-between items-center border-t border-border">
         <Skeleton className="h-3 w-24" />
-        <Skeleton className="h-7 w-16" />
+        <Skeleton className="h-9 w-12" />
       </CardFooter>
     </Card>
   );
@@ -263,8 +263,8 @@ function WorkspaceCardSkeleton() {
 
 function NoteCardSkeleton() {
   return (
-    <Card className="relative overflow-hidden bg-card/90 backdrop-blur-sm border-border flex-shrink-0 w-[300px] h-[225px] flex flex-col">
-      <CardHeader className="pb-2">
+    <Card className="relative overflow-hidden bg-card border-border flex-shrink-0 w-[330px] h-[230px] flex flex-col">
+      <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 space-y-2">
             <Skeleton className="h-5 w-3/4" />
@@ -272,14 +272,14 @@ function NoteCardSkeleton() {
           </div>
         </div>
       </CardHeader>
-      <CardContent className="pb-3 space-y-2">
+      <CardContent className="flex-grow flex-1 space-y-2">
         <Skeleton className="h-3 w-full" />
         <Skeleton className="h-3 w-5/6" />
         <Skeleton className="h-3 w-4/6" />
       </CardContent>
-      <CardFooter className="pt-3 flex justify-between items-center border-t border-border mt-auto">
+      <CardFooter className="py-4 flex justify-between items-center border-t border-border mt-auto">
         <Skeleton className="h-3 w-24" />
-        <Skeleton className="h-7 w-16" />
+        <Skeleton className="h-9 w-12" />
       </CardFooter>
     </Card>
   );

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1186,7 +1186,7 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
         {Array.from({ length: 5 }).map((_, index) => (
           <Card
             key={index}
-            className="bg-card/90 backdrop-blur-sm border-border"
+            className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px]"
           >
             <CardHeader className="pb-3">
               <div className="flex items-start justify-between gap-2">
@@ -1194,16 +1194,16 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
                 <div className="h-5 w-5 bg-border rounded animate-pulse" />
               </div>
             </CardHeader>
-            <CardContent className="pb-3">
+            <CardContent className="flex-grow flex-1">
               <div className="space-y-2">
                 <div className="h-4 w-full bg-border rounded animate-pulse" />
                 <div className="h-4 w-5/6 bg-border rounded animate-pulse" />
                 <div className="h-4 w-4/6 bg-border rounded animate-pulse" />
               </div>
             </CardContent>
-            <CardFooter className="pt-3 flex items-center justify-between border-t border-border">
+            <CardFooter className="py-4 flex items-center justify-between border-t border-border">
               <div className="h-4 w-24 bg-border rounded animate-pulse" />
-              <div className="h-7 w-16 bg-border rounded animate-pulse" />
+              <div className="h-9 w-12 bg-border rounded animate-pulse" />
             </CardFooter>
           </Card>
         ))}
@@ -1217,7 +1217,7 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
         <Card key={index} className="bg-card/90 backdrop-blur-sm border-border">
           <CardContent className="p-4">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 rounded-full bg-border animate-pulse flex-shrink-0" />
+              <div className="h-10 w-10 app-radius-md bg-border animate-pulse flex-shrink-0" />
               <div className="flex-1 min-w-0 space-y-2">
                 <div className="h-5 w-2/3 bg-border rounded animate-pulse" />
                 <div className="h-4 w-full bg-border rounded animate-pulse" />
@@ -1225,7 +1225,7 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
               <div className="flex items-center gap-3">
                 <div className="h-4 w-24 bg-border rounded animate-pulse" />
                 <div className="h-5 w-5 bg-border rounded animate-pulse" />
-                <div className="h-7 w-16 bg-border rounded animate-pulse" />
+                <div className="h-9 w-12 bg-border rounded animate-pulse" />
               </div>
             </div>
           </CardContent>

--- a/app/home/[id]/loading.tsx
+++ b/app/home/[id]/loading.tsx
@@ -27,9 +27,9 @@ function NotesGridSkeleton({ count }: { count: number }) {
       {Array.from({ length: count }).map((_, i) => (
         <div
           key={i}
-          className="app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden"
+          className="app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden min-h-[230px] flex flex-col"
         >
-          <div className="p-4 pb-2">
+          <div className="p-4 pb-3">
             <div className="flex items-start justify-between gap-3">
               <div className="flex-1 min-w-0 space-y-2">
                 <Skeleton className="h-5 w-2/3" />
@@ -38,14 +38,14 @@ function NotesGridSkeleton({ count }: { count: number }) {
               <Skeleton className="h-6 w-6" />
             </div>
           </div>
-          <div className="px-4 pb-4 space-y-2">
+          <div className="px-4 flex-grow flex-1 space-y-2">
             <Skeleton className="h-4 w-full" />
             <Skeleton className="h-4 w-5/6" />
             <Skeleton className="h-4 w-4/6" />
           </div>
-          <div className="px-4 py-3 border-t border-border flex items-center justify-between">
+          <div className="px-4 py-4 border-t border-border flex items-center justify-between">
             <Skeleton className="h-3 w-24" />
-            <Skeleton className="h-7 w-16" />
+            <Skeleton className="h-9 w-12" />
           </div>
         </div>
       ))}

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -1,26 +1,28 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
+  return (
+    <div className={`bg-border app-radius-md animate-pulse ${className}`} />
+  );
 }
 
 function WorkspaceCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[300px] h-fit app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden">
+    <div className="flex-shrink-0 w-[330px] min-h-[230px] app-radius-xl border border-border bg-card overflow-hidden flex flex-col">
       {/* CardHeader */}
       <div className="p-6 pb-3">
         <Skeleton className="h-5 w-3/4" />
       </div>
       {/* CardContent — folder icon area */}
-      <div className="px-6 pb-3">
-        <div className="h-20 flex items-center justify-center">
+      <div className="px-6 flex-1">
+        <div className="h-full flex items-center justify-center">
           <Skeleton className="h-8 w-8 app-radius-md" />
         </div>
       </div>
       {/* CardFooter */}
-      <div className="px-6 pt-3 pb-6 flex justify-between items-center border-t border-border">
+      <div className="px-6 py-4 flex justify-between items-center border-t border-border">
         <Skeleton className="h-3 w-24" />
-        <Skeleton className="h-7 w-16" />
+        <Skeleton className="h-9 w-12" />
       </div>
     </div>
   );
@@ -28,9 +30,9 @@ function WorkspaceCardSkeleton() {
 
 function NoteCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[300px] h-[225px] app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden flex flex-col">
+    <div className="flex-shrink-0 w-[330px] h-[230px] app-radius-xl border border-border bg-card overflow-hidden flex flex-col">
       {/* CardHeader */}
-      <div className="p-6 pb-2">
+      <div className="p-6 pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 space-y-2">
             <Skeleton className="h-5 w-3/4" />
@@ -45,9 +47,9 @@ function NoteCardSkeleton() {
         <Skeleton className="h-3 w-4/6" />
       </div>
       {/* CardFooter */}
-      <div className="px-6 pt-3 pb-6 flex justify-between items-center border-t border-border mt-auto">
+      <div className="px-6 py-4 flex justify-between items-center border-t border-border mt-auto">
         <Skeleton className="h-3 w-24" />
-        <Skeleton className="h-7 w-16" />
+        <Skeleton className="h-9 w-12" />
       </div>
     </div>
   );


### PR DESCRIPTION
this pr updates all skeleton components to match the new card layout and sizing introduced earlier, ensuring consistency between loading and loaded states.

**what changed:**

* standardized skeleton card widths and heights (330px width, min-height ~230px)
* updated layouts to use flex with `flex-col` and `flex-grow` for proper content distribution
* adjusted padding and spacing (especially headers and footers) to match real components
* increased footer button skeleton sizes for better alignment with actual UI
* removed backdrop blur in some places to match updated card styles
* improved centering of placeholder content (icons and text blocks)
* applied consistent structure across home, workspace, and loading screens

previous skeletons were out of sync with the actual card components, leading to layout shifts and inconsistent visual structure during loading states.