### PR TITLE
add note context menu and metadata details to settings

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -77,6 +77,7 @@ import { z } from "zod";
 import { generateSlug } from "@/lib/generateSlug";
 import { useQuery } from "@/cache/useQuery";
 import SkeletonSidebar from "../ui/skeleton-sidebar";
+import NoteContextMenu from "./NoteContextMenu";
 interface SidebarHeaderSectionProps {
   getWorkingSpaces: Doc<"workingSpaces">[] | undefined;
   handleCreateNote: (
@@ -355,7 +356,7 @@ const PinnedNoteItem = memo(
       ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
 
-    return (
+    const content = (
       <SidebarGroupContent
         className="relative w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
@@ -424,6 +425,14 @@ const PinnedNoteItem = memo(
           />
         </div>
       </SidebarGroupContent>
+    );
+
+    if (isEditing) return content;
+
+    return (
+      <NoteContextMenu noteId={note._id} noteTitle={note.title}>
+        {content}
+      </NoteContextMenu>
     );
   },
   (prevProps, nextProps) => {

--- a/components/home-components/NoteContextMenu.tsx
+++ b/components/home-components/NoteContextMenu.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useMutation } from "convex/react";
+import { useQuery } from "@/cache/useQuery";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { generateSlug } from "@/lib/generateSlug";
+import { cn } from "@/lib/utils";
+import {
+  Pin,
+  FileText,
+  FileJson,
+  FileType,
+  FileDown,
+  FileOutput,
+} from "lucide-react";
+import { FaRegTrashCan } from "react-icons/fa6";
+import MoveNoteDialog from "./MoveNoteDialog";
+import { useNoteDownload } from "@/hooks/useNoteDownload";
+
+interface NoteContextMenuProps {
+  noteId: Id<"notes">;
+  noteTitle: string | any;
+  children: React.ReactNode;
+}
+
+const NOTE_TITLE_MAX_LENGTH = 55;
+
+const itemClassName =
+  "h-8 w-full justify-start gap-2 px-2 text-sm text-foreground hover:bg-accent hover:text-accent-foreground";
+
+const formatNoteTimestamp = (timestamp?: number) => {
+  if (!timestamp) return "";
+
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+export default function NoteContextMenu({
+  noteId,
+  noteTitle,
+  children,
+}: NoteContextMenuProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [inputValue, setInputValue] = useState(noteTitle);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+
+  const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
+    (local, args) => {
+      const { _id, title, body, favorite } = args;
+      const note = local.getQuery(api.notes.getNoteById, { _id });
+      if (note) {
+        local.setQuery(
+          api.notes.getNoteById,
+          { _id },
+          {
+            ...note,
+            title: title ?? note.title,
+            body: body ?? note.body,
+            favorite: favorite !== undefined ? favorite : note.favorite,
+            updatedAt: Date.now(),
+          },
+        );
+      }
+    },
+  );
+
+  const deleteNote = useMutation(api.notes.deleteNote);
+  const getNote = useQuery(api.notes.getNoteById, { _id: noteId });
+
+  const currentNoteId = searchParams.get("id");
+  const isViewingThisNote = currentNoteId === noteId;
+
+  const { handleDownload } = useNoteDownload({
+    noteBody: getNote?.body,
+    noteTitle,
+  });
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    setInputValue(noteTitle);
+  }, [noteTitle]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const timeoutId = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 10);
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (event.button !== 0) return;
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
+
+  if (!getNote) return <>{children}</>;
+
+  const createdAtText = formatNoteTimestamp(getNote.createdAt);
+  const updatedAtText = formatNoteTimestamp(getNote.updatedAt);
+
+  const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const menuWidth = 220;
+    const menuHeight = 360;
+    const maxX = window.innerWidth - menuWidth - 8;
+    const maxY = window.innerHeight - menuHeight - 8;
+
+    setPosition({
+      x: Math.max(8, Math.min(event.clientX, maxX)),
+      y: Math.max(8, Math.min(event.clientY, maxY)),
+    });
+    setOpen(true);
+  };
+
+  const handleBlur = async () => {
+    const trimmedValue = inputValue.trim();
+    const isValid =
+      trimmedValue.length > 0 && trimmedValue.length <= NOTE_TITLE_MAX_LENGTH;
+
+    if (!isValid) {
+      setInputValue(noteTitle);
+      return;
+    }
+
+    if (trimmedValue !== noteTitle) {
+      await updateNote({ _id: noteId, title: trimmedValue });
+
+      if (isViewingThisNote) {
+        const newSlug = generateSlug(trimmedValue);
+        const pathSegments = pathname.split("/");
+        pathSegments[pathSegments.length - 1] = newSlug;
+        const newPath = pathSegments.join("/");
+        router.replace(`${newPath}?id=${noteId}`);
+      }
+    }
+
+    setInputValue(trimmedValue);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void handleBlur();
+      setOpen(false);
+    }
+  };
+
+  const handleFavoritePin = async () => {
+    await updateNote({
+      _id: noteId,
+      favorite: !getNote.favorite,
+    });
+    setOpen(false);
+  };
+
+  const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setIsAlertOpen(false);
+    try {
+      if (isViewingThisNote) {
+        router.push(`/home/${getNote.workingSpaceId}`);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        await deleteNote({ _id: noteId });
+      } else {
+        await deleteNote({ _id: noteId });
+      }
+    } catch (error) {
+      console.error("Failed to delete note:", error);
+    }
+  };
+
+  return (
+    <>
+      <div onContextMenu={handleContextMenu}>{children}</div>
+
+      {mounted &&
+        open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[10000] w-[220px] app-radius-md border border-border bg-popover p-1.5 text-popover-foreground shadow-md"
+            style={{ left: position.x, top: position.y }}
+            onContextMenu={(event) => event.preventDefault()}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className="space-y-4">
+              <div className="relative">
+                <Label>Rename :</Label>
+                <Input
+                  ref={inputRef}
+                  type="text"
+                  value={inputValue}
+                  onChange={(event) => setInputValue(event.target.value)}
+                  onBlur={() => void handleBlur()}
+                  onKeyDown={handleKeyDown}
+                  onMouseDown={(event) => event.stopPropagation()}
+                  placeholder="Rename your note"
+                  className="mt-1 h-8 text-foreground"
+                />
+              </div>
+
+              <div className="space-y-1 text-muted-foreground">
+                <Button
+                  variant="ghost"
+                  className={itemClassName}
+                  onClick={() => void handleFavoritePin()}
+                  aria-label="pin-note"
+                >
+                  <Pin size={14} className="text-muted-foreground" />
+                  {getNote.favorite ? "Unpin Note" : "Pin Note"}
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  className={itemClassName}
+                  onClick={() => {
+                    setOpen(false);
+                    setIsMoveDialogOpen(true);
+                  }}
+                  aria-label="move-note"
+                >
+                  <FileOutput size={14} className="text-muted-foreground" />
+                  Move Note
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  className={itemClassName}
+                  onClick={() => {
+                    handleDownload("markdown");
+                    setOpen(false);
+                  }}
+                  aria-label="download-markdown"
+                >
+                  <FileText size={14} className="text-muted-foreground" />
+                  Download Markdown (.md)
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  className={itemClassName}
+                  onClick={() => {
+                    handleDownload("json");
+                    setOpen(false);
+                  }}
+                  aria-label="download-json"
+                >
+                  <FileJson size={14} className="text-muted-foreground" />
+                  Download JSON
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  className={itemClassName}
+                  onClick={() => {
+                    handleDownload("docx");
+                    setOpen(false);
+                  }}
+                  aria-label="download-docx"
+                >
+                  <FileType size={14} className="text-muted-foreground" />
+                  Download Word (.docx)
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  className={itemClassName}
+                  onClick={() => {
+                    handleDownload("pdf");
+                    setOpen(false);
+                  }}
+                  aria-label="download-pdf"
+                >
+                  <FileDown size={14} className="text-muted-foreground" />
+                  Download PDF
+                </Button>
+
+                <div className="my-1 h-px bg-border" />
+
+                <Button
+                  variant="SidebarMenuButton_destructive"
+                  className="w-full h-8 px-2 text-sm"
+                  onClick={() => {
+                    setOpen(false);
+                    setIsAlertOpen(true);
+                  }}
+                  aria-label="delete-note"
+                >
+                  <FaRegTrashCan size={14} className="text-current" />
+                  Delete
+                </Button>
+
+                <div className="my-1 h-px bg-border" />
+
+                <div className="px-2 pt-1 text-[10px] leading-4 text-muted-foreground/80">
+                  <p>Last updated {updatedAtText}</p>
+                  <p>Created {createdAtText}</p>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+
+      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
+        <AlertDialogContent className="bg-card border border-border text-card-foreground">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Note Deletion</AlertDialogTitle>
+            <AlertDialogDescription className="text-muted-foreground">
+              Are you sure you want to delete this note? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground border-none"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <MoveNoteDialog
+        open={isMoveDialogOpen}
+        onOpenChange={setIsMoveDialogOpen}
+        note={{
+          _id: noteId,
+          title: getNote?.title,
+          slug: getNote?.slug,
+          workingSpaceId: getNote?.workingSpaceId,
+          notesTableId: getNote?.notesTableId,
+        }}
+      />
+    </>
+  );
+}

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -67,6 +67,18 @@ interface NoteSettingsProps {
 
 const NOTE_TITLE_MAX_LENGTH = 55;
 
+const formatNoteTimestamp = (timestamp?: number) => {
+  if (!timestamp) return "";
+
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
 export default function NoteSettings({
   noteId,
   noteTitle,
@@ -136,6 +148,9 @@ export default function NoteSettings({
   }, [open]);
 
   if (!getNote) return null;
+
+  const createdAtText = formatNoteTimestamp(getNote.createdAt);
+  const updatedAtText = formatNoteTimestamp(getNote.updatedAt);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
@@ -362,9 +377,15 @@ export default function NoteSettings({
               onClick={initiateDelete}
               aria-label="delete-note"
             >
-              <FaRegTrashCan size={14} className="text-muted-foreground" />
+              <FaRegTrashCan size={14} className="text-current" />
               Delete
             </Button>
+
+            <DropdownMenuSeparator />
+            <div className="px-2 pt-1 text-[10px] leading-4 text-muted-foreground/80">
+              <p>Last updated {updatedAtText}</p>
+              <p>Created {createdAtText}</p>
+            </div>
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { FaEllipsisVertical, FaRegTrashCan } from "react-icons/fa6";
@@ -30,13 +31,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from "@/components/ui/card";
 import { Label } from "../ui/label";
 interface TableSettingsProps {
   notesTableId: Id<"notesTables"> | any; // Strongly typed Id
@@ -44,6 +38,18 @@ interface TableSettingsProps {
 }
 
 const TABLE_NAME_MAX_LENGTH = 30;
+
+const formatTimestamp = (timestamp?: number) => {
+  if (!timestamp) return "";
+
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
 
 export default function TableSettings({
   notesTableId,
@@ -53,6 +59,7 @@ export default function TableSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false); // Alert Dialog State
   const inputRef = useRef<HTMLInputElement>(null);
+  const table = useQuery(api.notesTables.getTableById, { _id: notesTableId });
   const updateTable = useMutation(
     api.notesTables.updateTable,
   ).withOptimisticUpdate((local, args) => {
@@ -182,6 +189,8 @@ export default function TableSettings({
   const handleTooltipMouseLeave = () => {
     setIsTooltipOpen(false);
   };
+  const createdAtText = formatTimestamp(table?.createdAt);
+  const updatedAtText = formatTimestamp(table?.updatedAt);
   return (
     <>
       <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -223,9 +232,14 @@ export default function TableSettings({
                 onClick={initiateDelete}
                 aria-label="delete-table"
               >
-                <FaRegTrashCan size={14} className="text-muted-foreground" />
+                <FaRegTrashCan size={14} className="text-current" />
                 Delete
               </Button>
+              <DropdownMenuSeparator />
+              <div className="px-2 pt-1 text-[10px] leading-4 text-muted-foreground/80">
+                <p>Last updated {updatedAtText}</p>
+                <p>Created {createdAtText}</p>
+              </div>
             </DropdownMenuContent>
             <TooltipContent side="bottom" alignOffset={1} align="end">
               Rename , Delete

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -40,6 +41,18 @@ interface WorkingSpaceSettings {
 
 const WORKSPACE_NAME_MAX_LENGTH = 30;
 
+const formatTimestamp = (timestamp?: number) => {
+  if (!timestamp) return "";
+
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
 export default function WorkingSpaceSettings({
   className,
   workingSpaceId,
@@ -67,6 +80,9 @@ export default function WorkingSpaceSettings({
 
   const tables = useQuery(api.notesTables.getTables, {
     workingSpaceId,
+  });
+  const workspace = useQuery(api.workingSpaces.getWorkingSpaceById, {
+    _id: workingSpaceId,
   });
 
   const updateWorkingSpace = useMutation(
@@ -190,6 +206,8 @@ export default function WorkingSpaceSettings({
 
   const tableCount = tables?.length || 0;
   const hasContent = tableCount > 0;
+  const createdAtText = formatTimestamp(workspace?.createdAt);
+  const updatedAtText = formatTimestamp(workspace?.updatedAt);
   const handleTooltipMouseEnter = () => setIsTooltipOpen(true);
   const handleTooltipMouseLeave = () => setIsTooltipOpen(false);
   return (
@@ -247,11 +265,15 @@ export default function WorkingSpaceSettings({
               </>
             ) : (
               <>
-                <FaRegTrashCan size="14" className=" text-muted-foreground" />{" "}
-                Delete
+                <FaRegTrashCan size={14} className=" text-current" /> Delete
               </>
             )}
           </Button>
+          <DropdownMenuSeparator />
+          <div className="px-2 pt-1 text-[10px] leading-4 text-muted-foreground/80">
+            <p>Last updated {updatedAtText}</p>
+            <p>Created {createdAtText}</p>
+          </div>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -1,0 +1,4 @@
+// this should contain the create note and upload pdf btns
+export default function WorkingspaceNewDropdownBtn() {
+  return <div className="dropdown dropdown-end" />;
+}

--- a/convex/notesTables.ts
+++ b/convex/notesTables.ts
@@ -185,3 +185,31 @@ export const getTables = query({
     return tables;
   },
 });
+
+export const getTableById = query({
+  args: {
+    _id: v.id("notesTables"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const table = await ctx.db.get(args._id);
+    if (!table) {
+      throw new Error("Table not found");
+    }
+
+    const workspace = await ctx.db.get(table.workingSpaceId);
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+
+    if (workspace.userId !== userId) {
+      throw new Error("Not authorized to view this table");
+    }
+
+    return table;
+  },
+});


### PR DESCRIPTION
improves note interactions and adds useful metadata details across note, table, and workspace settings menus.

**what changed:**

* added a dedicated `NoteContextMenu` wrapper for pinned notes in the sidebar
* prevented context menu wrapping while a note is actively being edited
* added created and updated timestamps to note, table, and workspace settings dropdowns
* introduced reusable timestamp formatting helpers
* added a new query to fetch table details by id with authorization checks
* updated delete icons to inherit current text color instead of muted foreground
* cleaned up unused imports from table settings

important metadata like creation and update times was missing from settings menus, and pinned notes lacked a proper context menu experience. table settings also needed direct table fetching for accurate metadata display.