### PR TITLE
improve table renaming ux and refine form/input styles

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 import {
   Calendar,
+  Check,
   FileText,
   LayoutGrid,
   List,
@@ -38,6 +39,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   AlertDialog,
@@ -141,7 +147,7 @@ const STORAGE_KEYS = {
 };
 
 function TableTab({ table }: { table: any }) {
-  const [isEditing, setIsEditing] = useState(false);
+  const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [editedName, setEditedName] = useState(table.name || "Untitled");
   const [isHovered, setIsHovered] = useState(false);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
@@ -204,20 +210,31 @@ function TableTab({ table }: { table: any }) {
       e.preventDefault();
       e.stopPropagation();
       setEditedName(table.name || "Untitled");
-      setIsEditing(true);
-      requestAnimationFrame(() => {
-        inputRef.current?.focus();
-        inputRef.current?.select();
-      });
+      setIsRenameOpen(true);
     },
     [table.name],
   );
 
-  const handleBlur = useCallback(async () => {
+  useEffect(() => {
+    setEditedName(table.name || "Untitled");
+  }, [table.name]);
+
+  useEffect(() => {
+    if (!isRenameOpen) return;
+    requestAnimationFrame(() => {
+      const input = inputRef.current;
+      if (!input) return;
+      input.focus();
+      input.select();
+      input.scrollLeft = 0;
+    });
+  }, [isRenameOpen]);
+
+  const handleRenameSave = useCallback(async () => {
     const result = tableNameSchema.safeParse(editedName.trim());
     if (!result.success) {
-      setIsEditing(false);
       setEditedName(table.name || "Untitled");
+      setIsRenameOpen(false);
       return;
     }
     const trimmed = result.data;
@@ -229,21 +246,27 @@ function TableTab({ table }: { table: any }) {
         setEditedName(table.name || "Untitled");
       }
     }
-    setIsEditing(false);
+    setIsRenameOpen(false);
     setIsHovered(false);
   }, [editedName, table.name, table._id, updateTable]);
+
+  const handleRenameCancel = useCallback(() => {
+    setEditedName(table.name || "Untitled");
+    setIsRenameOpen(false);
+    setIsHovered(false);
+  }, [table.name]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
-        inputRef.current?.blur();
+        e.preventDefault();
+        void handleRenameSave();
       } else if (e.key === "Escape") {
-        setIsEditing(false);
-        setEditedName(table.name || "Untitled");
-        setIsHovered(false);
+        e.preventDefault();
+        handleRenameCancel();
       }
     },
-    [table.name],
+    [handleRenameCancel, handleRenameSave],
   );
   const handleContentMouseEnter = useCallback(() => {
     setIsHovered(true);
@@ -267,61 +290,86 @@ function TableTab({ table }: { table: any }) {
     }
   }, [deleteTable, table._id]);
 
-  if (isEditing) {
-    return (
-      <div className="flex flex-col gap-1 px-1 flex-shrink-0 max-w-[8.1rem] overflow-hidden">
-        <Input
-          ref={inputRef as any}
-          value={editedName}
-          onChange={(e) => setEditedName(e.target.value)}
-          onBlur={handleBlur}
-          onKeyDown={handleKeyDown}
-          className=" w-full border-transparent bg-transparent px-3 h-[3.3rem] text-sm focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
-        />
-      </div>
-    );
-  }
-
   return (
     <>
-      <div
-        className="relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-32"
-        onMouseEnter={handleContentMouseEnter}
-        onMouseLeave={handleContentMouseLeave}
+      <Popover
+        open={isRenameOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            setIsRenameOpen(true);
+            return;
+          }
+          handleRenameCancel();
+        }}
       >
-        <TabsTrigger
-          value={table._id}
-          data-tab-id={table._id}
-          className="px-4 py-2.5 rounded-none rounded-tl-lg w-full text-start whitespace-nowrap flex items-center gap-1.5 border border-transparent border-b-0 data-[state=active]:border-border"
-          onDoubleClick={handleDoubleClick}
-          title="Double-click to rename"
-        >
-          <p className={cn(textClassName, "w-full")}>
-            {formatTableName(table.name)}
-          </p>
-        </TabsTrigger>
-        <div
-          className={cn(
-            "absolute inset-y-0 right-2 flex items-center",
-            isHovered ? "opacity-100 " : "opacity-0 pointer-events-none",
-          )}
-        >
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setIsDeleteAlertOpen(true);
-            }}
-            className=" px-1 h-6 text-foreground hover:text-destructive"
-            title="Delete table"
-            aria-label="Delete table"
+        <PopoverAnchor asChild>
+          <div
+            className="relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-32"
+            onMouseEnter={handleContentMouseEnter}
+            onMouseLeave={handleContentMouseLeave}
           >
-            <X size={16} />
-          </Button>
-        </div>
-      </div>
+            <TabsTrigger
+              value={table._id}
+              data-tab-id={table._id}
+              className="px-4 py-2.5 rounded-none rounded-tl-lg w-full text-start whitespace-nowrap flex items-center gap-1.5 border border-transparent border-b-0 data-[state=active]:border-border"
+              onDoubleClick={handleDoubleClick}
+              title="Double-click to rename"
+            >
+              <p className={cn(textClassName, "w-full")}>
+                {formatTableName(table.name)}
+              </p>
+            </TabsTrigger>
+            <div
+              className={cn(
+                "absolute inset-y-0 right-2 flex items-center",
+                isHovered ? "opacity-100 " : "opacity-0 pointer-events-none",
+              )}
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsDeleteAlertOpen(true);
+                }}
+                className=" px-1 h-6 text-foreground hover:text-destructive"
+                title="Delete table"
+                aria-label="Delete table"
+              >
+                <X size={16} />
+              </Button>
+            </div>
+          </div>
+        </PopoverAnchor>
+        <PopoverContent
+          align="start"
+          side="bottom"
+          sideOffset={3}
+          className="w-52 border-0 bg-transparent p-0"
+        >
+          <div className=" relative flex items-center gap-2">
+            <Input
+              ref={inputRef as any}
+              value={editedName}
+              onChange={(e) => setEditedName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Rename table"
+              className="h-8 border-border bg-background px-1 py-1"
+            />
+            <Button
+              variant="ghost"
+              type="button"
+              size="icon"
+              onClick={() => void handleRenameSave()}
+              className=" absolute top-1/2 -translate-y-1/2 right-1 h-6 w-6 shrink-0 bg-primary text-primary-foreground hover:text-primary-foreground hover:bg-primary/80"
+              aria-label="Save table name"
+            >
+              <Check className="h-4 w-4" />
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
 
       <AlertDialog open={isDeleteAlertOpen} onOpenChange={setIsDeleteAlertOpen}>
         <AlertDialogContent className="bg-card border border-border text-card-foreground">

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -380,7 +380,7 @@ const PinnedNoteItem = memo(
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
                 aria-label="pinned note title"
-                className="flex-1 h-8 pl-6 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+                className="flex-1 h-8 pl-7 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <TooltipProvider delayDuration={200} skipDelayDuration={0}>

--- a/components/home-components/Feedback.tsx
+++ b/components/home-components/Feedback.tsx
@@ -104,7 +104,11 @@ export default function Feedback() {
                   <FormItem>
                     <FormLabel>Feedback</FormLabel>
                     <FormControl>
-                      <Textarea placeholder="Your feedback..." {...field} />
+                      <Textarea
+                        rows={4}
+                        placeholder="Your feedback..."
+                        {...field}
+                      />
                     </FormControl>
                     <FormDescription>
                       Please let us know your thoughts or suggestions.
@@ -118,28 +122,11 @@ export default function Feedback() {
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Name</FormLabel>
+                    <FormLabel>Name </FormLabel>
                     <FormControl>
                       <Input
                         type="text"
-                        placeholder="Your name (optional)"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder="Your email (optional)"
+                        placeholder="or Github username (optional if you want a shoutout)"
                         {...field}
                       />
                     </FormControl>

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -73,7 +73,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           backgroundImage: `url(${NOISE_PNG})`,
           backgroundRepeat: "repeat",
           backgroundSize: "128px 128px",
-          opacity: isDark ? 0.05 : 0.03,
+          opacity: isDark ? 0.05 : 0.02,
           mixBlendMode: "multiply",
           zIndex: 90000,
         }}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full app-radius-lg border border-primary/30 bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-primary/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[60px] w-full app-radius-lg border border-border bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-foreground/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
this pr improves the table renaming experience using a popover-based flow and refines various input, form, and visual styles across the app.

**what changed:**

* replaced inline table renaming with a popover-based input for a cleaner interaction
* added explicit save and cancel handling for renaming (enter to save, escape to cancel)
* improved focus behavior when opening the rename input
* added a save button with icon for better usability
* synced edited name with external updates using effects
* adjusted sidebar input padding for better alignment
* simplified feedback form by removing email field and updating name placeholder
* set textarea rows for better default sizing
* refined textarea styles to use border colors consistent with the design system
* slightly reduced background noise opacity for a subtler effect

**why:**
the previous inline editing felt cramped and error-prone, with limited control over saving or cancelling. form inputs and textarea styles were also inconsistent with the rest of the UI.

**what’s better now:**

* clearer and more controlled renaming experience
* improved accessibility and keyboard interactions
* more consistent input and form styling
* cleaner feedback form with less friction
* overall more polished and cohesive UI interactions
