### PR TITLE
inline rename ux polish+ table tab min-width+ sidebar input fixes

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -480,12 +480,12 @@ function WorkspaceCard({
               onChange={(e) => setEditedName(e.target.value)}
               onBlur={handleNameBlur}
               onKeyDown={handleNameKeyDown}
-              className="min-w-fit max-w-md text-base font-semibold h-7 py-1 px-1 app-radius-md border border-transparent bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="min-w-fit max-w-md !text-lg font-semibold h-[1.9rem] py-0 px-0 app-radius-md border border-transparent bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
         ) : (
           <CardTitle
-            className="text-base font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-muted-foreground/20 transition-all duration-300 "
+            className="text-lg font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-muted-foreground/20"
             onDoubleClick={handleNameDoubleClick}
             title="Double-click to rename"
           >

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -218,6 +218,7 @@ function TableTab({ table }: { table: any }) {
       }
     }
     setIsEditing(false);
+    setIsHovered(false);
   }, [editedName, table.name, table._id, updateTable]);
 
   const handleKeyDown = useCallback(
@@ -227,10 +228,19 @@ function TableTab({ table }: { table: any }) {
       } else if (e.key === "Escape") {
         setIsEditing(false);
         setEditedName(table.name || "Untitled");
+        setIsHovered(false);
       }
     },
     [table.name],
   );
+  const handleContentMouseEnter = useCallback(() => {
+    setIsHovered(true);
+  }, []);
+
+  const handleContentMouseLeave = useCallback(() => {
+    setIsHovered(false);
+  }, []);
+
   const textClassName = isHovered
     ? "truncate flex-grow bg-gradient-to-r from-foreground from-75% via-transparent via-85% to-transparent to-95% text-transparent bg-clip-text"
     : "truncate flex-grow";
@@ -247,7 +257,7 @@ function TableTab({ table }: { table: any }) {
 
   if (isEditing) {
     return (
-      <div className="flex flex-col gap-1 px-1 flex-shrink-0 max-w-28 overflow-hidden">
+      <div className="flex flex-col gap-1 px-1 flex-shrink-0 max-w-[8.1rem] overflow-hidden">
         <Input
           ref={inputRef as any}
           value={editedName}
@@ -263,9 +273,9 @@ function TableTab({ table }: { table: any }) {
   return (
     <>
       <div
-        className="relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-28"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
+        className="relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-32"
+        onMouseEnter={handleContentMouseEnter}
+        onMouseLeave={handleContentMouseLeave}
       >
         <TabsTrigger
           value={table._id}
@@ -1151,7 +1161,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
                   onChange={(e) => setEditedTitle(e.target.value)}
                   onBlur={handleTitleBlur}
                   onKeyDown={handleTitleKeyDown}
-                  className="min-w-fit max-w-sm border border-transparent bg-transparent h-[1.8rem] px-0 py-3 !text-lg font-semibold focus-visible:ring-0 focus-visible:ring-offset-0"
+                  className="min-w-fit max-w-md border border-transparent bg-transparent h-[1.8rem] px-0 py-3 !text-lg font-semibold focus-visible:ring-0 focus-visible:ring-offset-0"
                 />
               </>
             ) : (

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -306,8 +306,11 @@ const PinnedNoteItem = memo(
       setIsEditing(true);
       setEditedTitle(note.title || "Untitled");
       requestAnimationFrame(() => {
-        inputRef.current?.focus();
-        inputRef.current?.select();
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.select();
+        input.scrollLeft = 0;
       });
     }, [note.title]);
 
@@ -376,7 +379,8 @@ const PinnedNoteItem = memo(
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
-                className="flex-1 h-8 px-6 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+                aria-label="pinned note title"
+                className="flex-1 h-8 pl-6 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>
@@ -605,8 +609,11 @@ const WorkspaceItem = memo(
       setIsEditing(true);
       setEditedName(workingSpace.name || "Untitled");
       requestAnimationFrame(() => {
-        inputRef.current?.focus();
-        inputRef.current?.select();
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.select();
+        input.scrollLeft = 0;
       });
     }, [workingSpace.name]);
 
@@ -674,7 +681,8 @@ const WorkspaceItem = memo(
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
-                className="flex-1 h-8 px-7 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+                aria-label="work space name"
+                className="flex-1 h-8 pl-7 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>


### PR DESCRIPTION
small polish pass across all inline rename interactions.

### what changed

**`TableTab`**
- hover enter/leave handlers extracted to `useCallback` instead of inline arrows
- `setIsHovered(false)` added after save and on Escape so the hover state clears correctly after editing
- editing input container bumped to `max-w-[8.1rem]` from `max-w-28`
- tab container min width bumped from `min-w-28` to `min-w-32`

**`AppSidebar`  sidebar rename inputs**
- `requestAnimationFrame` callbacks now null-check `inputRef.current` before calling methods
- added `input.scrollLeft = 0` after focus/select so long titles don't leave the input scrolled to the end
- input padding changed from symmetric `px-6/px-7` to `pl-6/pl-7 pr-2` so there's proper right padding
- `aria-label` added to both inputs

**`WorkspaceCard` in `HomePageClient`**
- title font bumped from `text-base` to `text-lg` in both display and edit states
- edit input height adjusted to `h-[1.9rem]` and padding simplified
- removed `transition-all duration-300` from the hover border

**`ListNoteCard`**
- list note edit input `max-w-sm` to `max-w-md`