### PR TITLE
pdf pinning, thumbnails panel, and sidebar uploads

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -2,15 +2,12 @@
 import {
   Calendar,
   Check,
-  ExternalLink,
   FileText,
   LayoutGrid,
   List,
-  MoreVertical,
   Search,
   ChevronLeft,
   ChevronRight,
-  Trash2,
   X,
 } from "lucide-react";
 import { useMediaQuery } from "react-responsive";
@@ -24,6 +21,7 @@ import { z } from "zod";
 import MaxWContainer from "@/components/ui/MaxWContainer";
 import CreateTableBtn from "@/components/home-components/CreateTableBtn";
 import CreateNoteBtn from "@/components/home-components/CreateNoteBtn";
+import PdfSettings from "@/components/home-components/PdfSettings";
 import TableSettings from "@/components/home-components/TableSettings";
 import NoteSettings from "@/components/home-components/NoteSettings";
 import TablesNotFound from "@/components/home-components/TablesNotFound";
@@ -62,13 +60,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { cn, formatTableName } from "@/lib/utils";
 import {
   extractTextFromTiptap as parseTiptapContentExtractText,
@@ -131,6 +122,7 @@ interface PdfItem {
   _id: Id<"pdfs">;
   storageId: Id<"_storage">;
   title?: string;
+  favorite?: boolean;
   userId?: Id<"users">;
   workingSpaceId?: Id<"workingSpaces">;
   notesTableId?: Id<"notesTables">;
@@ -899,7 +891,12 @@ export function NotesDroppableContainer({
     );
     const notDeletedItems = [...noteItems, ...pdfItems]
       .filter((item) => item && !deletedItemIds.has(item._id))
-      .sort((a, b) => b.updatedAt - a.updatedAt);
+      .sort((a, b) => {
+        const aPinned = a.favorite ? 1 : 0;
+        const bPinned = b.favorite ? 1 : 0;
+        if (aPinned !== bPinned) return bPinned - aPinned;
+        return b.updatedAt - a.updatedAt;
+      });
 
     if (!searchQuery.trim()) return notDeletedItems;
     const q = searchQuery.toLowerCase();
@@ -1352,90 +1349,6 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   );
 }
 
-function PdfCardMenu({ pdf, onDelete }: PdfCardProps) {
-  const [open, setOpen] = useState(false);
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const deletePdf = useMutation(api.pdfs.deletePdf);
-  const pdfSlug = generateSlug(pdf.title || "untitled-pdf");
-  const pdfHref = `/home/${pdf.workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdf._id}`;
-
-  const handleDelete = useCallback(async () => {
-    if (onDelete) onDelete(pdf._id);
-    setIsAlertOpen(false);
-    try {
-      await deletePdf({ _id: pdf._id });
-    } catch (error) {
-      console.error("Failed to delete PDF:", error);
-    }
-  }, [deletePdf, onDelete, pdf._id]);
-
-  return (
-    <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="Trigger"
-            className="px-0.5 h-8 mt-0.5"
-            aria-label="upload-options"
-          >
-            <MoreVertical size={18} className="text-muted-foreground" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-40">
-          <DropdownMenuItem asChild>
-            <IntentPrefetchLink href={pdfHref}>
-              <ExternalLink className="h-4 w-4 text-muted-foreground" />
-              Open upload
-            </IntentPrefetchLink>
-          </DropdownMenuItem>
-          {pdf.fileUrl ? (
-            <DropdownMenuItem asChild>
-              <a href={pdf.fileUrl} target="_blank" rel="noreferrer">
-                <ExternalLink className="h-4 w-4 text-muted-foreground" />
-                Original file
-              </a>
-            </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() => {
-              setOpen(false);
-              setIsAlertOpen(true);
-            }}
-            className="text-destructive focus:text-destructive"
-          >
-            <Trash2 className="h-4 w-4" />
-            Delete upload
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
-        <AlertDialogContent className="bg-card border border-border text-card-foreground">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm Upload Deletion</AlertDialogTitle>
-            <AlertDialogDescription className="text-muted-foreground">
-              Are you sure you want to delete this upload? This action cannot be
-              undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => void handleDelete()}
-              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground border-none"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
-}
-
 function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(pdf.title || "Untitled");
@@ -1516,7 +1429,14 @@ function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
               {pdf.title || "Untitled"}
             </CardTitle>
           )}
-          <PdfCardMenu pdf={pdf} onDelete={onDelete} />
+          <PdfSettings
+            pdfId={pdf._id}
+            pdfTitle={pdf.title}
+            iconVariant="vertical_icon"
+            dropdownMenuContentAlign="start"
+            tooltipContentAlign="start"
+            onDelete={onDelete}
+          />
         </div>
       </CardHeader>
 
@@ -1646,7 +1566,15 @@ function PdfListCard({ pdf, onDelete }: PdfCardProps) {
                 <SkeletonTextAnimation className="w-20" />
               )}
             </div>
-            <PdfCardMenu pdf={pdf} onDelete={onDelete} />
+            <PdfSettings
+              pdfId={pdf._id}
+              pdfTitle={pdf.title}
+              iconVariant="vertical_icon"
+              dropdownMenuContentAlign="start"
+              tooltipContentAlign="start"
+              onDelete={onDelete}
+              btnClassName="pt-0 mr-10 mt-1.5"
+            />
             <Button
               size="sm"
               asChild

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -10,6 +10,7 @@ import {
   Root,
   Search as LectorSearch,
   TextLayer,
+  Thumbnail,
   usePdf,
   usePdfJump,
   useSearch,
@@ -58,6 +59,7 @@ type LectorSearchResult = {
 
 const ZOOM_PRESETS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
 const PDF_PAGE_GAP = 20;
+type PanelMode = "search" | "thumbnails" | null;
 
 function isFiniteRectValue(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
@@ -194,7 +196,7 @@ function SearchPanel({
 
   return (
     <aside className="flex h-full w-[290px] shrink-0 flex-col border-r border-border bg-card/95 backdrop-blur-sm">
-      <div className="border-b border-border p-3">
+      <div className="border-b border-border p-2">
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -264,6 +266,78 @@ function SearchPanel({
   );
 }
 
+function ThumbnailsPanel({ onClose }: { onClose: () => void }) {
+  const currentPage = usePdf((state) => state.currentPage);
+  const totalPages = usePdf((state) => state.pdfDocumentProxy.numPages);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const activeThumbnail = panelRef.current?.querySelector(
+      `[data-thumbnail-page="${currentPage}"]`,
+    );
+
+    if (activeThumbnail instanceof HTMLElement) {
+      activeThumbnail.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+        behavior: "smooth",
+      });
+    }
+  }, [currentPage]);
+
+  return (
+    <aside className="flex h-full w-[142px] shrink-0 flex-col border-r border-border bg-card/95 backdrop-blur-sm">
+      <div className="flex items-center justify-between border-b border-border p-2">
+        <p className="text-sm font-medium text-foreground">Pages</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0 border border-border"
+          onClick={onClose}
+          aria-label="close-thumbnails-panel"
+        >
+          <X size={16} />
+        </Button>
+      </div>
+
+      <div
+        ref={panelRef}
+        className="flex-1 overflow-y-auto overflow-x-hidden px-1 py-3 scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent"
+      >
+        <div className="flex flex-col items-center gap-2">
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+            const isActive = pageNumber === currentPage;
+
+            return (
+              <div
+                key={pageNumber}
+                data-thumbnail-page={pageNumber}
+                className="flex w-full items-start gap-2"
+              >
+                <span className="w-4 pt-1 text-right text-sm font-semibold text-muted-foreground">
+                  {pageNumber}
+                </span>
+                <div>
+                  <Thumbnail
+                    pageNumber={pageNumber}
+                    className={cn(
+                      "w-[88px] rounded-[14px] bg-transparent border border-border outline outline-1 outline-border hover:border-muted-foreground/50 hover:outline-muted-foreground/50",
+                      isActive &&
+                        "border-muted-foreground outline-muted-foreground",
+                    )}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
 function ZoomDropdown() {
   const zoom = usePdf((state) => state.zoom);
   const updateZoom = usePdf((state) => state.updateZoom);
@@ -324,15 +398,11 @@ function ZoomDropdown() {
   );
 }
 
-function PageNavigator({
-  currentPageOverride,
-}: {
-  currentPageOverride?: number;
-}) {
+function PageNavigator() {
   const currentPageFromStore = usePdf((state) => state.currentPage);
   const totalPages = usePdf((state) => state.pdfDocumentProxy.numPages);
   const { jumpToPage } = usePdfJump();
-  const currentPage = currentPageOverride ?? currentPageFromStore;
+  const currentPage = currentPageFromStore;
   const [pageInput, setPageInput] = useState(String(currentPage));
 
   useEffect(() => {
@@ -414,58 +484,7 @@ function PdfViewerContent({
   title: string;
 }) {
   const [query, setQuery] = useState("");
-  const [isSearchOpen, setIsSearchOpen] = useState(true);
-  const zoom = usePdf((state) => state.zoom);
-  const viewports = usePdf((state) => state.viewports);
-  const currentPageFromStore = usePdf((state) => state.currentPage);
-  const viewportRef = usePdf((state) => state.viewportRef);
-  const [scrollOffset, setScrollOffset] = useState(0);
-  const [viewportHeight, setViewportHeight] = useState(0);
-
-  useEffect(() => {
-    const viewport = viewportRef?.current;
-    if (!viewport) return;
-
-    const updateHeight = () => {
-      setViewportHeight(viewport.clientHeight);
-    };
-
-    updateHeight();
-
-    const observer = new ResizeObserver(() => {
-      updateHeight();
-    });
-
-    observer.observe(viewport);
-
-    return () => observer.disconnect();
-  }, [viewportRef]);
-
-  const reactiveCurrentPage = useMemo(() => {
-    if (!viewports.length || !viewportHeight || zoom <= 0) {
-      return currentPageFromStore;
-    }
-
-    const viewportCenter = scrollOffset / zoom + viewportHeight / zoom / 2;
-    let bestPage = 1;
-    let smallestDistance = Number.POSITIVE_INFINITY;
-    let pageStart = 0;
-
-    for (let index = 0; index < viewports.length; index += 1) {
-      const pageSize = viewports[index].height + PDF_PAGE_GAP;
-      const pageCenter = pageStart + pageSize / 2;
-      const distance = Math.abs(pageCenter - viewportCenter);
-
-      if (distance < smallestDistance) {
-        smallestDistance = distance;
-        bestPage = index + 1;
-      }
-
-      pageStart += pageSize;
-    }
-
-    return bestPage;
-  }, [currentPageFromStore, scrollOffset, viewportHeight, viewports, zoom]);
+  const [panelMode, setPanelMode] = useState<PanelMode>("search");
 
   return (
     <LectorSearch
@@ -475,40 +494,68 @@ function PdfViewerContent({
         </div>
       }
     >
-      <div className="relative h-full w-full">
-        <div className="pointer-events-none fixed inset-0 top-20 z-20 ">
-          <div className="pointer-events-auto mx-auto flex w-fit max-w-[calc(100%-0.5rem)] flex-wrap items-center justify-between gap-3 app-radius-md border border-border bg-card/95 px-3 py-1.5 shadow-2xl backdrop-blur-xl">
+      <div className="relative flex h-full min-h-0 w-full">
+        <div className="pointer-events-none fixed right-4 top-20 z-20 ">
+          <div className="pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-3 app-radius-md border border-border bg-card/95 px-3 py-1.5 shadow-2xl backdrop-blur-xl">
             <div className="flex items-center gap-0">
               <Button
                 type="button"
                 variant="outline"
                 size="icon"
                 className="h-8 w-8 border border-border"
-                onClick={() => setIsSearchOpen((current) => !current)}
+                onClick={() =>
+                  setPanelMode((current) =>
+                    current === "search" ? null : "search",
+                  )
+                }
                 aria-label="show-search-panel"
+                aria-pressed={panelMode === "search"}
               >
                 <Search size={16} />
               </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className={cn(
+                  "h-8 w-8 border-y border-r border-border !rounded-none",
+                  panelMode === "thumbnails" && "bg-muted text-foreground",
+                )}
+                onClick={() =>
+                  setPanelMode((current) =>
+                    current === "thumbnails" ? null : "thumbnails",
+                  )
+                }
+                aria-label="show-thumbnails-panel"
+                aria-pressed={panelMode === "thumbnails"}
+              >
+                <span className="text-[11px] font-semibold">Pg</span>
+              </Button>
               <ZoomDropdown />
             </div>
-            <PageNavigator currentPageOverride={reactiveCurrentPage} />
+            <PageNavigator />
           </div>
         </div>
 
-        {isSearchOpen ? (
+        {panelMode === "search" ? (
           <div className="absolute left-0 top-0 z-20 h-full w-[290px] max-w-[calc(100%-1.5rem)] overflow-hidden border border-border">
             <SearchPanel
               query={query}
               setQuery={setQuery}
-              onClose={() => setIsSearchOpen(false)}
+              onClose={() => setPanelMode(null)}
             />
           </div>
         ) : null}
 
+        {panelMode === "thumbnails" ? (
+          <div className="absolute left-0 top-0 z-20 h-full overflow-hidden border border-border">
+            <ThumbnailsPanel onClose={() => setPanelMode(null)} />
+          </div>
+        ) : null}
+
         <Pages
-          className="h-full w-full transition-all scroll-smooth scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent"
+          className="h-full min-h-0 w-full transition-all scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
           gap={PDF_PAGE_GAP}
-          onOffsetChange={setScrollOffset}
         >
           <Page>
             <CanvasLayer />
@@ -532,7 +579,7 @@ function PdfViewerShell({
     <Root
       source={fileUrl}
       isZoomFitWidth
-      className="pdf-viewer-shell flex flex-1 overflow-hidden rounded-none border-0 bg-background"
+      className="pdf-viewer-shell flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-none border-0 bg-background"
       loader={
         <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
           Loading PDF...
@@ -625,7 +672,10 @@ export default function PdfViewerPageClient({ pdfId }: { pdfId: Id<"pdfs"> }) {
   }
 
   return (
-    <div ref={viewerHostRef} className="flex min-h-0 flex-1">
+    <div
+      ref={viewerHostRef}
+      className="flex h-full min-h-0 w-full flex-1 overflow-hidden"
+    >
       {isViewerReady && hasMeasuredViewport ? (
         <PdfViewerShell
           fileUrl={pdf.fileUrl}

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -3,6 +3,7 @@ import {
   Notebook,
   Plus,
   Pin,
+  FileText,
   CircleUserRound,
   LogOut,
   HomeIcon,
@@ -61,6 +62,7 @@ import {
 import { Doc } from "@/convex/_generated/dataModel";
 import { Input } from "../ui/input";
 import NoteSettingsSidbar from "./NoteSettingsSidbar";
+import PdfSettingsSidebar from "./PdfSettingsSidebar";
 import WorkingSpaceSettingsSidbar from "./WorkingSpaceSettingsSidbar";
 import React from "react";
 import { ThemeToggle } from "../ThemeToggle";
@@ -538,6 +540,264 @@ const PinnedNotesList = memo(function PinnedNotesList({
   );
 });
 
+interface PinnedUploadItemProps {
+  pdf: Doc<"pdfs">;
+  pathname: string;
+  open: boolean;
+}
+
+const PinnedUploadItem = memo(
+  function PinnedUploadItem({ pdf, pathname, open }: PinnedUploadItemProps) {
+    const [isHovered, setIsHovered] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedTitle, setEditedTitle] = useState(pdf.title || "Untitled");
+    const updatePdf = useMutation(api.pdfs.updatePdf);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const pdfSlug = generateSlug(pdf.title || "untitled-pdf");
+    const pdfPath = `/home/${pdf.workingSpaceId}/pdf/${pdfSlug}`;
+    const pdfHref = `${pdfPath}?pdfId=${pdf._id}`;
+    const isActive = pathname === pdfPath;
+
+    const handleContentMouseEnter = useCallback(() => {
+      setIsHovered(true);
+    }, []);
+
+    const handleContentMouseLeave = useCallback(() => {
+      setIsHovered(false);
+    }, []);
+
+    const handleDoubleClick = useCallback(() => {
+      setIsEditing(true);
+      setEditedTitle(pdf.title || "Untitled");
+      requestAnimationFrame(() => {
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.select();
+        input.scrollLeft = 0;
+      });
+    }, [pdf.title]);
+
+    const handleInputChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        setEditedTitle(e.target.value);
+      },
+      [],
+    );
+
+    const handleInputBlur = useCallback(async () => {
+      const currentTitle = pdf.title || "Untitled";
+      const result = noteTitleSchema.safeParse(editedTitle.trim());
+
+      if (!result.success) {
+        setEditedTitle(currentTitle);
+        setIsEditing(false);
+        return;
+      }
+
+      const trimmedTitle = result.data;
+
+      if (trimmedTitle !== currentTitle) {
+        try {
+          await updatePdf({
+            _id: pdf._id,
+            title: trimmedTitle,
+          });
+        } catch (error) {
+          console.error("Error updating PDF title:", error);
+          setEditedTitle(currentTitle);
+        }
+      }
+      setIsEditing(false);
+    }, [editedTitle, pdf._id, pdf.title, updatePdf]);
+
+    const handleInputKeyPress = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+          inputRef.current?.blur();
+        } else if (e.key === "Escape") {
+          setIsEditing(false);
+          setEditedTitle(pdf.title || "Untitled");
+        }
+      },
+      [pdf.title],
+    );
+
+    const textClassName = isHovered
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
+      : "truncate flex-grow";
+
+    return (
+      <SidebarGroupContent
+        className="relative w-full flex justify-between items-center overflow-hidden group/item"
+        onMouseEnter={handleContentMouseEnter}
+        onMouseLeave={handleContentMouseLeave}
+      >
+        <SidebarMenu className="flex-1">
+          <SidebarMenuItem>
+            {isEditing ? (
+              <Input
+                ref={inputRef}
+                value={editedTitle}
+                onChange={handleInputChange}
+                onBlur={handleInputBlur}
+                onKeyDown={handleInputKeyPress}
+                aria-label="pinned upload title"
+                className="flex-1 h-8 pl-7 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+              />
+            ) : (
+              <TooltipProvider delayDuration={200} skipDelayDuration={0}>
+                <Tooltip disableHoverableContent>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="SidebarMenuButton"
+                      className={`px-2 my-0.5 h-8 group flex-1 ${
+                        isActive ? "bg-border" : ""
+                      }`}
+                      asChild
+                      onDoubleClick={handleDoubleClick}
+                    >
+                      <IntentPrefetchLink
+                        href={pdfHref}
+                        className="flex items-center gap-2 flex-grow min-w-0"
+                      >
+                        {isHovered || isActive ? (
+                          <ChevronRight
+                            size="16"
+                            className="text-muted-foreground flex-shrink-0"
+                          />
+                        ) : (
+                          <FileText
+                            size="16"
+                            className="text-muted-foreground flex-shrink-0"
+                          />
+                        )}
+                        <span className={textClassName}>
+                          {formatWorkspaceName(pdf.title || "Untitled")}
+                        </span>
+                      </IntentPrefetchLink>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={5}>
+                    {pdf.title || "Untitled"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </SidebarMenuItem>
+        </SidebarMenu>
+        <div
+          className={`absolute right-0 ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
+        >
+          <PdfSettingsSidebar pdfId={pdf._id} />
+        </div>
+      </SidebarGroupContent>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.pdf.favorite === nextProps.pdf.favorite &&
+      prevProps.pdf.title === nextProps.pdf.title &&
+      prevProps.pathname === nextProps.pathname &&
+      prevProps.open === nextProps.open
+    );
+  },
+);
+
+interface PinnedUploadsListProps {
+  favoritePdfs: Doc<"pdfs">[];
+  pathname: string;
+  open: boolean;
+  status: "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
+  loadMore: (numItems: number) => void;
+}
+
+const PinnedUploadsList = memo(function PinnedUploadsList({
+  favoritePdfs,
+  pathname,
+  open,
+  status,
+  loadMore,
+}: PinnedUploadsListProps) {
+  if (status === "LoadingFirstPage") {
+    return (
+      <SidebarGroup>
+        <SidebarGroupLabel className="text-muted-foreground flex items-center justify-between">
+          <span>Pinned Uploads</span>
+        </SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SkeletonTextAndIconAnimation
+                text_className={open ? "w-full h-5" : "hidden"}
+              />
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SkeletonTextAndIconAnimation
+                text_className={open ? "w-full h-5" : "hidden"}
+              />
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SkeletonTextAndIconAnimation
+                text_className={open ? "w-full h-5" : "hidden"}
+              />
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    );
+  }
+
+  if (favoritePdfs.length === 0) {
+    return null;
+  }
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel className="text-muted-foreground flex items-center justify-between">
+        <span>Pinned Uploads</span>
+      </SidebarGroupLabel>
+      {favoritePdfs.map((pdf) => (
+        <PinnedUploadItem
+          key={pdf._id}
+          pdf={pdf}
+          pathname={pathname}
+          open={open}
+        />
+      ))}
+
+      {favoritePdfs.length > 4 && status === "CanLoadMore" && (
+        <SidebarGroupContent>
+          <Button
+            variant="SidebarMenuButton"
+            size="sm"
+            onClick={() => loadMore(5)}
+            className="px-2 my-0.5 h-8 group flex-1"
+          >
+            <ChevronDown size="16" className=" text-muted-foreground" />
+            Show More
+          </Button>
+        </SidebarGroupContent>
+      )}
+
+      {favoritePdfs.length > 4 && status === "LoadingMore" && (
+        <SidebarGroupContent>
+          <Button
+            variant="SidebarMenuButton"
+            size="sm"
+            disabled
+            className="px-2 my-0.5 h-8 group flex-1"
+          >
+            <LoadingAnimation className="h-3 w-3" />
+            Loading...
+          </Button>
+        </SidebarGroupContent>
+      )}
+    </SidebarGroup>
+  );
+});
+
 interface WorkspaceItemProps {
   workingSpace: Doc<"workingSpaces">;
   pathname: string;
@@ -982,6 +1242,11 @@ const AppSidebar = React.memo(function AppSidebar() {
     {},
     { initialNumItems: 5 },
   );
+  const {
+    results: favoritePdfs,
+    status: favoritePdfsStatus,
+    loadMore: loadMorePdfs,
+  } = usePaginatedQuery(api.pdfs.getFavPdfs, {}, { initialNumItems: 5 });
   const createTable = useMutation(
     api.notesTables.createTable,
   ).withOptimisticUpdate((local, args) => {
@@ -1041,7 +1306,7 @@ const AppSidebar = React.memo(function AppSidebar() {
     setHasMoreBelow(
       overflow && el.scrollTop + el.clientHeight < el.scrollHeight - 8,
     );
-  }, [results?.length, getWorkingSpaces?.length]);
+  }, [results?.length, favoritePdfs?.length, getWorkingSpaces?.length]);
 
   const isSidebarLoading = useMemo(
     () => getWorkingSpaces === undefined || User === undefined,
@@ -1150,6 +1415,13 @@ const AppSidebar = React.memo(function AppSidebar() {
             open={open}
             status={status}
             loadMore={loadMore}
+          />
+          <PinnedUploadsList
+            favoritePdfs={favoritePdfs}
+            pathname={pathname}
+            open={open}
+            status={favoritePdfsStatus}
+            loadMore={loadMorePdfs}
           />
           <WorkspacesList
             getWorkingSpaces={getWorkingSpaces}

--- a/components/home-components/GlobalFolderDropUpload.tsx
+++ b/components/home-components/GlobalFolderDropUpload.tsx
@@ -176,7 +176,7 @@ export default function GlobalFolderDropUpload() {
     | undefined;
 
   const createWorkingSpace = useMutation(api.workingSpaces.createWorkingSpace);
-  const createTable = useMutation(api.notesTables.createTable);
+  const getOrCreateTable = useMutation(api.notesTables.getOrCreateTable);
   const generateUploadUrl = useMutation(api.pdfs.generateUploadUrl);
   const sendPdf = useMutation(api.pdfs.sendPdf);
 
@@ -191,7 +191,7 @@ export default function GlobalFolderDropUpload() {
     ) => {
       setIsUploading(true);
       try {
-        const tableId = await createTable({
+        const tableId = await getOrCreateTable({
           name: DEFAULT_TABLE_NAME,
           workingSpaceId,
         });
@@ -252,7 +252,7 @@ export default function GlobalFolderDropUpload() {
         setIsWorkspaceDialogOpen(false);
       }
     },
-    [createTable, generateUploadUrl, router, sendPdf, toast],
+    [generateUploadUrl, getOrCreateTable, router, sendPdf, toast],
   );
 
   const resolveSingleWorkspaceUpload = useCallback(
@@ -363,8 +363,8 @@ export default function GlobalFolderDropUpload() {
             </div>
 
             <p className="mt-2 max-w-sm text-sm text-start text-muted-foreground">
-              We&apos;ll create a new table named "{DEFAULT_TABLE_NAME}" <br />{" "}
-              and add the PDFs there.
+              We&apos;ll use the "{DEFAULT_TABLE_NAME}" table if it already
+              exists, or create it and add the PDFs there.
             </p>
           </div>
         </div>
@@ -402,7 +402,8 @@ export default function GlobalFolderDropUpload() {
                 {pendingUpload?.folderName ?? "this folder"}
               </span>
               <br />
-              We&apos;ll create a table named "{DEFAULT_TABLE_NAME}" there.
+              We&apos;ll use the "{DEFAULT_TABLE_NAME}" table there if it
+              already exists, or create it for these PDFs.
             </DialogDescription>
           </DialogHeader>
 

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -17,10 +17,13 @@ import BreadcrumbWithCustomSeparator from "@/components/home-components/Breadcru
 import GlobalFolderDropUpload from "@/components/home-components/GlobalFolderDropUpload";
 import { MobileWarning } from "@/components/ui/mobile-warning";
 import NoteSettings from "@/components/home-components/NoteSettings";
+import PdfSettings from "@/components/home-components/PdfSettings";
 import SearchDialog from "@/components/home-components/SearchDialog";
 import { usePathname, useSearchParams } from "next/navigation";
 import type { Id } from "@/convex/_generated/dataModel";
 import { parseSlug } from "@/lib/parseSlug";
+import { useQuery } from "@/cache/useQuery";
+import { api } from "@/convex/_generated/api";
 import PublicNote from "../PublicNote";
 import { motion } from "framer-motion";
 import { NOISE_PNG } from "@/lib/data";
@@ -59,8 +62,13 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
   const searchParams = useSearchParams();
   const pathSegments = pathname.split("/").filter((segment) => segment);
   const noteid = searchParams.get("id") as Id<"notes">;
+  const pdfId = searchParams.get("pdfId") as Id<"pdfs"> | null;
   const noteTitle = parseSlug(`${pathSegments[2]}`);
   const isPdfRoute = pathSegments[2] === "pdf";
+  const currentPdf = useQuery(
+    api.pdfs.getPdfById,
+    pdfId ? { _id: pdfId } : "skip",
+  );
 
   const showTopFade = scrollTop > 0;
 
@@ -82,7 +90,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         }}
       />
       <main
-        className={`relative flex flex-col flex-1 h-auto border-border bg-background transition-[margin,border-radius] duration-150 ease-linear motion-reduce:transition-none ${
+        className={`relative flex min-h-0 flex-col flex-1 border-border bg-background transition-[margin,border-radius] duration-150 ease-linear motion-reduce:transition-none ${
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
@@ -93,7 +101,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
               <BreadcrumbWithCustomSeparator />
             </div>
             <div>
-              {noteid && noteTitle && (
+              {!isPdfRoute && noteid && noteTitle && (
                 <span className=" flex justify-between items-center gap-2">
                   <PublicNote noteId={noteid} noteTitle={noteTitle} />
                   <NoteSettings
@@ -106,12 +114,23 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
                   />
                 </span>
               )}
+              {isPdfRoute && currentPdf && (
+                <span className="flex justify-between items-center gap-2">
+                  <PdfSettings
+                    pdfId={currentPdf._id}
+                    pdfTitle={currentPdf.title}
+                    iconVariant="horizontal_icon"
+                    dropdownMenuContentAlign="end"
+                    tooltipContentAlign="end"
+                  />
+                </span>
+              )}
             </div>
           </div>
         </div>
         <div
           ref={scrollContainerRef}
-          className={`flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent ${
+          className={`min-h-0 flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent ${
             isPdfRoute ? "overflow-hidden py-0" : "overflow-y-auto py-6"
           }`}
         >

--- a/components/home-components/MovePdfDialog.tsx
+++ b/components/home-components/MovePdfDialog.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import {
+  ChevronRight,
+  FileSymlink,
+  Folder,
+  FolderOpen,
+  Plus,
+  Search,
+} from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useQuery } from "@/cache/useQuery";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+import { generateSlug } from "@/lib/generateSlug";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import LoadingAnimation from "@/components/ui/LoadingAnimation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import CreateTableBtn from "./CreateTableBtn";
+import IntentPrefetchLink from "../IntentPrefetchLink";
+
+interface MovePdfDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pdf: {
+    _id: Id<"pdfs">;
+    title?: string;
+    workingSpaceId?: Id<"workingSpaces">;
+    notesTableId?: Id<"notesTables">;
+  };
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  if (!query) return <>{text}</>;
+
+  const index = text.toLowerCase().indexOf(query.toLowerCase());
+  if (index === -1) return <>{text}</>;
+
+  return (
+    <>
+      {text.slice(0, index)}
+      <span className="bg-primary/15 text-primary font-semibold">
+        {text.slice(index, index + query.length)}
+      </span>
+      {text.slice(index + query.length)}
+    </>
+  );
+}
+
+export default function MovePdfDialog({
+  open,
+  onOpenChange,
+  pdf,
+}: MovePdfDialogProps) {
+  const { toast } = useToast();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = useState<string[]>(
+    [],
+  );
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
+  const [movingTableId, setMovingTableId] = useState<string | null>(null);
+
+  const moveTargets = useQuery(api.notes.getWorkspaceTree, {
+    searchQuery: debouncedQuery || undefined,
+  }) as any[] | undefined;
+
+  const movePdf = useMutation(api.pdfs.movePdf).withOptimisticUpdate(
+    (local, args) => {
+      const currentPdf = local.getQuery(api.pdfs.getPdfById, {
+        _id: args._id,
+      });
+
+      if (!currentPdf) return;
+
+      local.setQuery(
+        api.pdfs.getPdfById,
+        { _id: args._id },
+        {
+          ...currentPdf,
+          workingSpaceId: args.targetWorkingSpaceId,
+          notesTableId: args.targetNotesTableId,
+          updatedAt: Date.now(),
+        },
+      );
+    },
+  );
+  const createWorkingSpace = useMutation(api.workingSpaces.createWorkingSpace);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setQuery("");
+    setDebouncedQuery("");
+    setExpandedWorkspaceIds(
+      pdf.workingSpaceId ? [String(pdf.workingSpaceId)] : [],
+    );
+    setIsCreatingWorkspace(false);
+    setMovingTableId(null);
+
+    const timer = setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 20);
+
+    return () => clearTimeout(timer);
+  }, [open, pdf.workingSpaceId]);
+
+  useEffect(() => {
+    if (!debouncedQuery || !moveTargets) return;
+    setExpandedWorkspaceIds(
+      moveTargets.map((workspace) => String(workspace._id)),
+    );
+  }, [debouncedQuery, moveTargets]);
+
+  const hasResults = useMemo(
+    () => (moveTargets?.length ?? 0) > 0,
+    [moveTargets],
+  );
+
+  const toggleWorkspace = (workspaceId: string) => {
+    setExpandedWorkspaceIds((prev) =>
+      prev.includes(workspaceId)
+        ? prev.filter((id) => id !== workspaceId)
+        : [...prev, workspaceId],
+    );
+  };
+
+  const handleCreateWorkspace = async () => {
+    try {
+      setIsCreatingWorkspace(true);
+      const workspaceId = await createWorkingSpace({ name: "Untitled" });
+      setExpandedWorkspaceIds((prev) =>
+        prev.includes(String(workspaceId))
+          ? prev
+          : [...prev, String(workspaceId)],
+      );
+    } catch (error) {
+      console.error("Failed to create workspace:", error);
+    } finally {
+      setIsCreatingWorkspace(false);
+    }
+  };
+
+  const handleMove = async (
+    targetWorkingSpaceId: Id<"workingSpaces">,
+    targetNotesTableId: Id<"notesTables">,
+  ) => {
+    try {
+      setMovingTableId(String(targetNotesTableId));
+      const result = await movePdf({
+        _id: pdf._id,
+        targetWorkingSpaceId,
+        targetNotesTableId,
+      });
+      onOpenChange(false);
+
+      const pdfSlug = generateSlug(result.title || pdf.title || "untitled-pdf");
+
+      toast({
+        variant: "default",
+        title: "Upload moved successfully",
+        description: "Jump straight to the file in its new location.",
+        action: (
+          <Button variant="secondary" className="px-4" size="sm" asChild>
+            <IntentPrefetchLink
+              href={`/home/${result.workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdf._id}`}
+              className="flex justify-center items-center gap-2"
+            >
+              <FileSymlink size={16} />
+              Checkout
+            </IntentPrefetchLink>
+          </Button>
+        ),
+      });
+    } catch (error) {
+      console.error("Failed to move PDF:", error);
+      toast({
+        variant: "destructive",
+        title: "Failed to move upload",
+        description: "Try again later",
+      });
+    } finally {
+      setMovingTableId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 overflow-hidden bg-muted border-border md:min-w-[500px] gap-0 shadow-2xl">
+        <DialogHeader className="px-5 pt-4 pb-3 border-b border-border">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-primary/70 mb-1">
+            Move upload
+          </p>
+          <DialogTitle className="text-[15px] font-medium text-foreground leading-snug">
+            {pdf.title || "Untitled"}
+          </DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground mt-0.5">
+            Select a destination table in this workspace or any other workspace.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-1 bg-muted">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <Search className="h-4 w-4 shrink-0 text-primary/70" />
+            <Input
+              ref={searchInputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search workspaces and tables..."
+              className="border-none px-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 text-sm bg-transparent"
+            />
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCreateWorkspace}
+            disabled={isCreatingWorkspace}
+            className="gap-1 text-xs px-2 h-8"
+          >
+            {isCreatingWorkspace ? (
+              <LoadingAnimation className="h-4 w-4 text-primary" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Workspace
+          </Button>
+        </div>
+
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
+          {moveTargets === undefined ? (
+            <div className="space-y-2 p-2">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-10 app-radius-lg bg-border animate-pulse"
+                />
+              ))}
+            </div>
+          ) : !hasResults ? (
+            <div className="flex min-h-[360px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
+              <Folder className="mb-4 h-10 w-10 text-primary/50" />
+              <p className="font-medium text-foreground">
+                {debouncedQuery
+                  ? `No targets found for "${debouncedQuery}"`
+                  : "No workspaces found"}
+              </p>
+              <p className="mt-1">
+                Create a workspace or table, then move this upload there.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {moveTargets.map((workspace) => {
+                const workspaceId = String(workspace._id);
+                const isExpanded = expandedWorkspaceIds.includes(workspaceId);
+                const tables = workspace.tables ?? [];
+                return (
+                  <div
+                    key={workspace._id}
+                    className="overflow-hidden app-radius-lg transition-colors"
+                  >
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-primary/10 hover:border-2 hover:bg-transparent"
+                      onClick={() => toggleWorkspace(workspaceId)}
+                    >
+                      <ChevronRight
+                        className={cn(
+                          "h-3.5 w-3.5 shrink-0 transition-transform text-primary/60",
+                          isExpanded && "rotate-90",
+                        )}
+                      />
+                      {isExpanded ? (
+                        <FolderOpen className="h-3.5 w-3.5 shrink-0 text-primary/80" />
+                      ) : (
+                        <Folder className="h-3.5 w-3.5 shrink-0 text-primary/60" />
+                      )}
+                      <span className="truncate text-sm font-medium text-foreground">
+                        <HighlightedText
+                          text={workspace.name || "Untitled"}
+                          query={debouncedQuery}
+                        />
+                      </span>
+                    </Button>
+
+                    {isExpanded && (
+                      <div className="space-y-0.5 px-1 py-1">
+                        {tables.length === 0 ? (
+                          <div className="flex flex-col justify-center items-center gap-2 app-radius-lg mx-2 py-3 bg-card text-xs text-muted-foreground/60 text-center">
+                            No tables in this workspace yet.
+                            <CreateTableBtn
+                              workingSpaceId={workspace._id}
+                              variant="secondary"
+                              size="sm"
+                              label="Table"
+                              className="h-8 shrink-0 gap-1 px-2 text-muted-foreground"
+                              onCreated={() => {
+                                setExpandedWorkspaceIds((prev) =>
+                                  prev.includes(workspaceId)
+                                    ? prev
+                                    : [...prev, workspaceId],
+                                );
+                              }}
+                            />
+                          </div>
+                        ) : (
+                          tables.map((table: any) => {
+                            const isCurrentTarget =
+                              pdf.workingSpaceId === workspace._id &&
+                              pdf.notesTableId === table._id;
+                            const isMoving =
+                              movingTableId === String(table._id);
+
+                            return (
+                              <button
+                                key={table._id}
+                                type="button"
+                                onClick={() =>
+                                  handleMove(workspace._id, table._id)
+                                }
+                                disabled={isCurrentTarget || isMoving}
+                                className={cn(
+                                  "flex w-full items-center justify-between app-radius-lg px-3 py-2 text-left transition-colors",
+                                  isCurrentTarget
+                                    ? "cursor-not-allowed bg-primary/10"
+                                    : "hover:bg-primary/10",
+                                )}
+                              >
+                                <div className="flex min-w-0 items-center gap-2">
+                                  <span className="ml-4 h-px w-3 bg-muted-foreground/60" />
+                                  <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+                                  <span className="truncate text-[13px] font-medium">
+                                    <HighlightedText
+                                      text={table.name || "Untitled"}
+                                      query={debouncedQuery}
+                                    />
+                                  </span>
+                                </div>
+
+                                <span className="shrink-0 text-[11px] text-muted-foreground/60">
+                                  {isMoving ? (
+                                    <LoadingAnimation className="h-4 w-4 text-primary" />
+                                  ) : isCurrentTarget ? (
+                                    <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
+                                      current
+                                    </span>
+                                  ) : (
+                                    <span className="text-[11px] text-muted-foreground/50 group-hover:text-primary/60">
+                                      move
+                                    </span>
+                                  )}
+                                </span>
+                              </button>
+                            );
+                          })
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import {
+  Download,
+  ExternalLink,
+  FileDown,
+  FileOutput,
+  Pin,
+} from "lucide-react";
+import { FaEllipsis, FaEllipsisVertical, FaRegTrashCan } from "react-icons/fa6";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import { useQuery } from "@/cache/useQuery";
+import { cn } from "@/lib/utils";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import MovePdfDialog from "./MovePdfDialog";
+
+interface PdfSettingsProps {
+  pdfId: Id<"pdfs">;
+  pdfTitle?: string;
+  iconVariant: "vertical_icon" | "horizontal_icon";
+  btnClassName?: string;
+  dropdownMenuContentAlign: "end" | "start";
+  tooltipContentAlign: "end" | "start";
+  onDelete?: (pdfId: Id<"pdfs">) => void;
+}
+
+const PDF_TITLE_MAX_LENGTH = 55;
+
+const formatPdfTimestamp = (timestamp?: number) => {
+  if (!timestamp) return "";
+
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+export default function PdfSettings({
+  pdfId,
+  pdfTitle,
+  iconVariant,
+  btnClassName,
+  dropdownMenuContentAlign,
+  tooltipContentAlign,
+  onDelete,
+}: PdfSettingsProps) {
+  const [inputValue, setInputValue] = useState(pdfTitle || "Untitled");
+  const [open, setOpen] = useState(false);
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });
+  const updatePdf = useMutation(api.pdfs.updatePdf);
+  const deletePdf = useMutation(api.pdfs.deletePdf);
+
+  useEffect(() => {
+    setInputValue(pdfTitle || "Untitled");
+  }, [pdfTitle]);
+
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 10);
+    }
+  }, [open]);
+
+  const handleBlur = useCallback(async () => {
+    const trimmedValue = inputValue.trim();
+    const isValid =
+      trimmedValue.length > 0 && trimmedValue.length <= PDF_TITLE_MAX_LENGTH;
+
+    if (!isValid) {
+      setInputValue(pdfTitle || "Untitled");
+      return;
+    }
+
+    if (trimmedValue !== (pdfTitle || "Untitled")) {
+      try {
+        await updatePdf({ _id: pdfId, title: trimmedValue });
+      } catch (error) {
+        console.error("Error updating PDF title:", error);
+        setInputValue(pdfTitle || "Untitled");
+      }
+    }
+
+    setInputValue(trimmedValue);
+  }, [inputValue, pdfId, pdfTitle, updatePdf]);
+
+  const handleDelete = useCallback(async () => {
+    if (onDelete) onDelete(pdfId);
+    setIsAlertOpen(false);
+    try {
+      await deletePdf({ _id: pdfId });
+    } catch (error) {
+      console.error("Failed to delete PDF:", error);
+    }
+  }, [deletePdf, onDelete, pdfId]);
+
+  const handleFavoritePin = useCallback(async () => {
+    if (!pdf) return;
+    await updatePdf({
+      _id: pdfId,
+      favorite: !pdf.favorite,
+    });
+  }, [pdf, pdfId, updatePdf]);
+
+  const handleDownloadOriginal = useCallback(() => {
+    if (!pdf?.fileUrl) return;
+
+    const link = document.createElement("a");
+    link.href = pdf.fileUrl;
+    link.download = `${pdf.title || "upload"}.pdf`;
+    link.target = "_blank";
+    link.rel = "noreferrer";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, [pdf]);
+
+  if (!pdf) return null;
+
+  const createdAtText = formatPdfTimestamp(pdf.createdAt);
+  const updatedAtText = formatPdfTimestamp(pdf.updatedAt);
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <TooltipProvider>
+          <Tooltip open={isTooltipOpen}>
+            <DropdownMenuTrigger asChild>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="Trigger"
+                  className={cn("px-0.5 h-8 mt-0.5", btnClassName)}
+                  onMouseEnter={() => setIsTooltipOpen(true)}
+                  onMouseLeave={() => setIsTooltipOpen(false)}
+                  aria-label="upload-options"
+                >
+                  {iconVariant === "vertical_icon" ? (
+                    <FaEllipsisVertical
+                      size={18}
+                      className="text-muted-foreground"
+                    />
+                  ) : (
+                    <FaEllipsis size={22} className="text-muted-foreground" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+            </DropdownMenuTrigger>
+            <TooltipContent
+              side="bottom"
+              alignOffset={1}
+              align={tooltipContentAlign}
+            >
+              Rename, Pin, Move, Download, Delete
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        <DropdownMenuContent
+          side="bottom"
+          align={dropdownMenuContentAlign}
+          alignOffset={1}
+          className="w-48 pb-1.5 px-1.5 pt-0 space-y-4 text-muted-foreground z-[10000]"
+        >
+          <DropdownMenuGroup className="relative">
+            <Label>Rename :</Label>
+            <Input
+              type="text"
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              onBlur={() => void handleBlur()}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void handleBlur();
+                  setOpen(false);
+                }
+              }}
+              placeholder="Rename your upload"
+              className="text-foreground h-8"
+              ref={inputRef}
+            />
+          </DropdownMenuGroup>
+
+          <DropdownMenuGroup>
+            <Button
+              variant="SidebarMenuButton"
+              className="w-full h-8 px-2 text-sm"
+              onClick={() => void handleFavoritePin()}
+              aria-label="pin-upload"
+            >
+              <Pin size={14} className="text-muted-foreground" />
+              {pdf.favorite ? "Unpin Upload" : "Pin Upload"}
+            </Button>
+
+            <Button
+              variant="SidebarMenuButton"
+              className="w-full h-8 px-2 text-sm"
+              onClick={() => {
+                setOpen(false);
+                setIsMoveDialogOpen(true);
+              }}
+              aria-label="move-upload"
+            >
+              <FileOutput size={14} className="text-muted-foreground" />
+              Move Upload
+            </Button>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="w-full h-8 px-2 text-sm flex items-center gap-2 text-foreground">
+                <Download size={14} className="text-muted-foreground" />
+                Download
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-48">
+                <DropdownMenuItem
+                  className="text-sm cursor-pointer flex items-center gap-2"
+                  onClick={handleDownloadOriginal}
+                >
+                  <FileDown size={16} className="text-muted-foreground" />
+                  PDF file
+                </DropdownMenuItem>
+                {pdf.fileUrl ? (
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={pdf.fileUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-sm cursor-pointer flex items-center gap-2"
+                    >
+                      <ExternalLink
+                        size={16}
+                        className="text-muted-foreground"
+                      />
+                      Open original
+                    </a>
+                  </DropdownMenuItem>
+                ) : null}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSeparator />
+            <Button
+              variant="SidebarMenuButton_destructive"
+              className="w-full h-8 px-2 text-sm"
+              onClick={() => {
+                setOpen(false);
+                setIsAlertOpen(true);
+              }}
+              aria-label="delete-upload"
+            >
+              <FaRegTrashCan size={14} className="text-current" />
+              Delete
+            </Button>
+
+            <DropdownMenuSeparator />
+            <div className="px-2 pt-1 text-[10px] leading-4 text-muted-foreground/80">
+              <p>Last updated {updatedAtText}</p>
+              <p>Created {createdAtText}</p>
+            </div>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
+        <AlertDialogContent className="bg-card border border-border text-card-foreground">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Upload Deletion</AlertDialogTitle>
+            <AlertDialogDescription className="text-muted-foreground">
+              Are you sure you want to delete this upload? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => void handleDelete()}
+              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground border-none"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <MovePdfDialog
+        open={isMoveDialogOpen}
+        onOpenChange={setIsMoveDialogOpen}
+        pdf={{
+          _id: pdfId,
+          title: pdf.title,
+          workingSpaceId: pdf.workingSpaceId,
+          notesTableId: pdf.notesTableId,
+        }}
+      />
+    </>
+  );
+}

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { useQuery } from "@/cache/useQuery";
+import { Button } from "@/components/ui/button";
+import { Pin, PinOff, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PdfSettingsSidebarProps {
+  pdfId: Id<"pdfs">;
+  containerClassName?: string;
+}
+
+export default function PdfSettingsSidebar({
+  pdfId,
+  containerClassName,
+}: PdfSettingsSidebarProps) {
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const updatePdf = useMutation(api.pdfs.updatePdf);
+  const deletePdf = useMutation(api.pdfs.deletePdf);
+  const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });
+
+  const handleFavoritePin = async () => {
+    if (!pdf) return;
+    await updatePdf({
+      _id: pdfId,
+      favorite: !pdf.favorite,
+    });
+  };
+
+  const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    try {
+      await deletePdf({ _id: pdfId });
+    } catch (error) {
+      console.error("Failed to delete PDF:", error);
+    } finally {
+      setIsAlertOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <TooltipProvider delayDuration={200} skipDelayDuration={0}>
+        <div
+          className={cn(
+            "flex justify-end items-center px-1",
+            containerClassName,
+          )}
+        >
+          <Tooltip disableHoverableContent>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={handleFavoritePin}
+                variant="SidebarMenuButton"
+                className="px-2 h-7 hover:bg-card"
+                aria-label="pin-upload"
+              >
+                {pdf?.favorite ? (
+                  <PinOff size={16} className="text-muted-foreground" />
+                ) : (
+                  <Pin size={16} className="text-muted-foreground" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={5}>
+              {pdf?.favorite ? "Unpin upload" : "Pin upload"}
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip disableHoverableContent>
+            <TooltipTrigger asChild>
+              <Button
+                onMouseDown={() => setIsAlertOpen(true)}
+                variant="SidebarMenuButton_destructive"
+                className="px-2 h-7 hover:bg-card"
+                aria-label="delete-upload"
+              >
+                <X size={16} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={5}>
+              Delete upload
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+
+      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
+        <AlertDialogContent className="bg-card border border-border text-card-foreground">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Upload Deletion</AlertDialogTitle>
+            <AlertDialogDescription className="text-muted-foreground">
+              Are you sure you want to delete this upload? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground border-none"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/convex/pdfs.ts
+++ b/convex/pdfs.ts
@@ -1,6 +1,7 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
+import { paginationOptsValidator } from "convex/server";
 
 export const generateUploadUrl = mutation({
   args: {},
@@ -49,6 +50,7 @@ export const sendPdf = mutation({
       workingSpaceId: args.workingSpaceId,
       notesTableId: args.notesTableId,
       title: args.title,
+      favorite: false,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
@@ -116,10 +118,28 @@ export const getPdfById = query({
   },
 });
 
+export const getFavPdfs = query({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, { paginationOpts }) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    return await ctx.db
+      .query("pdfs")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("favorite"), true))
+      .order("desc")
+      .paginate(paginationOpts);
+  },
+});
+
 export const updatePdf = mutation({
   args: {
     _id: v.id("pdfs"),
-    title: v.string(),
+    title: v.optional(v.string()),
+    favorite: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
@@ -133,9 +153,56 @@ export const updatePdf = mutation({
     }
 
     await ctx.db.patch(args._id, {
-      title: args.title,
+      title: args.title ?? pdf.title,
+      favorite: args.favorite ?? pdf.favorite,
       updatedAt: Date.now(),
     });
+  },
+});
+
+export const movePdf = mutation({
+  args: {
+    _id: v.id("pdfs"),
+    targetWorkingSpaceId: v.id("workingSpaces"),
+    targetNotesTableId: v.id("notesTables"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const pdf = await ctx.db.get(args._id);
+    if (!pdf || pdf.userId !== userId) {
+      throw new Error("PDF not found or not authorized");
+    }
+
+    const targetWorkspace = await ctx.db.get(args.targetWorkingSpaceId);
+    if (!targetWorkspace || targetWorkspace.userId !== userId) {
+      throw new Error("Target workspace not found or not authorized");
+    }
+
+    const targetTable = await ctx.db.get(args.targetNotesTableId);
+    if (!targetTable) {
+      throw new Error("Target table not found");
+    }
+
+    if (targetTable.workingSpaceId !== args.targetWorkingSpaceId) {
+      throw new Error("Target table does not belong to this workspace");
+    }
+
+    await ctx.db.patch(args._id, {
+      workingSpaceId: args.targetWorkingSpaceId,
+      notesTableId: args.targetNotesTableId,
+      updatedAt: Date.now(),
+    });
+
+    return {
+      pdfId: args._id,
+      workingSpaceId: args.targetWorkingSpaceId,
+      notesTableId: args.targetNotesTableId,
+      title: pdf.title,
+    };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -63,6 +63,7 @@ export default defineSchema({
     workingSpaceId: v.optional(v.id("workingSpaces")),
     notesTableId: v.optional(v.id("notesTables")),
     title: v.optional(v.string()),
+    favorite: v.optional(v.boolean()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })


### PR DESCRIPTION
## what changed (fun stuff)

**pinned pdfs**
- added `favorite` field to the pdfs schema so uploads can be pinned just like notes
- `updatePdf` now accepts `favorite` as an optional arg
- pinned uploads bubble to the top of the workspace list (sorted before recency)
- new `PinnedUploadsList` + `PinnedUploadItem` components in the sidebar, with the same double-click-to-rename and lazy-load-more behavior as pinned notes
- `getFavPdfs` paginated query fetches only the user's pinned pdfs

**pdf settings panel**
- pulled the old inline `PdfCardMenu` out and replaced it with a shared `PdfSettings` component used in three places: grid card, list card, and the top header bar when you're viewing a pdf
- `PdfSettingsSidebar` used in the sidebar pinned item
- header bar now shows pdf settings (pin, rename, delete, etc.) when on a pdf route, matching how note settings work

**thumbnails panel in the pdf viewer**
- new `ThumbnailsPanel` sidebar in the viewer, toggled with a "Pg" button in the toolbar
- auto-scrolls to the active page thumbnail as you navigate
- panel mode is now a union type (`"search" | "thumbnails" | null`) instead of a boolean, so search and thumbnails are mutually exclusive
- removed the old manual scroll-offset-based page tracking  `usePdf` state handles current page directly now
- toolbar moved to `fixed right-4 top-20` so it doesn't overlap the side panels

**drop upload idempotency**
- `GlobalFolderDropUpload` now calls `getOrCreateTable` instead of `createTable`, so dropping files into a workspace that already has a "uploads" table won't create a duplicate
- dialog copy updated to reflect the upsert behavior

**layout fixes**
- main content area gets `min-h-0` so the pdf viewer can fill the full height without overflowing
- note settings in the header are hidden on pdf routes (pdf settings show instead)
- `PdfSettingsSidebar` added to `AppSidebar` imports
- added `movePdf` mutation for moving a pdf between workspaces/tables (backend only for now)