### PR TITLE
replace scrollbar-thumb-primary/20 with scrollbar-thumb-border globally

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -102,7 +102,7 @@ export default function PublicNotePage() {
 
   return (
     <div
-      className="relative w-full flex flex-col h-screen overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent"
+      className="relative w-full flex flex-col h-screen overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
       onScroll={(e) => {
         setIsScrolled(e.currentTarget.scrollTop > 0);
       }}

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -563,26 +563,24 @@ export default function WorkingSpacePageClient({
     <MaxWContainer className="my-5">
       <header>
         <div className=" relative flex justify-between items-end w-full">
-          <div className="flex-1 py-1 px-1.5 border border-border bg-muted rounded-none rounded-tl-lg rounded-br-lg">
-            <h1 className="text-3xl md:text-5xl font-bol my-2">
+          <div className="flex-1 px-1.5 border border-border bg-muted rounded-none rounded-tl-lg rounded-br-lg">
+            <h1 className="text-3xl md:text-5xl font-bol my-3 h-[3rem]">
               {!workspace ? (
                 <div className="bg-border app-radius-md animate-pulse h-10 w-64 inline-block" />
               ) : isEditingName ? (
-                <div className="flex flex-col gap-1 overflow-hidden max-w-xl">
-                  <Input
-                    ref={nameInputRef as any}
-                    value={editedName}
-                    onChange={(e) => setEditedName(e.target.value)}
-                    onBlur={handleNameBlur}
-                    onKeyDown={handleNameKeyDown}
-                    className=" field-sizing-content width-fit-content min-w-fit max-w-full border-transparent bg-transparent px-2 py-7 text-3xl font-bold app-radius-md focus-visible:ring-0 focus-visible:ring-offset-0 md:text-5xl"
-                  />
-                </div>
+                <Input
+                  ref={nameInputRef as any}
+                  value={editedName}
+                  onChange={(e) => setEditedName(e.target.value)}
+                  onBlur={handleNameBlur}
+                  onKeyDown={handleNameKeyDown}
+                  className=" field-sizing-content width-fit-content min-w-fit max-w-full border-transparent bg-transparent px-2 h-[3.3rem] text-3xl md:text-5xl focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
+                />
               ) : (
                 <span
                   onDoubleClick={handleNameDoubleClick}
                   title="Double-click to rename"
-                  className="cursor-text app-radius-md border border-transparent px-2 hover:border-muted-foreground/50 transition-colors duration-150"
+                  className="cursor-text app-radius-md border border-transparent px-2 hover:border-muted-foreground/50"
                 >
                   {workspace.name}
                 </span>

--- a/components/ToC.tsx
+++ b/components/ToC.tsx
@@ -399,7 +399,7 @@ export const ToC = ({ items = [], editor, onActiveIdChange }: ToCProps) => {
     <div
       className={`max-h-[40rem] ${
         isExpanded
-          ? "overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent"
+          ? "overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
           : "overflow-hidden"
       }`}
       onMouseEnter={() => setIsExpanded(true)}
@@ -442,7 +442,7 @@ export const CompactFloatingToC = ({
       <div
         className={`
           transition-all duration-300 ease-in-out px-0.5 border border-solid rounded-tl-lg bg-background/60 backdrop-blur-xl
-          ${isExpanded ? "w-52 border-primary/10 " : "w-10 border-transparent"}
+          ${isExpanded ? "w-52 border-border " : "w-10 border-transparent"}
         `}
       >
         <div

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -171,7 +171,7 @@ const TailwindAdvancedEditor = ({
             }}
             slotAfter={<ImageResizer />}
           >
-            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent">
+            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
               <EditorCommandEmpty className="px-2 text-muted-foreground">
                 No results
               </EditorCommandEmpty>

--- a/components/code-block-component.tsx
+++ b/components/code-block-component.tsx
@@ -71,7 +71,7 @@ export const CodeBlockComponent = ({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="max-h-64 min-w-32 overflow-y-auto scroll-smooth scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent"
+            className="max-h-64 min-w-32 overflow-y-auto scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
             align="start"
           >
             {languages.map((lang) => (

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -376,7 +376,7 @@ const PinnedNoteItem = memo(
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
-                className="flex-1 h-8 px-2 py-1.5 text-sm focus:outline-none focus:ring-0 focus:border-foreground app-radius-lg"
+                className="flex-1 h-8 px-6 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>
@@ -674,7 +674,7 @@ const WorkspaceItem = memo(
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
-                className="flex-1 h-8 px-2 py-1.5 text-sm focus:outline-none focus:ring-0 focus:border-foreground app-radius-lg"
+                className="flex-1 h-8 px-7 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>
@@ -1143,7 +1143,7 @@ const AppSidebar = React.memo(function AppSidebar() {
         <SidebarContent
           ref={sidebarContentRef}
           onScroll={handleSidebarScroll}
-          className="relative text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-transparent scrollbar-track-transparent group-hover:scrollbar-thumb-primary/20"
+          className="relative text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-transparent scrollbar-track-transparent group-hover:scrollbar-thumb-border"
         >
           <SidebarNavigation
             pathname={pathname}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -108,7 +108,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         </div>
         <div
           ref={scrollContainerRef}
-          className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-primary/50 scrollbar-track-transparent py-6"
+          className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent py-6"
         >
           <motion.div
             initial={{ opacity: 0 }}

--- a/components/home-components/MoveNoteDialog.tsx
+++ b/components/home-components/MoveNoteDialog.tsx
@@ -254,7 +254,7 @@ export default function MoveNoteDialog({
           </Button>
         </div>
 
-        <div className="min-h-[320px] max-h-[350px] overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent p-3 bg-card">
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
           {moveTargets === undefined ? (
             <div className="space-y-2 p-2">
               {Array.from({ length: 6 }).map((_, index) => (

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -447,7 +447,8 @@ export default function SearchDialog({
       <DialogContent className="p-0 overflow-hidden bg-card border-border md:min-w-[850px] gap-0 shadow-2xl">
         <DialogTitle className="sr-only">Search Notes</DialogTitle>
         <DialogDescription className="sr-only">
-          Search across workspaces, tables, and notes, then open the selected result.
+          Search across workspaces, tables, and notes, then open the selected
+          result.
         </DialogDescription>
 
         <div className="flex items-center border-b border-border px-4 py-2">
@@ -469,7 +470,7 @@ export default function SearchDialog({
         <div
           ref={resultsScrollRef}
           onScroll={handleResultsScroll}
-          className="min-h-[40vh] max-h-[40vh] overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent p-3"
+          className="min-h-[40vh] max-h-[40vh] overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent p-3"
         >
           {canScroll && scrollTop > 8 && (
             <div

--- a/components/selectors/color-selector.tsx
+++ b/components/selectors/color-selector.tsx
@@ -129,7 +129,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
       </PopoverTrigger>
       <PopoverContent
         sideOffset={5}
-        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
+        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
         align="start"
       >
         <div className="flex flex-col">

--- a/components/ui/skeleton-sidebar.tsx
+++ b/components/ui/skeleton-sidebar.tsx
@@ -50,7 +50,7 @@ export default function SkeletonSidebar({
           )}
         </div>
       </SidebarHeader>
-      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent group-hover:scrollbar-thumb-primary/20">
+      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent group-hover:scrollbar-thumb-border">
         <SidebarGroup>
           <SidebarGroupLabel className="text-border">
             <SkeletonTextAnimation className="w-24 h-3" />


### PR DESCRIPTION
normalized all custom scrollbar thumb colors from the inconsistent `primary/20` (and `primary/50`) tint to the `border` token. applies across:

- `HomeClientLayout` main scroll container
- `AppSidebar` sidebar content
- `SkeletonSidebar`
- `SearchDialog` results area
- `MoveNoteDialog` target list
- `advanced-editor` slash command menu
- `code-block-component` language dropdown
- `color-selector` popover
- `ToC` expanded items list
- public document page scroll container

also:
- `CompactFloatingToC` expanded border changed from `border-primary/10` to `border-border`
- workspace page header input wrapper `py-1` removed and `h1` given fixed `h-[3rem]`, input set to `h-[3.3rem]` to fill it cleanly
- sidebar rename inputs adjusted (`px-6/px-7`, `py-0`, `border-0`)
- `WorkingSpacePageClient` header card `py-1` padding removed
- workspace name `<span>` hover transition removed (`transition-colors duration-150` dropped)