### PR TITLE
table-tab polish +formatTableName util + list card layout fixes

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -51,7 +51,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { getContentPreview } from "@/lib/getContentPreview";
-import { cn } from "@/lib/utils";
+import { cn, formatTableName } from "@/lib/utils";
 
 const workspaceNameSchema = z
   .string()
@@ -232,7 +232,7 @@ function TableTab({ table }: { table: any }) {
     [table.name],
   );
   const textClassName = isHovered
-    ? "truncate flex-grow bg-gradient-to-r from-foreground from-65% via-transparent via-85% to-transparent to-90% text-transparent bg-clip-text"
+    ? "truncate flex-grow bg-gradient-to-r from-foreground from-75% via-transparent via-85% to-transparent to-95% text-transparent bg-clip-text"
     : "truncate flex-grow";
 
   const handleDelete = useCallback(async () => {
@@ -247,14 +247,14 @@ function TableTab({ table }: { table: any }) {
 
   if (isEditing) {
     return (
-      <div className="flex flex-col gap-1 px-1 flex-shrink-0 max-w-[13rem] overflow-hidden">
+      <div className="flex flex-col gap-1 px-1 flex-shrink-0 max-w-28 overflow-hidden">
         <Input
           ref={inputRef as any}
           value={editedName}
           onChange={(e) => setEditedName(e.target.value)}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
-          className=" field-sizing-content width-fit-content min-w-fit max-w-full border-transparent bg-transparent px-4 h-[3.3rem] text-sm focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
+          className=" w-full border-transparent bg-transparent px-3 h-[3.3rem] text-sm focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
         />
       </div>
     );
@@ -263,26 +263,25 @@ function TableTab({ table }: { table: any }) {
   return (
     <>
       <div
-        className="relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg"
+        className="relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-28"
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
         <TabsTrigger
           value={table._id}
           data-tab-id={table._id}
-          className="px-5 py-2.5 rounded-none rounded-tl-lg whitespace-nowrap flex items-center gap-1.5 border border-transparent border-b-0 data-[state=active]:border-border"
+          className="px-4 py-2.5 rounded-none rounded-tl-lg w-full text-start whitespace-nowrap flex items-center gap-1.5 border border-transparent border-b-0 data-[state=active]:border-border"
           onDoubleClick={handleDoubleClick}
           title="Double-click to rename"
         >
-          <p className={textClassName}>{table.name}</p>
+          <p className={cn(textClassName, "w-full")}>
+            {formatTableName(table.name)}
+          </p>
         </TabsTrigger>
-
         <div
           className={cn(
-            "absolute inset-y-0 right-1 flex items-center transition-all",
-            isHovered
-              ? "opacity-100 translate-x-0"
-              : "opacity-0 translate-x-2 pointer-events-none",
+            "absolute inset-y-0 right-2 flex items-center",
+            isHovered ? "opacity-100 " : "opacity-0 pointer-events-none",
           )}
         >
           <Button
@@ -291,23 +290,9 @@ function TableTab({ table }: { table: any }) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              handleDoubleClick(e as any);
-            }}
-            className="px-1.5 h-7 text-foreground"
-            title="Rename table"
-            aria-label="Rename table"
-          >
-            <Pencil size={14} />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
               setIsDeleteAlertOpen(true);
             }}
-            className=" px-1.5 h-7 text-foreground"
+            className=" px-1 h-6 text-foreground hover:text-destructive"
             title="Delete table"
             aria-label="Delete table"
           >
@@ -1146,18 +1131,18 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   return (
     <Card
       className={cn(
-        "group relative overflow-hidden bg-card backdrop-blur-sm border transition-all duration-300 w-full",
+        "group relative overflow-hidden flex justify-center items-center bg-card backdrop-blur-sm border transition-all duration-300 w-full min-h-[100px]",
         isEmpty
           ? "border-dashed border-border"
           : "border-border hover:border-border",
       )}
     >
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
+      <CardContent className="p-3 flex-1">
+        <div className="flex items-center justify-center gap-4">
           <div className="h-10 w-10 flex items-center justify-center flex-shrink-0">
             <FileText className="h-5 w-5 text-primary" />
           </div>
-          <div className=" relative flex-1 min-w-0 overflow-hidden">
+          <div className=" relative flex-1 min-w-0 h-[3.5rem] overflow-hidden">
             {isEditingTitle ? (
               <>
                 <Input
@@ -1166,12 +1151,12 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                   onChange={(e) => setEditedTitle(e.target.value)}
                   onBlur={handleTitleBlur}
                   onKeyDown={handleTitleKeyDown}
-                  className="min-w-fit max-w-sm border border-transparent bg-transparent px-1 py-1 text-base font-semibold app-radius-md mb-1 focus-visible:ring-0 focus-visible:ring-offset-0"
+                  className="min-w-fit max-w-sm border border-transparent bg-transparent h-[1.8rem] px-0 py-3 !text-lg font-semibold focus-visible:ring-0 focus-visible:ring-offset-0"
                 />
               </>
             ) : (
               <h3
-                className="text-base font-semibold text-foreground line-clamp-2 flex-1 cursor-text app-radius-md border border-transparent hover:border-muted-foreground/20 w-fit mb-1"
+                className="text-lg font-semibold text-foreground line-clamp-2 flex-1 cursor-text app-radius-md border border-transparent hover:border-muted-foreground/20 w-fit"
                 onDoubleClick={handleDoubleClick}
                 title="Double-click to rename"
               >

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -123,7 +123,7 @@ export default function NoteSettingsSidbar({
               <Button
                 onClick={handleFavoritePin}
                 variant="SidebarMenuButton"
-                className="px-2 h-7"
+                className="px-2 h-7 hover:bg-card"
               >
                 {getNote?.favorite ? (
                   <PinOff size={16} className="text-muted-foreground" />
@@ -142,9 +142,9 @@ export default function NoteSettingsSidbar({
               <Button
                 onMouseDown={initiateDelete}
                 variant="SidebarMenuButton_destructive"
-                className="px-2 h-7"
+                className="px-2 h-7 hover:bg-card"
               >
-                <X size={16} className=" text-muted-foreground" />
+                <X size={16} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={5}>

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -111,9 +111,9 @@ export default function WorkingSpaceSettingsSidbar({
               <Button
                 onMouseDown={initiateDelete}
                 variant="SidebarMenuButton_destructive"
-                className="px-2 h-7"
+                className="px-2 h-7 hover:bg-card"
               >
-                <X size={16} className=" text-muted-foreground" />
+                <X size={16} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={5}>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,6 +12,15 @@ const getMaxTitleLength = () => {
   if (width < 1024) return 35; // tablet
   return 60; // desktop
 };
+const getMaxTableNameLength = () => {
+  if (typeof window === "undefined") return 12; // SSR safety
+
+  const width = window.innerWidth;
+
+  if (width < 640) return 10; // mobile
+  if (width < 1024) return 13; // tablet
+  return 15; // desktop
+};
 const MAX_NAME_LENGTH = 50;
 const EMAIL_DISPLAY_REGEX = /(.{3}).*?(@.{3}).*/;
 export const formatWorkspaceName = (name: string) =>
@@ -37,4 +46,10 @@ export const formatUserNoteTitle = (title: string) => {
 
   const max = getMaxTitleLength();
   return title.length > max ? `${title.slice(0, max)}…` : title;
+};
+
+export const formatTableName = (TableName: string) => {
+  if (!TableName) return;
+  const max = getMaxTableNameLength();
+  return TableName.length > max ? `${TableName.slice(0, max)}...` : TableName;
 };


### PR DESCRIPTION
### what changed

**`formatTableName` utility**
added to `lib/utils.ts` with responsive max lengths: 10 on mobile, 13 on tablet, 15 on desktop. used inside `TableTab` to truncate long names in the tab strip.

**`TableTab`  ui cleanup**
- removed the rename button from the hover actions (double-click to rename is still available)
- delete button gets `hover:text-destructive` and a smaller size (`h-6 px-1`)
- tab trigger gets `w-full text-start` so text aligns correctly
- tab container gets `min-w-28` so tabs don't collapse too small
- tab name rendered with `formatTableName(table.name)` for responsive truncation
- text gradient fade-out stops widened slightly
- editing input simplified to `w-full` with `max-w-28` container
- slide animation removed from hover actions (just opacity now)

**`ListNoteCard`  layout fixes**
- card gets `flex justify-center items-center min-h-[100px]`
- content container gets `h-[3.5rem]` for consistent height
- title font bumped to `text-lg` in both display and edit states
- edit input height and padding adjusted
- removed `mb-1` from title element

**sidebar settings buttons**
- note and workspace settings delete/pin buttons get `hover:bg-card` for a visible hover state within the sidebar
- delete button icon loses explicit `text-muted-foreground` so it inherits from the `SidebarMenuButton_destructive` variant