### PR TITLE
add pdf uploads to workspace ,SO CooL bro

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -243,6 +243,17 @@ html {
   background: var(--selection-background);
 }
 
+.pdf-viewer-shell ::selection,
+.pdf-viewer-shell .textLayer ::selection,
+.pdf-viewer-shell .textLayer span::selection {
+  background: var(--selection-background) !important;
+}
+
+.pdf-viewer-shell *::-moz-selection,
+.pdf-viewer-shell .textLayer *::-moz-selection {
+  background: var(--selection-background) !important;
+}
+
 .no-visible-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -2,13 +2,14 @@
 import {
   Calendar,
   Check,
+  ExternalLink,
   FileText,
   LayoutGrid,
   List,
+  MoreVertical,
   Search,
   ChevronLeft,
   ChevronRight,
-  Pencil,
   Trash2,
   X,
 } from "lucide-react";
@@ -61,11 +62,19 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn, formatTableName } from "@/lib/utils";
 import {
   extractTextFromTiptap as parseTiptapContentExtractText,
   truncateText as parseTiptapContentTruncateText,
 } from "@/lib/parse-tiptap-content";
+import { generateSlug } from "@/lib/generateSlug";
 const getContentPreviewFromBody = (body: any) => {
   if (!body) return "No content yet. Click to start writing...";
   try {
@@ -118,6 +127,21 @@ interface Note {
   order?: number;
 }
 
+interface PdfItem {
+  _id: Id<"pdfs">;
+  storageId: Id<"_storage">;
+  title?: string;
+  userId?: Id<"users">;
+  workingSpaceId?: Id<"workingSpaces">;
+  notesTableId?: Id<"notesTables">;
+  fileUrl?: string | null;
+  createdAt: number;
+  updatedAt: number;
+  kind: "pdf";
+}
+
+type WorkspaceEntry = (Note & { kind: "note" }) | PdfItem;
+
 interface NotesDroppableContainerProps {
   tableId: Id<"notesTables">;
   viewMode: ViewMode;
@@ -134,6 +158,11 @@ interface NoteCardProps {
   note: Note;
   workspaceId?: Id<"workingSpaces">;
   onDelete?: (noteId: Id<"notes">) => void;
+}
+
+interface PdfCardProps {
+  pdf: PdfItem;
+  onDelete?: (pdfId: Id<"pdfs">) => void;
 }
 
 interface EmptySearchResultsProps {
@@ -835,6 +864,15 @@ export function NotesDroppableContainer({
     { notesTableId: tableId },
     { initialNumItems: 5 },
   );
+  const pdfs = useQuery(api.pdfs.getPdfsByTableId, {
+    notesTableId: tableId,
+  }) as
+    | Array<
+        Omit<PdfItem, "kind"> & {
+          fileUrl?: string | null;
+        }
+      >
+    | undefined;
 
   const cachedNotes = tableNotesMemoryCache.get(tableId as unknown as string);
   useEffect(() => {
@@ -846,30 +884,38 @@ export function NotesDroppableContainer({
   const stableResults =
     status === "LoadingFirstPage" && cachedNotes ? cachedNotes : results;
 
-  const [deletedNoteIds, setDeletedNoteIds] = useState<Set<string>>(new Set());
+  const [deletedItemIds, setDeletedItemIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    setDeletedNoteIds(new Set());
+    setDeletedItemIds(new Set());
   }, [tableId]);
 
-  const filteredNotes = useMemo(() => {
-    const notDeletedNotes = stableResults.filter(
-      (note) => note && !deletedNoteIds.has(note._id),
+  const filteredItems = useMemo(() => {
+    const noteItems = stableResults.map(
+      (note) => ({ ...note, kind: "note" }) as WorkspaceEntry,
     );
-    if (!searchQuery.trim()) return notDeletedNotes;
-    const q = searchQuery.toLowerCase();
-    return notDeletedNotes.filter((note) => {
-      const searchableText = (note.preview ?? note.body ?? "").toLowerCase();
-      return (
-        note.title?.toLowerCase().includes(q) || searchableText.includes(q)
-      );
-    });
-  }, [stableResults, searchQuery, deletedNoteIds]);
+    const pdfItems = (pdfs ?? []).map(
+      (pdf) => ({ ...pdf, kind: "pdf" }) as WorkspaceEntry,
+    );
+    const notDeletedItems = [...noteItems, ...pdfItems]
+      .filter((item) => item && !deletedItemIds.has(item._id))
+      .sort((a, b) => b.updatedAt - a.updatedAt);
 
-  const handleNoteDelete = useCallback((noteId: Id<"notes">) => {
-    setDeletedNoteIds((prev) => {
+    if (!searchQuery.trim()) return notDeletedItems;
+    const q = searchQuery.toLowerCase();
+    return notDeletedItems.filter((item) => {
+      const titleMatches = item.title?.toLowerCase().includes(q);
+      if (item.kind === "pdf") return titleMatches;
+
+      const searchableText = (item.preview ?? item.body ?? "").toLowerCase();
+      return titleMatches || searchableText.includes(q);
+    });
+  }, [deletedItemIds, pdfs, searchQuery, stableResults]);
+
+  const handleItemDelete = useCallback((itemId: string) => {
+    setDeletedItemIds((prev) => {
       const newSet = new Set(prev);
-      newSet.add(noteId);
+      newSet.add(itemId);
       return newSet;
     });
   }, []);
@@ -883,7 +929,7 @@ export function NotesDroppableContainer({
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-foreground" />
             <Input
               type="text"
-              placeholder="Search Notes..."
+              placeholder="Search notes and uploads..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-10 border-border h-9 mt-0.5"
@@ -933,14 +979,14 @@ export function NotesDroppableContainer({
         </div>
       </div>
 
-      {status === "LoadingFirstPage" && !cachedNotes ? (
+      {status === "LoadingFirstPage" && !cachedNotes && pdfs === undefined ? (
         <NotesSkeleton viewMode={viewMode} />
-      ) : searchQuery && filteredNotes.length === 0 ? (
+      ) : searchQuery && filteredItems.length === 0 ? (
         <EmptySearchResults
           searchQuery={searchQuery}
           onClearSearch={() => setSearchQuery("")}
         />
-      ) : filteredNotes.length === 0 ? (
+      ) : filteredItems.length === 0 ? (
         <EmptyTableState
           tableId={tableId}
           workspaceSlug={workspaceSlug}
@@ -955,25 +1001,31 @@ export function NotesDroppableContainer({
                 : "flex flex-col gap-3"
             }
           >
-            {filteredNotes.map((note) => (
-              <div key={note._id}>
-                {viewMode === "grid" ? (
+            {filteredItems.map((item) => (
+              <div key={item._id}>
+                {item.kind === "pdf" ? (
+                  viewMode === "grid" || isMobile ? (
+                    <PdfGridCard
+                      pdf={item}
+                      onDelete={(pdfId) => handleItemDelete(pdfId)}
+                    />
+                  ) : (
+                    <PdfListCard
+                      pdf={item}
+                      onDelete={(pdfId) => handleItemDelete(pdfId)}
+                    />
+                  )
+                ) : viewMode === "grid" || isMobile ? (
                   <GridNoteCard
-                    note={note}
+                    note={item}
                     workspaceId={workspaceId}
-                    onDelete={handleNoteDelete}
-                  />
-                ) : !isMobile ? (
-                  <ListNoteCard
-                    note={note}
-                    workspaceId={workspaceId}
-                    onDelete={handleNoteDelete}
+                    onDelete={handleItemDelete as (noteId: Id<"notes">) => void}
                   />
                 ) : (
-                  <GridNoteCard
-                    note={note}
+                  <ListNoteCard
+                    note={item}
                     workspaceId={workspaceId}
-                    onDelete={handleNoteDelete}
+                    onDelete={handleItemDelete as (noteId: Id<"notes">) => void}
                   />
                 )}
               </div>
@@ -1300,6 +1352,317 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   );
 }
 
+function PdfCardMenu({ pdf, onDelete }: PdfCardProps) {
+  const [open, setOpen] = useState(false);
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const deletePdf = useMutation(api.pdfs.deletePdf);
+  const pdfSlug = generateSlug(pdf.title || "untitled-pdf");
+  const pdfHref = `/home/${pdf.workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdf._id}`;
+
+  const handleDelete = useCallback(async () => {
+    if (onDelete) onDelete(pdf._id);
+    setIsAlertOpen(false);
+    try {
+      await deletePdf({ _id: pdf._id });
+    } catch (error) {
+      console.error("Failed to delete PDF:", error);
+    }
+  }, [deletePdf, onDelete, pdf._id]);
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="Trigger"
+            className="px-0.5 h-8 mt-0.5"
+            aria-label="upload-options"
+          >
+            <MoreVertical size={18} className="text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-40">
+          <DropdownMenuItem asChild>
+            <IntentPrefetchLink href={pdfHref}>
+              <ExternalLink className="h-4 w-4 text-muted-foreground" />
+              Open upload
+            </IntentPrefetchLink>
+          </DropdownMenuItem>
+          {pdf.fileUrl ? (
+            <DropdownMenuItem asChild>
+              <a href={pdf.fileUrl} target="_blank" rel="noreferrer">
+                <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                Original file
+              </a>
+            </DropdownMenuItem>
+          ) : null}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => {
+              setOpen(false);
+              setIsAlertOpen(true);
+            }}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete upload
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
+        <AlertDialogContent className="bg-card border border-border text-card-foreground">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Upload Deletion</AlertDialogTitle>
+            <AlertDialogDescription className="text-muted-foreground">
+              Are you sure you want to delete this upload? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => void handleDelete()}
+              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground border-none"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editedTitle, setEditedTitle] = useState(pdf.title || "Untitled");
+  const titleInputRef = useRef<HTMLTextAreaElement>(null);
+  const updatePdf = useMutation(api.pdfs.updatePdf);
+  const pdfSlug = generateSlug(pdf.title || "untitled-pdf");
+  const pdfHref = `/home/${pdf.workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdf._id}`;
+
+  useEffect(() => {
+    setEditedTitle(pdf.title || "Untitled");
+  }, [pdf.title]);
+
+  const handleDoubleClick = useCallback(() => {
+    setEditedTitle(pdf.title || "Untitled");
+    setIsEditingTitle(true);
+    requestAnimationFrame(() => {
+      titleInputRef.current?.focus();
+      titleInputRef.current?.select();
+    });
+  }, [pdf.title]);
+
+  const handleTitleBlur = useCallback(async () => {
+    const result = noteTitleSchema.safeParse(editedTitle.trim());
+    if (!result.success) {
+      setIsEditingTitle(false);
+      setEditedTitle(pdf.title || "Untitled");
+      return;
+    }
+
+    const trimmed = result.data;
+    if (trimmed !== (pdf.title || "Untitled")) {
+      try {
+        await updatePdf({ _id: pdf._id, title: trimmed });
+      } catch (error) {
+        console.error("Error updating PDF title:", error);
+        setEditedTitle(pdf.title || "Untitled");
+      }
+    }
+    setIsEditingTitle(false);
+  }, [editedTitle, pdf._id, pdf.title, updatePdf]);
+
+  const handleTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        titleInputRef.current?.blur();
+      } else if (e.key === "Escape") {
+        setIsEditingTitle(false);
+        setEditedTitle(pdf.title || "Untitled");
+      }
+    },
+    [pdf.title],
+  );
+
+  return (
+    <Card className="group relative overflow-hidden bg-card border border-border flex flex-col min-h-[230px]">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          {isEditingTitle ? (
+            <div className="flex-1 flex flex-col gap-1 overflow-hidden">
+              <Textarea
+                ref={titleInputRef as any}
+                value={editedTitle}
+                onChange={(e) => setEditedTitle(e.target.value)}
+                onBlur={handleTitleBlur}
+                onKeyDown={handleTitleKeyDown}
+                rows={1}
+                style={{ resize: "none", overflow: "hidden" }}
+                className="field-sizing-content min-h-0 min-w-0 w-full max-w-full max-h-14 whitespace-pre-wrap [overflow-wrap:anywhere] border-transparent bg-transparent px-0 py-0 my-0 text-lg font-semibold app-radius-md focus-visible:ring-0 focus-visible:ring-offset-0"
+              />
+            </div>
+          ) : (
+            <CardTitle
+              className="text-lg font-semibold text-foreground line-clamp-2 w-fit cursor-text app-radius-md border border-transparent hover:border-muted-foreground/20"
+              onDoubleClick={handleDoubleClick}
+              title="Double-click to rename"
+            >
+              {pdf.title || "Untitled"}
+            </CardTitle>
+          )}
+          <PdfCardMenu pdf={pdf} onDelete={onDelete} />
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex-grow flex-1 flex flex-col justify-between">
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <FileText className="h-5 w-5 text-primary" />
+          <span>PDF upload</span>
+        </div>
+        <p className="text-sm text-muted-foreground line-clamp-3 mt-4">
+          Open this file in a new tab to read or review it.
+        </p>
+      </CardContent>
+
+      <CardFooter className="py-4 flex items-center justify-between border-t border-border">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Calendar className="h-3.5 w-3.5" />
+          {typeof window !== "undefined" ? (
+            <span>{new Date(pdf.updatedAt).toLocaleDateString()}</span>
+          ) : (
+            <SkeletonTextAnimation className="w-20" />
+          )}
+        </div>
+        <Button
+          size="sm"
+          asChild
+          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] absolute bottom-0 right-0 h-9 px-2 text-xs"
+          aria-label="open-upload"
+        >
+          <IntentPrefetchLink href={pdfHref}>
+            Open
+          </IntentPrefetchLink>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function PdfListCard({ pdf, onDelete }: PdfCardProps) {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editedTitle, setEditedTitle] = useState(pdf.title || "Untitled");
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const updatePdf = useMutation(api.pdfs.updatePdf);
+  const pdfSlug = generateSlug(pdf.title || "untitled-pdf");
+  const pdfHref = `/home/${pdf.workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdf._id}`;
+
+  useEffect(() => {
+    setEditedTitle(pdf.title || "Untitled");
+  }, [pdf.title]);
+
+  const handleDoubleClick = useCallback(() => {
+    setEditedTitle(pdf.title || "Untitled");
+    setIsEditingTitle(true);
+    requestAnimationFrame(() => {
+      titleInputRef.current?.focus();
+      titleInputRef.current?.select();
+    });
+  }, [pdf.title]);
+
+  const handleTitleBlur = useCallback(async () => {
+    const result = noteTitleSchema.safeParse(editedTitle.trim());
+    if (!result.success) {
+      setIsEditingTitle(false);
+      setEditedTitle(pdf.title || "Untitled");
+      return;
+    }
+
+    const trimmed = result.data;
+    if (trimmed !== (pdf.title || "Untitled")) {
+      try {
+        await updatePdf({ _id: pdf._id, title: trimmed });
+      } catch (error) {
+        console.error("Error updating PDF title:", error);
+        setEditedTitle(pdf.title || "Untitled");
+      }
+    }
+    setIsEditingTitle(false);
+  }, [editedTitle, pdf._id, pdf.title, updatePdf]);
+
+  const handleTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") titleInputRef.current?.blur();
+      else if (e.key === "Escape") {
+        setIsEditingTitle(false);
+        setEditedTitle(pdf.title || "Untitled");
+      }
+    },
+    [pdf.title],
+  );
+
+  return (
+    <Card className="group relative overflow-hidden flex justify-center items-center bg-card backdrop-blur-sm border border-border transition-all duration-300 w-full min-h-[100px]">
+      <CardContent className="p-3 flex-1">
+        <div className="flex items-center justify-center gap-4">
+          <div className="h-10 w-10 flex items-center justify-center flex-shrink-0">
+            <FileText className="h-5 w-5 text-primary" />
+          </div>
+          <div className="relative flex-1 min-w-0 h-[3.5rem] overflow-hidden">
+            {isEditingTitle ? (
+              <Input
+                ref={titleInputRef as any}
+                value={editedTitle}
+                onChange={(e) => setEditedTitle(e.target.value)}
+                onBlur={handleTitleBlur}
+                onKeyDown={handleTitleKeyDown}
+                className="min-w-fit max-w-md border border-transparent bg-transparent h-[1.8rem] px-0 py-3 !text-lg font-semibold focus-visible:ring-0 focus-visible:ring-offset-0"
+              />
+            ) : (
+              <h3
+                className="text-lg font-semibold text-foreground line-clamp-2 flex-1 cursor-text app-radius-md border border-transparent hover:border-muted-foreground/20 w-fit"
+                onDoubleClick={handleDoubleClick}
+                title="Double-click to rename"
+              >
+                {pdf.title || "Untitled"}
+              </h3>
+            )}
+            <p className="text-sm text-muted-foreground line-clamp-2">
+              PDF upload
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <div className="relative flex items-center gap-2 text-xs text-muted-foreground">
+              <Calendar className="h-3.5 w-3.5" />
+              {typeof window !== "undefined" ? (
+                <span>{new Date(pdf.updatedAt).toLocaleDateString()}</span>
+              ) : (
+                <SkeletonTextAnimation className="w-20" />
+              )}
+            </div>
+            <PdfCardMenu pdf={pdf} onDelete={onDelete} />
+            <Button
+              size="sm"
+              asChild
+              className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] absolute right-0 bottom-0 h-4/5 px-2 text-xs"
+            >
+              <IntentPrefetchLink href={pdfHref}>
+                <span aria-label="open-upload">Open</span>
+              </IntentPrefetchLink>
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function EmptySearchResults({
   searchQuery,
   onClearSearch,
@@ -1315,7 +1678,7 @@ function EmptySearchResults({
             No results found
           </h3>
           <p className="text-muted-foreground mb-6">
-            No notes found for "{searchQuery}"
+            No notes or uploads found for "{searchQuery}"
           </p>
           <Button
             variant="outline"
@@ -1344,10 +1707,10 @@ function EmptyTableState({
             <FileText className="h-8 w-8 text-primary" />
           </div>
           <h3 className="text-lg font-semibold mb-2 text-foreground">
-            No notes yet
+            No notes or uploads yet
           </h3>
           <p className="text-muted-foreground mb-6">
-            Create your first note to get started
+            Create your first note or upload to get started
           </p>
           <CreateNoteBtn
             workingSpaceId={workspaceId}

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -1,0 +1,639 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  calculateHighlightRects,
+  CanvasLayer,
+  HighlightLayer,
+  Page,
+  Pages,
+  Root,
+  Search as LectorSearch,
+  TextLayer,
+  usePdf,
+  usePdfJump,
+  useSearch,
+} from "@anaralabs/lector";
+import { GlobalWorkerOptions } from "pdfjs-dist/legacy/build/pdf.mjs";
+import "pdfjs-dist/web/pdf_viewer.css";
+import {
+  ArrowUpRight,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  FileSearch,
+  FileText,
+  Search,
+  X,
+} from "lucide-react";
+import { useQuery } from "@/cache/useQuery";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import MaxWContainer from "@/components/ui/MaxWContainer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import SkeletonTextAnimation from "@/components/ui/SkeletonTextAnimation";
+import { cn } from "@/lib/utils";
+
+GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/legacy/build/pdf.worker.mjs",
+  import.meta.url,
+).toString();
+
+type LectorSearchResult = {
+  pageNumber: number;
+  text: string;
+  score: number;
+  matchIndex: number;
+  isExactMatch: boolean;
+  searchText?: string;
+};
+
+const ZOOM_PRESETS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+const PDF_PAGE_GAP = 20;
+
+function isFiniteRectValue(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function sanitizeHighlightRects<
+  T extends { width: number; height: number; top: number; left: number },
+>(rects: T[]): T[] {
+  return rects.filter(
+    (rect) =>
+      isFiniteRectValue(rect.width) &&
+      isFiniteRectValue(rect.height) &&
+      isFiniteRectValue(rect.top) &&
+      isFiniteRectValue(rect.left) &&
+      rect.width > 0 &&
+      rect.height > 0,
+  );
+}
+
+function SearchPanel({
+  query,
+  setQuery,
+  onClose,
+}: {
+  query: string;
+  setQuery: (value: string) => void;
+  onClose: () => void;
+}) {
+  const { searchResults, search } = useSearch();
+  const { jumpToHighlightRects } = usePdfJump();
+  const getPdfPageProxy = usePdf((state) => state.getPdfPageProxy);
+  const setHighlight = usePdf((state) => state.setHighlight);
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+
+  const allResults = useMemo(
+    () => [...searchResults.exactMatches, ...searchResults.fuzzyMatches],
+    [searchResults.exactMatches, searchResults.fuzzyMatches],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      const trimmed = query.trim();
+
+      if (!trimmed) {
+        setActiveKey(null);
+        setHighlight([]);
+        search("");
+        return;
+      }
+
+      const nextResults = search(trimmed, {
+        limit: 30,
+        textSize: 90,
+      });
+
+      const rectGroups = await Promise.all(
+        [...nextResults.exactMatches, ...nextResults.fuzzyMatches].map(
+          async (result) => {
+            const proxy = getPdfPageProxy(result.pageNumber);
+            const rects = sanitizeHighlightRects(
+              await calculateHighlightRects(proxy, result),
+            );
+            return rects.map((rect) => ({
+              ...rect,
+              style: () => ({
+                background:
+                  activeKey ===
+                  `${result.pageNumber}-${result.matchIndex}-${result.searchText}`
+                    ? "rgba(245, 158, 11, 0.68)"
+                    : "rgba(250, 204, 21, 0.42)",
+                boxShadow:
+                  activeKey ===
+                  `${result.pageNumber}-${result.matchIndex}-${result.searchText}`
+                    ? "0 0 0 2px rgba(245, 158, 11, 0.95) inset"
+                    : "0 0 0 1px rgba(250, 204, 21, 0.6) inset",
+                borderRadius: "3px",
+              }),
+            }));
+          },
+        ),
+      );
+
+      if (cancelled) return;
+
+      const flatRects = rectGroups.flat();
+      setHighlight(flatRects);
+
+      const firstResult =
+        nextResults.exactMatches[0] ?? nextResults.fuzzyMatches[0];
+
+      if (firstResult) {
+        const firstKey = `${firstResult.pageNumber}-${firstResult.matchIndex}-${firstResult.searchText}`;
+        const nextActiveKey = activeKey ?? firstKey;
+        setActiveKey(nextActiveKey);
+
+        if (!activeKey) {
+          const firstRects = sanitizeHighlightRects(
+            await calculateHighlightRects(
+              getPdfPageProxy(firstResult.pageNumber),
+              firstResult,
+            ),
+          );
+          if (!cancelled) {
+            jumpToHighlightRects(firstRects, "pixels", "center", -40);
+          }
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeKey,
+    getPdfPageProxy,
+    jumpToHighlightRects,
+    query,
+    search,
+    setHighlight,
+  ]);
+
+  const handleResultClick = async (result: LectorSearchResult) => {
+    const rects = sanitizeHighlightRects(
+      await calculateHighlightRects(getPdfPageProxy(result.pageNumber), result),
+    );
+    const nextKey = `${result.pageNumber}-${result.matchIndex}-${result.searchText}`;
+    setActiveKey(nextKey);
+    jumpToHighlightRects(rects, "pixels", "center", -40);
+  };
+
+  return (
+    <aside className="flex h-full w-[290px] shrink-0 flex-col border-r border-border bg-card/95 backdrop-blur-sm">
+      <div className="border-b border-border p-3">
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search PDF..."
+              className="h-8 border-border bg-background pl-10"
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-8 px-0.5 shrink-0 border border-border"
+            onClick={onClose}
+            aria-label="close-search-panel"
+          >
+            <X size={16} />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2 transition-all scroll-smooth scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent">
+        {!query.trim() ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+            <FileSearch className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Search inside this PDF and jump straight to highlighted matches.
+            </p>
+          </div>
+        ) : allResults.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+            <Search className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No matches found for "{query}".
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {allResults.map((result) => {
+              const itemKey = `${result.pageNumber}-${result.matchIndex}-${result.searchText}`;
+
+              return (
+                <button
+                  key={itemKey}
+                  type="button"
+                  onClick={() => void handleResultClick(result)}
+                  className={cn(
+                    "w-full rounded-xl border border-border bg-card px-3 py-2 text-left transition-colors hover:bg-muted",
+                    activeKey === itemKey && "border-muted-foreground bg-muted",
+                  )}
+                >
+                  <p className="line-clamp-3 text-sm font-medium text-foreground">
+                    {result.text}
+                  </p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Page {result.pageNumber}
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function ZoomDropdown() {
+  const zoom = usePdf((state) => state.zoom);
+  const updateZoom = usePdf((state) => state.updateZoom);
+  const zoomFitWidth = usePdf((state) => state.zoomFitWidth);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-8 gap-2 border-border !border-l-0 !rounded-none"
+        >
+          <span>{Math.round(zoom * 100)}%</span>
+          <ChevronDown className="h-4 w-4 text-muted-foreground " />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-44">
+        <div className="flex items-center justify-between px-2 py-1.5">
+          <span className="text-sm font-medium text-foreground">
+            {Math.round(zoom * 100)}%
+          </span>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-7 w-7 !rounded-full"
+              onClick={() =>
+                updateZoom((prev) => Number((prev - 0.1).toFixed(2)))
+              }
+            >
+              <span className="text-base">-</span>
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-7 w-7 !rounded-full"
+              onClick={() =>
+                updateZoom((prev) => Number((prev + 0.1).toFixed(2)))
+              }
+            >
+              <span className="text-base">+</span>
+            </Button>
+          </div>
+        </div>
+        <DropdownMenuItem onClick={() => zoomFitWidth()}>
+          Page fit
+        </DropdownMenuItem>
+        {ZOOM_PRESETS.map((preset) => (
+          <DropdownMenuItem key={preset} onClick={() => updateZoom(preset)}>
+            {Math.round(preset * 100)}%
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function PageNavigator({
+  currentPageOverride,
+}: {
+  currentPageOverride?: number;
+}) {
+  const currentPageFromStore = usePdf((state) => state.currentPage);
+  const totalPages = usePdf((state) => state.pdfDocumentProxy.numPages);
+  const { jumpToPage } = usePdfJump();
+  const currentPage = currentPageOverride ?? currentPageFromStore;
+  const [pageInput, setPageInput] = useState(String(currentPage));
+
+  useEffect(() => {
+    setPageInput(String(currentPage));
+  }, [currentPage]);
+
+  const commitPageInput = () => {
+    const parsedPage = Number(pageInput.trim());
+
+    if (!Number.isFinite(parsedPage)) {
+      setPageInput(String(currentPage));
+      return;
+    }
+
+    const nextPage = Math.min(Math.max(Math.round(parsedPage), 1), totalPages);
+    setPageInput(String(nextPage));
+
+    if (nextPage !== currentPage) {
+      jumpToPage(nextPage, { behavior: "auto" });
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-0 text-sm text-muted-foreground">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-8 w-8 !rounded-full"
+        disabled={currentPage <= 1}
+        onClick={() => jumpToPage(currentPage - 1, { behavior: "auto" })}
+        aria-label="previous-page"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <Input
+        value={pageInput}
+        onChange={(event) => {
+          const nextValue = event.target.value.replace(/[^\d]/g, "");
+          setPageInput(nextValue);
+        }}
+        onBlur={commitPageInput}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            commitPageInput();
+          }
+
+          if (event.key === "Escape") {
+            event.preventDefault();
+            setPageInput(String(currentPage));
+          }
+        }}
+        inputMode="numeric"
+        aria-label="current-page-input"
+        className="h-7 w-7 p-0 mx-1 bg-transparent border-0 text-center text-sm font-medium text-foreground"
+      />
+      <span className=" mr-3"> of {totalPages}</span>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-8 w-8 !rounded-full"
+        disabled={currentPage >= totalPages}
+        onClick={() => jumpToPage(currentPage + 1, { behavior: "auto" })}
+        aria-label="next-page"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function PdfViewerContent({
+  fileUrl,
+  title,
+}: {
+  fileUrl: string;
+  title: string;
+}) {
+  const [query, setQuery] = useState("");
+  const [isSearchOpen, setIsSearchOpen] = useState(true);
+  const zoom = usePdf((state) => state.zoom);
+  const viewports = usePdf((state) => state.viewports);
+  const currentPageFromStore = usePdf((state) => state.currentPage);
+  const viewportRef = usePdf((state) => state.viewportRef);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+
+  useEffect(() => {
+    const viewport = viewportRef?.current;
+    if (!viewport) return;
+
+    const updateHeight = () => {
+      setViewportHeight(viewport.clientHeight);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(() => {
+      updateHeight();
+    });
+
+    observer.observe(viewport);
+
+    return () => observer.disconnect();
+  }, [viewportRef]);
+
+  const reactiveCurrentPage = useMemo(() => {
+    if (!viewports.length || !viewportHeight || zoom <= 0) {
+      return currentPageFromStore;
+    }
+
+    const viewportCenter = scrollOffset / zoom + viewportHeight / zoom / 2;
+    let bestPage = 1;
+    let smallestDistance = Number.POSITIVE_INFINITY;
+    let pageStart = 0;
+
+    for (let index = 0; index < viewports.length; index += 1) {
+      const pageSize = viewports[index].height + PDF_PAGE_GAP;
+      const pageCenter = pageStart + pageSize / 2;
+      const distance = Math.abs(pageCenter - viewportCenter);
+
+      if (distance < smallestDistance) {
+        smallestDistance = distance;
+        bestPage = index + 1;
+      }
+
+      pageStart += pageSize;
+    }
+
+    return bestPage;
+  }, [currentPageFromStore, scrollOffset, viewportHeight, viewports, zoom]);
+
+  return (
+    <LectorSearch
+      loading={
+        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+          Preparing PDF search...
+        </div>
+      }
+    >
+      <div className="relative h-full w-full">
+        <div className="pointer-events-none fixed inset-0 top-20 z-20 ">
+          <div className="pointer-events-auto mx-auto flex w-fit max-w-[calc(100%-0.5rem)] flex-wrap items-center justify-between gap-3 app-radius-md border border-border bg-card/95 px-3 py-1.5 shadow-2xl backdrop-blur-xl">
+            <div className="flex items-center gap-0">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-8 w-8 border border-border"
+                onClick={() => setIsSearchOpen((current) => !current)}
+                aria-label="show-search-panel"
+              >
+                <Search size={16} />
+              </Button>
+              <ZoomDropdown />
+            </div>
+            <PageNavigator currentPageOverride={reactiveCurrentPage} />
+          </div>
+        </div>
+
+        {isSearchOpen ? (
+          <div className="absolute left-0 top-0 z-20 h-full w-[290px] max-w-[calc(100%-1.5rem)] overflow-hidden border border-border">
+            <SearchPanel
+              query={query}
+              setQuery={setQuery}
+              onClose={() => setIsSearchOpen(false)}
+            />
+          </div>
+        ) : null}
+
+        <Pages
+          className="h-full w-full transition-all scroll-smooth scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent"
+          gap={PDF_PAGE_GAP}
+          onOffsetChange={setScrollOffset}
+        >
+          <Page>
+            <CanvasLayer />
+            <TextLayer />
+            <HighlightLayer />
+          </Page>
+        </Pages>
+      </div>
+    </LectorSearch>
+  );
+}
+
+function PdfViewerShell({
+  fileUrl,
+  title,
+}: {
+  fileUrl: string;
+  title: string;
+}) {
+  return (
+    <Root
+      source={fileUrl}
+      isZoomFitWidth
+      className="pdf-viewer-shell flex flex-1 overflow-hidden rounded-none border-0 bg-background"
+      loader={
+        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+          Loading PDF...
+        </div>
+      }
+    >
+      <PdfViewerContent fileUrl={fileUrl} title={title} />
+    </Root>
+  );
+}
+
+export default function PdfViewerPageClient({ pdfId }: { pdfId: Id<"pdfs"> }) {
+  const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });
+  const [isViewerReady, setIsViewerReady] = useState(false);
+  const [hasMeasuredViewport, setHasMeasuredViewport] = useState(false);
+  const viewerHostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setIsViewerReady(false);
+    const frame = window.requestAnimationFrame(() => {
+      setIsViewerReady(true);
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [pdfId]);
+
+  useEffect(() => {
+    setHasMeasuredViewport(false);
+    let frameId = 0;
+    let attempts = 0;
+
+    const measureUntilReady = () => {
+      const host = viewerHostRef.current;
+
+      if (!host) {
+        frameId = window.requestAnimationFrame(measureUntilReady);
+        return;
+      }
+
+      const rect = host.getBoundingClientRect();
+      const hasUsableWidth = rect.width > 0;
+      const hasUsableHeight = rect.height > 0;
+
+      if (hasUsableWidth && hasUsableHeight) {
+        setHasMeasuredViewport(true);
+        return;
+      }
+
+      attempts += 1;
+
+      if (attempts >= 20 && hasUsableWidth) {
+        setHasMeasuredViewport(true);
+        return;
+      }
+
+      frameId = window.requestAnimationFrame(measureUntilReady);
+    };
+
+    frameId = window.requestAnimationFrame(measureUntilReady);
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [pdfId]);
+
+  if (pdf === undefined) {
+    return (
+      <div className="flex h-full max-w-full min-h-0 flex-col px-0 py-0 mx-0">
+        <div className="flex-1 rounded-2xl border border-border bg-card animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!pdf.fileUrl) {
+    return (
+      <div className="flex h-full max-w-none min-h-0 flex-col ">
+        <Card className="border-border bg-card">
+          <CardContent className="py-10 text-center">
+            <div className="flex flex-col items-center gap-3">
+              <FileText className="h-8 w-8 text-primary" />
+              <h1 className="text-xl font-semibold text-foreground">
+                PDF unavailable
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                We couldn&apos;t generate a view link for this PDF.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={viewerHostRef} className="flex min-h-0 flex-1">
+      {isViewerReady && hasMeasuredViewport ? (
+        <PdfViewerShell
+          fileUrl={pdf.fileUrl}
+          title={pdf.title || "Untitled PDF"}
+        />
+      ) : (
+        <div className="flex-1 bg-card animate-pulse" />
+      )}
+    </div>
+  );
+}

--- a/app/home/[id]/pdf/[pdfId]/loading.tsx
+++ b/app/home/[id]/pdf/[pdfId]/loading.tsx
@@ -1,0 +1,15 @@
+import MaxWContainer from "@/components/ui/MaxWContainer";
+
+function Skeleton({ className = "" }: { className?: string }) {
+  return (
+    <div className={`bg-border app-radius-md animate-pulse ${className}`} />
+  );
+}
+
+export default function Loading() {
+  return (
+    <div className="flex h-full max-w-full min-h-0 flex-col px-0 py-0 mx-0">
+      <div className="flex-1 rounded-none border border-border bg-card animate-pulse" />
+    </div>
+  );
+}

--- a/app/home/[id]/pdf/[pdfId]/page.tsx
+++ b/app/home/[id]/pdf/[pdfId]/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import type { Id } from "@/convex/_generated/dataModel";
+import PdfViewerPageClient from "./PdfViewerPageClient";
+
+export default async function PdfViewerPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ pdfId?: string }>;
+  searchParams: Promise<{ pdfId?: string | string[] }>;
+}) {
+  const { pdfId: routeSegment } = await params;
+  const { pdfId } = await searchParams;
+  const resolvedPdfId =
+    typeof pdfId === "string" ? pdfId : Array.isArray(pdfId) ? pdfId[0] : routeSegment;
+
+  if (!resolvedPdfId) {
+    redirect("/");
+  }
+
+  return <PdfViewerPageClient pdfId={resolvedPdfId as Id<"pdfs">} />;
+}

--- a/components/home-components/BreadcrumbWithCustomSeparator.tsx
+++ b/components/home-components/BreadcrumbWithCustomSeparator.tsx
@@ -73,6 +73,8 @@ export default function BreadcrumbWithCustomSeparator() {
               workspaceDatafilter.name
             ) {
               displayName = workspaceDatafilter.name;
+            } else if (segment.toLowerCase() === "pdf") {
+              displayName = "PDF";
             } else {
               // For other segments, use the parseSlug utility
               displayName = parseSlug(segment);

--- a/components/home-components/CreateNoteBtn.tsx
+++ b/components/home-components/CreateNoteBtn.tsx
@@ -1,10 +1,5 @@
-import { api } from "@/convex/_generated/api";
-import { cn } from "@/lib/utils";
-import { Button } from "../ui/button";
-import { useMutation, insertAtTop } from "convex/react";
-import { Plus } from "lucide-react";
 import type { Id } from "@/convex/_generated/dataModel";
-import { useRouter } from "next/navigation";
+import WorkingspaceNewDropdownBtn from "./workingspace-new-dropdown-btn";
 
 interface CreateNoteBtnProps {
   CNBP_notesTableId: Id<"notesTables"> | undefined;
@@ -19,63 +14,12 @@ export default function CreateNoteBtn({
   workingSpaceId,
   className,
 }: CreateNoteBtnProps) {
-  const router = useRouter();
-
-  const createNote = useMutation(api.notes.createNote).withOptimisticUpdate(
-    (local, args) => {
-      const { notesTableId, title, workingSpacesSlug, workingSpaceId } = args;
-
-      if (!CNBP_notesTableId || notesTableId !== CNBP_notesTableId) return;
-
-      const now = Date.now();
-      const uuid = crypto.randomUUID();
-      const tempId = `${uuid}-${now}` as Id<"notes">;
-      insertAtTop({
-        localQueryStore: local,
-        paginatedQuery: api.notes.getNotesByTableId,
-        argsToMatch: { notesTableId: CNBP_notesTableId },
-        item: {
-          _id: tempId,
-          _creationTime: now,
-          title: title || "Untitled",
-          body: undefined,
-          slug: "untitled",
-          workingSpaceId,
-          workingSpacesSlug,
-          notesTableId: CNBP_notesTableId,
-          favorite: false,
-          createdAt: now,
-          updatedAt: now,
-        },
-      });
-    },
-  );
-
-  const handleCreateNote = async () => {
-    try {
-      const newNoteId = await createNote({
-        title: "Untitled",
-        notesTableId: CNBP_notesTableId,
-        workingSpacesSlug,
-        workingSpaceId,
-      });
-    } catch (error) {
-      console.error("Failed to create note:", error);
-      // Optional: show toast/error if creation fails
-    }
-  };
-
   return (
-    <Button
-      className={cn(
-        "flex items-center justify-between gap-1 h-9 px-2",
-        className,
-      )}
-      variant="outline"
-      onClick={handleCreateNote}
-    >
-      <Plus className="mt-[0.06rem]" size={14} />
-      <p>New Note</p>
-    </Button>
+    <WorkingspaceNewDropdownBtn
+      notesTableId={CNBP_notesTableId}
+      workingSpacesSlug={workingSpacesSlug}
+      workingSpaceId={workingSpaceId}
+      className={className}
+    />
   );
 }

--- a/components/home-components/GlobalFolderDropUpload.tsx
+++ b/components/home-components/GlobalFolderDropUpload.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "convex/react";
+import { Upload, FolderOpen, FileUp, Loader2 } from "lucide-react";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import { useQuery } from "@/cache/useQuery";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { generateSlug } from "@/lib/generateSlug";
+import { cn } from "@/lib/utils";
+
+type PendingUpload = {
+  files: File[];
+  folderName: string;
+};
+
+type FileSystemHandleLike = {
+  kind: "file" | "directory";
+  name: string;
+  getFile?: () => Promise<File>;
+  values?: () => AsyncIterable<FileSystemHandleLike>;
+};
+
+type FileSystemEntryLike = {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  file?: (callback: (file: File) => void) => void;
+  createReader?: () => {
+    readEntries: (callback: (entries: FileSystemEntryLike[]) => void) => void;
+  };
+};
+
+const DEFAULT_TABLE_NAME = "new uploaded";
+
+function isPdfFile(file: File) {
+  return (
+    file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+  );
+}
+
+async function readAllEntries(
+  reader: ReturnType<NonNullable<FileSystemEntryLike["createReader"]>>,
+): Promise<FileSystemEntryLike[]> {
+  const entries: FileSystemEntryLike[] = [];
+
+  while (true) {
+    const batch = await new Promise<FileSystemEntryLike[]>((resolve) => {
+      reader.readEntries(resolve);
+    });
+
+    if (!batch.length) break;
+    entries.push(...batch);
+  }
+
+  return entries;
+}
+
+async function collectFilesFromEntry(
+  entry: FileSystemEntryLike,
+  files: File[],
+): Promise<void> {
+  if (entry.isFile && entry.file) {
+    const file = await new Promise<File>((resolve, reject) => {
+      try {
+        entry.file?.(resolve);
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    if (isPdfFile(file)) {
+      files.push(file);
+    }
+    return;
+  }
+
+  if (entry.isDirectory && entry.createReader) {
+    const reader = entry.createReader();
+    const children = await readAllEntries(reader);
+    await Promise.all(
+      children.map((child) => collectFilesFromEntry(child, files)),
+    );
+  }
+}
+
+async function collectFilesFromHandle(
+  handle: FileSystemHandleLike,
+  files: File[],
+): Promise<void> {
+  if (handle.kind === "file" && handle.getFile) {
+    const file = await handle.getFile();
+    if (isPdfFile(file)) {
+      files.push(file);
+    }
+    return;
+  }
+
+  if (handle.kind === "directory" && handle.values) {
+    for await (const child of handle.values()) {
+      await collectFilesFromHandle(child, files);
+    }
+  }
+}
+
+async function extractPdfFilesFromDrop(dataTransfer: DataTransfer) {
+  const files: File[] = [];
+  const folderNames: string[] = [];
+  const items = Array.from(dataTransfer.items ?? []);
+
+  for (const item of items) {
+    if (item.kind !== "file") continue;
+
+    const itemWithHandle = item as DataTransferItem & {
+      getAsFileSystemHandle?: () => Promise<FileSystemHandleLike>;
+      webkitGetAsEntry?: () => FileSystemEntryLike | null;
+    };
+
+    if (itemWithHandle.getAsFileSystemHandle) {
+      const handle = await itemWithHandle.getAsFileSystemHandle();
+      folderNames.push(handle.name);
+      await collectFilesFromHandle(handle, files);
+      continue;
+    }
+
+    if (itemWithHandle.webkitGetAsEntry) {
+      const entry = itemWithHandle.webkitGetAsEntry();
+      if (entry) {
+        folderNames.push(entry.name);
+        await collectFilesFromEntry(entry, files);
+        continue;
+      }
+    }
+
+    const fallbackFile = item.getAsFile();
+    if (fallbackFile && isPdfFile(fallbackFile)) {
+      folderNames.push(fallbackFile.name);
+      files.push(fallbackFile);
+    }
+  }
+
+  const folderName =
+    folderNames.find((name) => !name.toLowerCase().endsWith(".pdf")) ??
+    folderNames[0] ??
+    "Uploaded folder";
+
+  return {
+    files,
+    folderName,
+  };
+}
+
+export default function GlobalFolderDropUpload() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const dragDepthRef = useRef(0);
+  const [isDragActive, setIsDragActive] = useState(false);
+  const [pendingUpload, setPendingUpload] = useState<PendingUpload | null>(
+    null,
+  );
+  const [isUploading, setIsUploading] = useState(false);
+  const [isWorkspaceDialogOpen, setIsWorkspaceDialogOpen] = useState(false);
+
+  const workspaces = useQuery(api.workingSpaces.getRecentWorkingSpaces, {}) as
+    | Array<{ _id: Id<"workingSpaces">; name: string; slug?: string }>
+    | undefined;
+
+  const createWorkingSpace = useMutation(api.workingSpaces.createWorkingSpace);
+  const createTable = useMutation(api.notesTables.createTable);
+  const generateUploadUrl = useMutation(api.pdfs.generateUploadUrl);
+  const sendPdf = useMutation(api.pdfs.sendPdf);
+
+  const workspaceCount = workspaces?.length ?? 0;
+  const hasMultipleWorkspaces = workspaceCount > 1;
+
+  const uploadToWorkspace = useCallback(
+    async (
+      files: File[],
+      folderName: string,
+      workingSpaceId: Id<"workingSpaces">,
+    ) => {
+      setIsUploading(true);
+      try {
+        const tableId = await createTable({
+          name: DEFAULT_TABLE_NAME,
+          workingSpaceId,
+        });
+
+        let firstPdfRoute: string | null = null;
+
+        for (const file of files) {
+          const uploadUrl = await generateUploadUrl({});
+          const response = await fetch(uploadUrl, {
+            method: "POST",
+            headers: {
+              "Content-Type": file.type || "application/pdf",
+            },
+            body: file,
+          });
+
+          if (!response.ok) {
+            throw new Error(`Failed to upload ${file.name}`);
+          }
+
+          const { storageId } = (await response.json()) as {
+            storageId: Id<"_storage">;
+          };
+
+          const pdfId = await sendPdf({
+            storageId,
+            title: file.name.replace(/\.pdf$/i, ""),
+            workingSpaceId,
+            notesTableId: tableId,
+          });
+
+          if (!firstPdfRoute) {
+            const pdfSlug = generateSlug(file.name.replace(/\.pdf$/i, ""));
+            firstPdfRoute = `/home/${workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdfId}`;
+          }
+        }
+
+        toast({
+          title: "Folder uploaded",
+          description: `${files.length} PDF${files.length > 1 ? "s" : ""} from "${folderName}" added to ${DEFAULT_TABLE_NAME}.`,
+        });
+
+        if (firstPdfRoute) {
+          router.push(firstPdfRoute);
+        } else {
+          router.push(`/home/${workingSpaceId}`);
+        }
+      } catch (error) {
+        console.error("Folder upload failed:", error);
+        toast({
+          title: "Upload failed",
+          description: "We couldn't upload that folder.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsUploading(false);
+        setPendingUpload(null);
+        setIsWorkspaceDialogOpen(false);
+      }
+    },
+    [createTable, generateUploadUrl, router, sendPdf, toast],
+  );
+
+  const resolveSingleWorkspaceUpload = useCallback(
+    async (files: File[], folderName: string) => {
+      if (workspaceCount === 0) {
+        const newWorkspaceId = await createWorkingSpace({ name: "Untitled" });
+        await uploadToWorkspace(files, folderName, newWorkspaceId);
+        return;
+      }
+
+      const firstWorkspace = workspaces?.[0];
+      if (!firstWorkspace) return;
+      await uploadToWorkspace(files, folderName, firstWorkspace._id);
+    },
+    [createWorkingSpace, uploadToWorkspace, workspaceCount, workspaces],
+  );
+
+  const handleResolvedDrop = useCallback(
+    async (files: File[], folderName: string) => {
+      if (!files.length) {
+        toast({
+          title: "No PDFs found",
+          description: "Drop a folder that contains at least one PDF file.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (hasMultipleWorkspaces) {
+        setPendingUpload({ files, folderName });
+        setIsWorkspaceDialogOpen(true);
+        return;
+      }
+
+      await resolveSingleWorkspaceUpload(files, folderName);
+    },
+    [hasMultipleWorkspaces, resolveSingleWorkspaceUpload, toast],
+  );
+
+  useEffect(() => {
+    const hasFiles = (event: DragEvent) =>
+      Array.from(event.dataTransfer?.types ?? []).includes("Files");
+
+    const handleDragEnter = (event: DragEvent) => {
+      if (!hasFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current += 1;
+      setIsDragActive(true);
+    };
+
+    const handleDragOver = (event: DragEvent) => {
+      if (!hasFiles(event)) return;
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "copy";
+      }
+      setIsDragActive(true);
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
+      if (!hasFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) {
+        setIsDragActive(false);
+      }
+    };
+
+    const handleDrop = async (event: DragEvent) => {
+      if (!hasFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current = 0;
+      setIsDragActive(false);
+
+      if (!event.dataTransfer) return;
+
+      const { files, folderName } = await extractPdfFilesFromDrop(
+        event.dataTransfer,
+      );
+      await handleResolvedDrop(files, folderName);
+    };
+
+    window.addEventListener("dragenter", handleDragEnter);
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragleave", handleDragLeave);
+    window.addEventListener("drop", handleDrop);
+
+    return () => {
+      window.removeEventListener("dragenter", handleDragEnter);
+      window.removeEventListener("dragover", handleDragOver);
+      window.removeEventListener("dragleave", handleDragLeave);
+      window.removeEventListener("drop", handleDrop);
+    };
+  }, [handleResolvedDrop]);
+
+  const workspaceChoices = useMemo(() => workspaces ?? [], [workspaces]);
+
+  return (
+    <>
+      {isDragActive ? (
+        <div className="pointer-events-none fixed inset-0 z-[100000] flex items-center justify-center bg-background/60 backdrop-blur-sm">
+          <div className="app-radius-lg border-4 border-dashed border-border bg-card px-4 pb-3 pt-3.5 text-center shadow-2xl">
+            <div className=" mb-3 flex items-center justify-start gap-2 ">
+              <FolderOpen size={20} className=" text-muted-foreground mt-0.5" />
+              <h3 className="text-xl font-semibold text-foreground">
+                Drop folder to upload PDFs
+              </h3>
+            </div>
+
+            <p className="mt-2 max-w-sm text-sm text-start text-muted-foreground">
+              We&apos;ll create a new table named "{DEFAULT_TABLE_NAME}" <br />{" "}
+              and add the PDFs there.
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {isUploading ? (
+        <div className="fixed inset-0 z-[100001] flex items-center justify-center bg-background/55 backdrop-blur-sm">
+          <div className=" mb-2 flex items-center justify-start gap-2 ">
+            <Loader2
+              size={20}
+              className="animate-spin text-muted-foreground mt-0.5"
+            />
+            <h3 className="text-xl font-semibold text-foreground">
+              Uploading folder...
+            </h3>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog
+        open={isWorkspaceDialogOpen}
+        onOpenChange={(open) => {
+          if (!isUploading) {
+            setIsWorkspaceDialogOpen(open);
+            if (!open) setPendingUpload(null);
+          }
+        }}
+      >
+        <DialogContent className="app-radius-lg px-4 pb-3 pt-4 sm:max-w-md bg-card">
+          <DialogHeader className="mb-2 pl-1">
+            <DialogTitle>Choose Workspace</DialogTitle>
+            <DialogDescription>
+              Select where to upload{" "}
+              <span className="font-medium text-foreground">
+                {pendingUpload?.folderName ?? "this folder"}
+              </span>
+              <br />
+              We&apos;ll create a table named "{DEFAULT_TABLE_NAME}" there.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            {workspaceChoices.map((workspace) => (
+              <Button
+                key={workspace._id}
+                type="button"
+                variant="outline"
+                className={cn(
+                  "h-auto w-full justify-start gap-3 px-4 py-3 text-left",
+                )}
+                disabled={!pendingUpload || isUploading}
+                onClick={() => {
+                  if (!pendingUpload) return;
+                  void uploadToWorkspace(
+                    pendingUpload.files,
+                    pendingUpload.folderName,
+                    workspace._id,
+                  );
+                }}
+              >
+                <FileUp size={16} className="text-muted-foreground" />
+                <span className="truncate">{workspace.name}</span>
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/sidebar";
 import AppSidebar from "@/components/home-components/AppSidebar";
 import BreadcrumbWithCustomSeparator from "@/components/home-components/BreadcrumbWithCustomSeparator";
+import GlobalFolderDropUpload from "@/components/home-components/GlobalFolderDropUpload";
 import { MobileWarning } from "@/components/ui/mobile-warning";
 import NoteSettings from "@/components/home-components/NoteSettings";
 import SearchDialog from "@/components/home-components/SearchDialog";
@@ -59,12 +60,14 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
   const pathSegments = pathname.split("/").filter((segment) => segment);
   const noteid = searchParams.get("id") as Id<"notes">;
   const noteTitle = parseSlug(`${pathSegments[2]}`);
+  const isPdfRoute = pathSegments[2] === "pdf";
 
   const showTopFade = scrollTop > 0;
 
   return (
     <div className="flex h-screen w-full bg-muted overflow-hidden">
       <AppSidebar />
+      <GlobalFolderDropUpload />
       <SearchDialog showTrigger={false} enableShortcut={true} />
       <div
         aria-hidden="true"
@@ -108,15 +111,19 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         </div>
         <div
           ref={scrollContainerRef}
-          className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent py-6"
+          className={`flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent ${
+            isPdfRoute ? "overflow-hidden py-0" : "overflow-y-auto py-6"
+          }`}
         >
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: showTopFade ? 1 : 0 }}
-            transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
-            className="sticky -top-12 left-0 w-full h-28 bg-gradient-to-b from-background from-25% to-transparent to-100% z-[5] pointer-events-none -mb-32"
-            aria-hidden
-          />
+          {!isPdfRoute ? (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: showTopFade ? 1 : 0 }}
+              transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
+              className="sticky -top-12 left-0 w-full h-28 bg-gradient-to-b from-background from-25% to-transparent to-100% z-[5] pointer-events-none -mb-32"
+              aria-hidden
+            />
+          ) : null}
           {children}
         </div>
         <MobileWarning />

--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -1,4 +1,259 @@
-// this should contain the create note and upload pdf btns
-export default function WorkingspaceNewDropdownBtn() {
-  return <div className="dropdown dropdown-end" />;
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { insertAtTop, useMutation } from "convex/react";
+import { ChevronDown, FileUp, FileText } from "lucide-react";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/hooks/use-toast";
+
+type PreferredAction = "note" | "upload";
+
+const STORAGE_KEY = "notevo_workspace_primary_create_action";
+
+interface WorkingspaceNewDropdownBtnProps {
+  notesTableId?: Id<"notesTables">;
+  workingSpacesSlug?: string;
+  workingSpaceId?: Id<"workingSpaces">;
+  className?: string;
+}
+
+export default function WorkingspaceNewDropdownBtn({
+  notesTableId,
+  workingSpacesSlug,
+  workingSpaceId,
+  className,
+}: WorkingspaceNewDropdownBtnProps) {
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [preferredAction, setPreferredAction] =
+    useState<PreferredAction>("note");
+  const [isUploading, setIsUploading] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const savedAction = window.localStorage.getItem(STORAGE_KEY);
+    if (savedAction === "note" || savedAction === "upload") {
+      setPreferredAction(savedAction);
+    }
+  }, []);
+
+  const persistPreferredAction = useCallback((action: PreferredAction) => {
+    setPreferredAction(action);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, action);
+    }
+  }, []);
+
+  const createNote = useMutation(api.notes.createNote).withOptimisticUpdate(
+    (local, args) => {
+      const {
+        notesTableId: nextTableId,
+        title,
+        workingSpacesSlug,
+        workingSpaceId,
+      } = args;
+
+      if (!notesTableId || nextTableId !== notesTableId) return;
+
+      const now = Date.now();
+      const uuid = crypto.randomUUID();
+      const tempId = `${uuid}-${now}` as Id<"notes">;
+
+      insertAtTop({
+        localQueryStore: local,
+        paginatedQuery: api.notes.getNotesByTableId,
+        argsToMatch: { notesTableId },
+        item: {
+          _id: tempId,
+          _creationTime: now,
+          title: title || "Untitled",
+          slug: "untitled",
+          workingSpaceId,
+          workingSpacesSlug,
+          notesTableId,
+          favorite: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+    },
+  );
+
+  const generateUploadUrl = useMutation(api.pdfs.generateUploadUrl);
+  const sendPdf = useMutation(api.pdfs.sendPdf);
+
+  const isDisabled = useMemo(
+    () => !notesTableId || !workingSpaceId || !workingSpacesSlug || isUploading,
+    [isUploading, notesTableId, workingSpaceId, workingSpacesSlug],
+  );
+
+  const handleCreateNote = useCallback(async () => {
+    if (!notesTableId || !workingSpaceId || !workingSpacesSlug) return;
+
+    try {
+      await createNote({
+        title: "Untitled",
+        notesTableId,
+        workingSpacesSlug,
+        workingSpaceId,
+      });
+    } catch (error) {
+      console.error("Failed to create note:", error);
+      toast({
+        title: "Could not create note",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, [createNote, notesTableId, toast, workingSpaceId, workingSpacesSlug]);
+
+  const uploadPdfFile = useCallback(
+    async (file: File) => {
+      if (!notesTableId || !workingSpaceId) return;
+
+      if (file.type !== "application/pdf") {
+        toast({
+          title: "PDF only",
+          description: "Please choose a PDF file.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setIsUploading(true);
+      try {
+        const uploadUrl = await generateUploadUrl({});
+        const response = await fetch(uploadUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": file.type,
+          },
+          body: file,
+        });
+
+        if (!response.ok) {
+          throw new Error("Upload failed");
+        }
+
+        const { storageId } = (await response.json()) as {
+          storageId: Id<"_storage">;
+        };
+
+        await sendPdf({
+          storageId,
+          title: file.name.replace(/\.pdf$/i, ""),
+          workingSpaceId,
+          notesTableId,
+        });
+      } catch (error) {
+        console.error("Failed to upload PDF:", error);
+        toast({
+          title: "Upload failed",
+          description: "Your PDF could not be uploaded.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [generateUploadUrl, notesTableId, sendPdf, toast, workingSpaceId],
+  );
+
+  const handlePrimaryAction = useCallback(async () => {
+    if (preferredAction === "upload") {
+      fileInputRef.current?.click();
+      return;
+    }
+
+    await handleCreateNote();
+  }, [handleCreateNote, preferredAction]);
+
+  const handleFileChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file) return;
+      await uploadPdfFile(file);
+    },
+    [uploadPdfFile],
+  );
+
+  const handleSelectNote = useCallback(async () => {
+    persistPreferredAction("note");
+    await handleCreateNote();
+  }, [handleCreateNote, persistPreferredAction]);
+
+  const handleSelectUpload = useCallback(() => {
+    persistPreferredAction("upload");
+    fileInputRef.current?.click();
+  }, [persistPreferredAction]);
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/pdf"
+        className="hidden"
+        onChange={(event) => void handleFileChange(event)}
+      />
+
+      <div
+        className={cn(
+          "flex h-9 items-center overflow-hidden app-radius-lg",
+          className,
+        )}
+      >
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => void handlePrimaryAction()}
+          disabled={isDisabled}
+          className="h-9 "
+        >
+          {isUploading ? "Uploading..." : "New"}
+        </Button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isDisabled}
+              className="h-9 px-1 border-l-0 !rounded-none"
+              aria-label="open-create-menu"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem onClick={() => void handleSelectNote()}>
+              <FileText className="h-4 w-4 text-muted-foreground" />
+              New note
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleSelectUpload}>
+              <FileUp className="h-4 w-4 text-muted-foreground" />
+              Upload PDF
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </>
+  );
 }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -38,19 +38,17 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-      "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-2 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-none sm:rounded-tl-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-2 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-none sm:rounded-tl-lg",
         className,
       )}
       {...props}
     >
-      <DialogPrimitive.Title className="sr-only">
-        Dialog
-      </DialogPrimitive.Title>
+      <DialogPrimitive.Title className="sr-only">Dialog</DialogPrimitive.Title>
       <DialogPrimitive.Description className="sr-only">
         Dialog content
       </DialogPrimitive.Description>
       {children}
-      <DialogPrimitive.Close className="absolute right-5 top-5 app-radius-lg opacity-50 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-2 top-2 app-radius-lg opacity-50 ring-offset-0 transition-opacity hover:opacity-100 focus:outline-none focus:ring-0 focus:ring-ring focus:ring-offset-0 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4 text-muted-foreground" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -25,14 +25,14 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-lg border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative backdrop-blur-sm flex w-full items-center justify-between space-x-2 overflow-hidden app-radius-md border p-2.5 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
         default:
-          "border border-border bg-card text-foreground hover:bg-card/50",
+          "border border-border bg-card text-foreground hover:bg-card/90",
         destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "destructive group border-destructive/50 bg-card text-destructive-foreground hover:bg-card/90",
       },
     },
     defaultVariants: {
@@ -63,7 +63,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-lg border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      "inline-flex h-8 shrink-0 items-center justify-center app-radius-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
       className,
     )}
     {...props}
@@ -78,7 +78,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 rounded-lg p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-1 top-1 app-radius-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className,
     )}
     toast-close=""

--- a/convex/notesTables.ts
+++ b/convex/notesTables.ts
@@ -56,6 +56,73 @@ export const createTable = mutation({
   },
 });
 
+export const getOrCreateTable = mutation({
+  args: {
+    name: v.string(),
+    workingSpaceId: v.id("workingSpaces"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const { name, workingSpaceId } = args;
+    const normalizedName = name.trim().toLowerCase();
+
+    const workspace = await ctx.db.get(workingSpaceId);
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+
+    if (workspace.userId !== userId) {
+      throw new Error("Not authorized to create tables in this workspace");
+    }
+
+    const tables = await ctx.db
+      .query("notesTables")
+      .withIndex("by_workingSpaceId", (q) =>
+        q.eq("workingSpaceId", workingSpaceId),
+      )
+      .collect();
+
+    const existingTable = tables.find(
+      (table) => table.name?.trim().toLowerCase() === normalizedName,
+    );
+
+    if (existingTable) {
+      await ctx.db.patch(existingTable._id, {
+        updatedAt: Date.now(),
+      });
+      return existingTable._id;
+    }
+
+    const generateSlugName = generateSlug(name);
+    let slug = generateSlugName;
+    let existingTableBySlug = await ctx.db
+      .query("notesTables")
+      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .first();
+    let counter = 1;
+    while (existingTableBySlug) {
+      slug = `${generateSlugName}-${counter}`;
+      existingTableBySlug = await ctx.db
+        .query("notesTables")
+        .withIndex("by_slug", (q) => q.eq("slug", slug))
+        .first();
+      counter++;
+    }
+
+    return ctx.db.insert("notesTables", {
+      name,
+      workingSpaceId,
+      slug,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 export const updateTable = mutation({
   args: {
     _id: v.id("notesTables"),
@@ -144,8 +211,18 @@ export const deleteTable = mutation({
       .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
       .collect();
 
+    const pdfsToDelete = await ctx.db
+      .query("pdfs")
+      .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+      .collect();
+
     for (const note of notesToDelete) {
       await ctx.db.delete(note._id);
+    }
+
+    for (const pdf of pdfsToDelete) {
+      await ctx.storage.delete(pdf.storageId);
+      await ctx.db.delete(pdf._id);
     }
 
     await ctx.db.delete(_id);

--- a/convex/pdfs.ts
+++ b/convex/pdfs.ts
@@ -1,4 +1,4 @@
-import { mutation } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 
@@ -14,6 +14,7 @@ export const sendPdf = mutation({
     storageId: v.id("_storage"),
     title: v.optional(v.string()),
     workingSpaceId: v.optional(v.id("workingSpaces")),
+    notesTableId: v.optional(v.id("notesTables")),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
@@ -21,13 +22,140 @@ export const sendPdf = mutation({
       throw new Error("Unauthenticated");
     }
 
-    await ctx.db.insert("pdfs", {
+    if (args.workingSpaceId) {
+      const workspace = await ctx.db.get(args.workingSpaceId);
+      if (!workspace || workspace.userId !== userId) {
+        throw new Error("Workspace not found or not authorized");
+      }
+    }
+
+    if (args.notesTableId) {
+      const table = await ctx.db.get(args.notesTableId);
+      if (!table) {
+        throw new Error("Table not found");
+      }
+
+      if (
+        args.workingSpaceId &&
+        table.workingSpaceId !== args.workingSpaceId
+      ) {
+        throw new Error("Table does not belong to the provided workspace");
+      }
+    }
+
+    const pdfId = await ctx.db.insert("pdfs", {
       storageId: args.storageId,
       userId,
       workingSpaceId: args.workingSpaceId,
+      notesTableId: args.notesTableId,
       title: args.title,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
+
+    return pdfId;
+  },
+});
+
+export const getPdfsByTableId = query({
+  args: {
+    notesTableId: v.id("notesTables"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const table = await ctx.db.get(args.notesTableId);
+    if (!table) {
+      throw new Error("Table not found");
+    }
+
+    const workspace = await ctx.db.get(table.workingSpaceId);
+    if (!workspace || workspace.userId !== userId) {
+      throw new Error("Workspace not found or not authorized");
+    }
+
+    const pdfs = await ctx.db
+      .query("pdfs")
+      .withIndex("by_notesTableId", (q) =>
+        q.eq("notesTableId", args.notesTableId),
+      )
+      .order("desc")
+      .collect();
+
+    return Promise.all(
+      pdfs.map(async (pdf) => ({
+        ...pdf,
+        fileUrl: await ctx.storage.getUrl(pdf.storageId),
+      })),
+    );
+  },
+});
+
+export const getPdfById = query({
+  args: {
+    _id: v.id("pdfs"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const pdf = await ctx.db.get(args._id);
+    if (!pdf || pdf.userId !== userId) {
+      throw new Error("PDF not found or not authorized");
+    }
+
+    return {
+      ...pdf,
+      fileUrl: await ctx.storage.getUrl(pdf.storageId),
+    };
+  },
+});
+
+export const updatePdf = mutation({
+  args: {
+    _id: v.id("pdfs"),
+    title: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const pdf = await ctx.db.get(args._id);
+    if (!pdf || pdf.userId !== userId) {
+      throw new Error("PDF not found or not authorized");
+    }
+
+    await ctx.db.patch(args._id, {
+      title: args.title,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const deletePdf = mutation({
+  args: {
+    _id: v.id("pdfs"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const pdf = await ctx.db.get(args._id);
+    if (!pdf || pdf.userId !== userId) {
+      throw new Error("PDF not found or not authorized");
+    }
+
+    await ctx.storage.delete(pdf.storageId);
+    await ctx.db.delete(args._id);
+    return args._id;
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -61,10 +61,12 @@ export default defineSchema({
     storageId: v.id("_storage"),
     userId: v.id("users"),
     workingSpaceId: v.optional(v.id("workingSpaces")),
+    notesTableId: v.optional(v.id("notesTables")),
     title: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })
     .index("by_userId", ["userId"])
-    .index("by_workingSpaceId", ["workingSpaceId"]),
+    .index("by_workingSpaceId", ["workingSpaceId"])
+    .index("by_notesTableId", ["notesTableId"]),
 });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.1.9",
     "@ai-sdk/react": "^1.1.10",
+    "@anaralabs/lector": "^3.12.0",
     "@auth/core": "^0.37.0",
     "@convex-dev/auth": "^0.0.77",
     "@elevenlabs/react": "^0.12.3",
@@ -86,6 +87,7 @@
     "next-themes": "^0.4.6",
     "nextjs-progressbar": "^0.0.16",
     "novel": "^1.0.2",
+    "pdfjs-dist": "^5.7.284",
     "react": "^19.0.0",
     "react-ai": "^0.16.3",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## what changed

**pdf support in workspace**
- pdfs now live alongside notes in each table  fetched, displayed, and sorted together by `updatedAt`
- added `PdfGridCard` and `PdfListCard` components that match the existing note card patterns (grid/list views, mobile fallback to grid)
- `PdfCardMenu` handles open, open original file, and delete with a confirmation dialog
- double-click to rename works on both card variants, same as notes

**new create button**
- replaced the old single "new note" button with a split `WorkingspaceNewDropdownBtn`
- primary action is either "new note" or "upload pdf"  it remembers your last choice via `localStorage`
- pdf upload goes through convex storage: generates an upload url → posts the file → saves the record

**backend (convex)**
- `pdfs` schema now has a `notesTableId` field and a matching index so pdfs can be scoped to a table
- added `getPdfsByTableId`, `getPdfById`, `updatePdf`, `deletePdf` queries/mutations
- `sendPdf` now validates workspace + table ownership before inserting
- `deleteTable` now cleans up pdfs (storage + db records) when a table is deleted
- added `getOrCreateTable` mutation for upsert-style table creation

**layout & ui fixes**
- pdf routes (`/home/[id]/pdf/...`) skip the scroll container padding and top fade  the pdf viewer needs the full height
- `GlobalFolderDropUpload` added to `HomeClientLayout` (drop-to-upload support)
- breadcrumb now renders "PDF" correctly for the pdf path segment
- search placeholder updated to "search notes and uploads..."
- empty state copy updated to mention uploads
- added `@anaralabs/lector` and `pdfjs-dist` for pdf rendering

**small polish**
- fixed missing newline at end of `globals.css`
- added `::selection` styles scoped to `.pdf-viewer-shell` so text selection color matches the theme in the pdf viewer
- toast and dialog close button spacing/style tweaks
- destructive toast now uses card background instead of red bg for a softer look