### PR TITLE
pdfs schema + tooltip alignment + ui polish

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -135,7 +135,9 @@ export default function PublicNotePage() {
                     <span className="sr-only">Toggle theme</span>
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">Toggle theme</TooltipContent>
+                <TooltipContent align="end" side="bottom">
+                  Toggle theme
+                </TooltipContent>
               </Tooltip>
             </TooltipProvider>
             <Button variant="secondary" className="text-sm px-1.5 py-1.5 h-8">

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1057,7 +1057,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   return (
     <Card
       className={cn(
-        "group relative overflow-hidden bg-card border  flex flex-col min-h-[230px]",
+        "group relative overflow-hidden bg-card border flex flex-col min-h-[230px]",
         isEmpty
           ? "border-dashed border-border"
           : "border-border hover:border-border",

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -76,7 +76,9 @@ export default function NoteDownloadDropdown({
               </Button>
             </TooltipTrigger>
           </DropdownMenuTrigger>
-          <TooltipContent side="bottom">Download note</TooltipContent>
+          <TooltipContent align="end" side="bottom">
+            Download note
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
 

--- a/components/readOnly-warning.tsx
+++ b/components/readOnly-warning.tsx
@@ -29,12 +29,12 @@ export function ReadOnlyWarning() {
       transition={{ ease: "linear", duration: 0.5, delay: 2 }}
       className="fixed top-4 inset-x-0 z-50 flex justify-center px-4"
     >
-      <div className="w-full max-w-2xl bg-background/60 backdrop-blur-md p-4 rounded-lg border border-border shadow-lg">
+      <div className="w-full max-w-2xl bg-background/80 backdrop-blur-md p-4 rounded-tl-lg border border-border shadow-lg">
         <div className="flex items-start gap-3">
           <AlertTriangle className="h-5 w-5 text-yellow-500 mt-0.5" />
           <div className="flex-1">
-            <h3 className="font-semibold text-primary">Read only</h3>
-            <p className="text-base text-primary/70 mt-1">
+            <h3 className="font-semibold text-foreground">Read only</h3>
+            <p className="text-base text-muted-foreground mt-1">
               You're viewing a live copy of the original note. Your changes
               won't affect the original but you can download your edited copy
               anytime.

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "app-radius-lg border bg-card text-card-foreground shadow",
+      "app-radius-lg border bg-card text-card-foreground",
       className,
     )}
     {...props}

--- a/convex.json
+++ b/convex.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "node_modules/convex/schemas/convex.schema.json",
+  "aiFiles": {
+    "enabled": false
+  }
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as notes from "../notes.js";
 import type * as notesTables from "../notesTables.js";
 import type * as otp_ResendOTP from "../otp/ResendOTP.js";
 import type * as otp_VerificationCodeEmail from "../otp/VerificationCodeEmail.js";
+import type * as pdfs from "../pdfs.js";
 import type * as users from "../users.js";
 import type * as workingSpaces from "../workingSpaces.js";
 
@@ -34,6 +35,7 @@ declare const fullApi: ApiFromModules<{
   notesTables: typeof notesTables;
   "otp/ResendOTP": typeof otp_ResendOTP;
   "otp/VerificationCodeEmail": typeof otp_VerificationCodeEmail;
+  pdfs: typeof pdfs;
   users: typeof users;
   workingSpaces: typeof workingSpaces;
 }>;

--- a/convex/pdfs.ts
+++ b/convex/pdfs.ts
@@ -1,0 +1,33 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+export const sendPdf = mutation({
+  args: {
+    storageId: v.id("_storage"),
+    title: v.optional(v.string()),
+    workingSpaceId: v.optional(v.id("workingSpaces")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    await ctx.db.insert("pdfs", {
+      storageId: args.storageId,
+      userId,
+      workingSpaceId: args.workingSpaceId,
+      title: args.title,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,8 +2,6 @@ import { authTables } from "@convex-dev/auth/server";
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
-// The schema is normally optional, but Convex Auth
-// requires indexes defined on `authTables`.
 export default defineSchema({
   ...authTables,
   messages: defineTable({
@@ -57,4 +55,16 @@ export default defineSchema({
     name: v.optional(v.string()),
     noteId: v.optional(v.id("notes")),
   }),
+
+  // New table for PDF uploads
+  pdfs: defineTable({
+    storageId: v.id("_storage"),
+    userId: v.id("users"),
+    workingSpaceId: v.optional(v.id("workingSpaces")),
+    title: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_workingSpaceId", ["workingSpaceId"]),
 });


### PR DESCRIPTION
### what changed

**`convex/schema.ts`  new `pdfs` table**
added a `pdfs` table for storing pdf uploads with `storageId`, `userId`, optional `workingSpaceId`, `title`, and timestamps. indexed by `userId` and `workingSpaceId`.

**tooltip alignment**
added `align="end"` to tooltips on the theme toggle and download note button so they don't clip against the edge of the screen.

**`readOnly-warning.tsx`**
bumped backdrop opacity from `/60` to `/80`, changed `rounded-lg` to `rounded-tl-lg`, and updated text colors from `text-primary` / `text-primary/70` to `text-foreground` / `text-muted-foreground`.

**`card.tsx`**
removed `shadow` from the base card classname.

**`WorkingSpacePageClient.tsx`**
trimmed a stray double space in the grid note card classname.

---

### why

the pdfs table lays the groundwork for pdf upload support. the rest are small visual polish items.