### PR TITLE
image click-to-expand +add-block btn + editor shell css+some reverts

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -18,10 +18,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  getEmptyTiptapDoc,
-  parseTiptapContent,
-} from "@/lib/parse-tiptap-content";
 import { parseSlug } from "@/lib/parseSlug";
 import { formatUserNoteTitle } from "@/lib/utils";
 import { ReadOnlyWarning } from "@/components/readOnly-warning";
@@ -53,7 +49,7 @@ export default function PublicNotePage() {
 
   useEffect(() => {
     if (getNote?.body) {
-      setContent(parseTiptapContent(getNote.body));
+      setContent(JSON.parse(getNote.body));
     }
   }, [getNote]);
 
@@ -96,9 +92,7 @@ export default function PublicNotePage() {
   const PublicNoteTitle = formatUserNoteTitle(
     `${parseSlug(`${getNote.title}`)}`,
   );
-  const parsedContent = getNote.body
-    ? parseTiptapContent(getNote.body)
-    : (content ?? getEmptyTiptapDoc());
+  const parsedContent = getNote.body ? JSON.parse(getNote.body) : content;
 
   return (
     <div

--- a/app/globals.css
+++ b/app/globals.css
@@ -983,6 +983,24 @@ hr {
   }
 }
 
+.advanced-editor-shell {
+  --editor-image-accent: hsl(var(--muted-foreground));
+}
+
+.dark .advanced-editor-shell {
+  --editor-image-accent: hsl(var(--muted-foreground));
+}
+
+.advanced-editor-shell .ProseMirror-selectednode {
+  border-color: var(--editor-image-accent) !important;
+  border-color: transparent !important;
+}
+
+.advanced-editor-shell .moveable-control-box {
+  --moveable-color: var(--editor-image-accent);
+  z-index: 40 !important;
+}
+
 @layer base {
   body {
     @apply bg-background text-foreground;

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -666,7 +666,7 @@ export default function WorkingSpacePageClient({
     <MaxWContainer className="my-5">
       <header>
         <div className=" relative flex justify-between items-end w-full">
-          <div className="flex-1 px-1.5 border border-border bg-muted rounded-none rounded-tl-lg rounded-br-lg">
+          <div className="flex-1 px-1.5 border border-border bg-muted app-radius-md">
             <h1 className="text-3xl md:text-5xl font-bol my-3 h-[3rem]">
               {!workspace ? (
                 <div className="bg-border app-radius-md animate-pulse h-10 w-64 inline-block" />

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -6,10 +6,6 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useQuery } from "@/cache/useQuery";
 import { useNoteWidth } from "@/hooks/useNoteWidth";
-import {
-  getEmptyTiptapDoc,
-  parseTiptapContent,
-} from "@/lib/parse-tiptap-content";
 import { cn } from "@/lib/utils";
 import type { JSONContent } from "@tiptap/react";
 import { useMutation } from "convex/react";
@@ -73,13 +69,17 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   );
 
   const serverContent = useMemo(() => {
-    if (!stableNote?.body) return getEmptyTiptapDoc();
-    return parseTiptapContent(stableNote.body);
+    if (!stableNote?.body) return undefined;
+    try {
+      return JSON.parse(stableNote.body) as JSONContent;
+    } catch {
+      return undefined;
+    }
   }, [stableNote?.body]);
 
   useEffect(() => {
     if (content !== undefined) return;
-    setContent(serverContent);
+    if (serverContent !== undefined) setContent(serverContent);
   }, [content, serverContent]);
 
   useEffect(() => {
@@ -138,7 +138,7 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
     >
       <TailwindAdvancedEditor
         editorBubblePlacement={false}
-        initialContent={content ?? serverContent ?? getEmptyTiptapDoc()}
+        initialContent={content ?? serverContent}
         onUpdate={(editor) => {
           const updatedContent = editor.getJSON();
           setContent(updatedContent);

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -35,6 +35,8 @@ import {
 } from "@tiptap/extension-table-of-contents";
 import { CompactFloatingToC } from "./ToC";
 import { useMediaQuery } from "react-responsive";
+import { Dialog, DialogContent, DialogTitle } from "./ui/dialog";
+import { Maximize2, Plus } from "lucide-react";
 const TailwindAdvancedEditor = ({
   initialContent,
   onUpdate,
@@ -53,6 +55,7 @@ const TailwindAdvancedEditor = ({
   );
   const [items, setItems] = useState<any[]>([]);
   const [dragHandleColor, setDragHandleColor] = useState<string>();
+  const [imagePreviewSrc, setImagePreviewSrc] = useState<string | null>(null);
   const { resolvedTheme } = useTheme();
   const isMobile = useMediaQuery({ maxWidth: 640 });
 
@@ -88,6 +91,25 @@ const TailwindAdvancedEditor = ({
     setOpenLink(open);
   };
 
+  const insertBlockBelowWithSlashMenu = (editor: EditorInstance) => {
+    const { $from } = editor.state.selection;
+
+    if ($from.depth < 1) {
+      return;
+    }
+    const insertAt = $from.after(1);
+
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(insertAt, {
+        type: "paragraph",
+        content: [{ type: "text", text: "/" }],
+      })
+      .setTextSelection(insertAt + 2)
+      .run();
+  };
+
   // Create extensions array with ToC configuration
   const extensions = [
     TextStyle,
@@ -115,31 +137,47 @@ const TailwindAdvancedEditor = ({
             <>
               <TableControls editor={editorInstance} />
               <DragHandle editor={editorInstance}>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth="3"
-                  className=" w-4 h-4 opacity-80"
-                  stroke={dragHandleColor}
-                >
-                  <path
-                    d="
-                      M9 6
-                      a1.25 1.25 0 1 0 0.01 0
-                      M15 6
-                      a1.25 1.25 0 1 0 0.01 0
-                      M9 12
-                      a1.25 1.25 0 1 0 0.01 0
-                      M15 12
-                      a1.25 1.25 0 1 0 0.01 0
-                      M9 18
-                      a1.25 1.25 0 1 0 0.01 0
-                      M15 18
-                      a1.25 1.25 0 1 0 0.01 0
-                    "
-                  />
-                </svg>
+                <div className="flex items-center justify-center ">
+                  <button
+                    type="button"
+                    aria-label="Insert block below"
+                    className="flex h-5 w-5 items-center justify-center text-muted-foreground rounded-tl-lg opacity-50 transition-colors hover:bg-border"
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      insertBlockBelowWithSlashMenu(editorInstance);
+                    }}
+                  >
+                    <Plus className="h-4 w-4 mt-0.5" />
+                  </button>
+                  <div className="flex h-5 w-5 items-center justify-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth="3"
+                      className="h-4 w-4 opacity-90"
+                      stroke={dragHandleColor}
+                    >
+                      <path
+                        d="
+                          M9 6
+                          a1.25 1.25 0 1 0 0.01 0
+                          M15 6
+                          a1.25 1.25 0 1 0 0.01 0
+                          M9 12
+                          a1.25 1.25 0 1 0 0.01 0
+                          M15 12
+                          a1.25 1.25 0 1 0 0.01 0
+                          M9 18
+                          a1.25 1.25 0 1 0 0.01 0
+                          M15 18
+                          a1.25 1.25 0 1 0 0.01 0
+                        "
+                      />
+                    </svg>
+                  </div>
+                </div>
               </DragHandle>
             </>
           )}
@@ -147,10 +185,24 @@ const TailwindAdvancedEditor = ({
             initialContent={initialContent}
             autofocus={true}
             extensions={extensions}
-            className="relative w-full bg-transparent text-foreground placeholder"
+            className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder"
             editorProps={{
               handleDOMEvents: {
                 keydown: (_view, event) => handleCommandNavigation(event),
+              },
+              handleClickOn: (view, _pos, node, nodePos, _event, direct) => {
+                if (!direct || node.type.name !== "image") {
+                  return false;
+                }
+                const isImageSelected =
+                  view.state.selection.from === nodePos &&
+                  view.state.selection.to === nodePos + node.nodeSize;
+
+                if (!isImageSelected || !node.attrs.src) {
+                  return false;
+                }
+                setImagePreviewSrc(node.attrs.src);
+                return true;
               },
               handlePaste: (view, event) =>
                 handleImagePaste(view, event, uploadFn),
@@ -212,11 +264,28 @@ const TailwindAdvancedEditor = ({
           </EditorContent>
         </div>
       </EditorRoot>
-
       {/* Compact Floating ToC */}
       {!isMobile && (
         <CompactFloatingToC items={items} editor={editorInstance} />
       )}
+      <Dialog
+        open={Boolean(imagePreviewSrc)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setImagePreviewSrc(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-5xl border border-border bg-background/96 p-1 shadow-2xl backdrop-blur">
+          {imagePreviewSrc && (
+            <img
+              src={imagePreviewSrc}
+              alt="Expanded editor image"
+              className="overflow-hidden rounded-none rounded-tl-lg border border-border/70 max-h-[80vh] w-full object-contain"
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/components/extensions.ts
+++ b/components/extensions.ts
@@ -55,7 +55,9 @@ const image = UpdatedImage.extend({
 }).configure({
   allowBase64: true,
   HTMLAttributes: {
-    class: cx("rounded-lg border border-muted"),
+    class: cx(
+      "rounded-lg border border-muted cursor-zoom-in transition-shadow duration-200",
+    ),
   },
 });
 


### PR DESCRIPTION
### what changed

**`advanced-editor.tsx`  image click-to-expand**
added `handleClickOn` to `editorProps` when an already-selected image node is clicked, it opens a dialog showing the image at full size. a `Dialog` component is rendered below the editor and `imagePreviewSrc` state drives it. the image gets `max-h-[80vh] object-contain` so it fits the viewport.

**`advanced-editor.tsx`  drag handle + block insert**
wrapped the drag handle dots in a container that also shows a `+` button to the left. clicking `+` inserts a paragraph with `"/"` at the position below the current block, which triggers the slash command menu. uses `insertContentAt` + `setTextSelection` to place the cursor in the right spot.

**`extensions.ts`  image cursor and transition**
added `cursor-zoom-in transition-shadow duration-200` to the image html attributes so users get a visual cue that clicking will expand the image.

**`globals.css` `.advanced-editor-shell`**
added css for the `advanced-editor-shell` class: normalizes `--moveable-color` for the image resize handle and sets `ProseMirror-selectednode` border to transparent (removing the default blue outline on selected images since the moveable control box handles that).

selecter resizer that match the theme 
<img width="837" height="231" alt="image" src="https://github.com/user-attachments/assets/99ec4294-1379-4561-933d-12b502830f6e" />


**`WorkingSpacePageClient.tsx`**
workspace header card changed from `rounded-none rounded-tl-lg rounded-br-lg` to `app-radius-md`.

**`NotePageClient.tsx` + `public/document/[id]/page.tsx`  reverted `parseTiptapContent`**
reverted back to plain `JSON.parse` with try/catch. the `parseTiptapContent` abstraction was removed from these call sites.