### PR TITLE
refactor toc: clean up styles and simplify compact floating toc

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -613,23 +613,6 @@ hr {
   scroll-margin-top: 6rem;
 }
 
-/* Scrollbar for expanded ToC */
-.compact-toc-container::-webkit-scrollbar {
-  width: 4px;
-}
-
-.compact-toc-container::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.compact-toc-container::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--primary));
-  border-radius: 2px;
-}
-
-.compact-toc-container::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--primary) / 0.3);
-}
 
 /* Hide on mobile/tablet */
 @media (max-width: 1024px) {
@@ -656,22 +639,6 @@ hr {
   }
 }
 
-/* Animation for smooth appearance */
-@keyframes fadeInRight {
-  from {
-    opacity: 0;
-    transform: translateX(10px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-.compact-toc-container:hover .toc-text {
-  animation: fadeInRight 0.2s ease-out;
-}
 
 /* Optional: Add a subtle background on hover */
 .compact-toc-container:hover::before {

--- a/components/ToC.tsx
+++ b/components/ToC.tsx
@@ -66,7 +66,7 @@ export const ToCItem = ({ item, onItemClick, isExpanded }: ToCItemProps) => {
             ${
               item.isActive && !item.isScrolledOver
                 ? "bg-muted-foreground h-[3px] w-6"
-                : "bg-muted-foreground/60 w-4 group-hover:w-6"
+                : "bg-muted-foreground/60 w-4 "
             }
           `}
           style={{
@@ -441,7 +441,7 @@ export const CompactFloatingToC = ({
     <div className="fixed right-3 top-32 z-50">
       <div
         className={`
-          transition-all duration-300 ease-in-out px-0.5 border border-solid rounded-tl-lg bg-background/60 backdrop-blur-xl
+          transition-all duration-150 ease-linear px-0.5 border border-solid rounded-tl-lg bg-background 
           ${isExpanded ? "w-52 border-border " : "w-10 border-transparent"}
         `}
       >

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -136,10 +136,7 @@ const TailwindAdvancedEditor = ({
         <div className="relative">
           {editorInstance && (
             <>
-              <LinkHoverCard
-                editor={editorInstance}
-                disabled={openLink}
-              />
+              <LinkHoverCard editor={editorInstance} disabled={openLink} />
               <TableControls editor={editorInstance} />
               <DragHandle editor={editorInstance}>
                 <div className="flex items-center justify-center ">

--- a/components/link-hover-card.tsx
+++ b/components/link-hover-card.tsx
@@ -201,7 +201,7 @@ export function LinkHoverCard({
         align="start"
         side="bottom"
         sideOffset={0}
-        className="z-[10002] flex w-[320px] items-center rounded-tl-xl border-border bg-muted p-0.5 text-popover-foreground"
+        className="z-[10002] flex w-[320px] items-center rounded-tl-xl border-border bg-muted p-0 text-popover-foreground"
         onOpenAutoFocus={(event) => event.preventDefault()}
         onCloseAutoFocus={(event) => event.preventDefault()}
         onMouseEnter={clearHideTimer}


### PR DESCRIPTION
cleaned up the table of contents:

- removed unused scrollbar styles and fade-in animation from globals.css
- simplified the compact floating toc (solid background, faster transition, cleaner look)
- removed hover width animation from the active indicator line
- minor cleanups in editor components (padding + formatting)

code is lighter and the toc feels smoother and less cluttered now.