### PR TITLE
pdf search, highlight fix, and ui polish

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1445,9 +1445,6 @@ function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
           <FileText className="h-5 w-5 text-primary" />
           <span>PDF upload</span>
         </div>
-        <p className="text-sm text-muted-foreground line-clamp-3 mt-4">
-          Open this file in a new tab to read or review it.
-        </p>
       </CardContent>
 
       <CardFooter className="py-4 flex items-center justify-between border-t border-border">
@@ -1465,9 +1462,7 @@ function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
           className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] absolute bottom-0 right-0 h-9 px-2 text-xs"
           aria-label="open-upload"
         >
-          <IntentPrefetchLink href={pdfHref}>
-            Open
-          </IntentPrefetchLink>
+          <IntentPrefetchLink href={pdfHref}>Open</IntentPrefetchLink>
         </Button>
       </CardFooter>
     </Card>

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -211,7 +211,7 @@ function SearchPanel({
             type="button"
             variant="outline"
             size="icon"
-            className="h-8 px-0.5 shrink-0 border border-border"
+            className="h-8 px-0.5 shrink-0 !border-0  bg-transparent"
             onClick={onClose}
             aria-label="close-search-panel"
           >
@@ -286,14 +286,14 @@ function ThumbnailsPanel({ onClose }: { onClose: () => void }) {
   }, [currentPage]);
 
   return (
-    <aside className="flex h-full w-[142px] shrink-0 flex-col border-r border-border bg-card/95 backdrop-blur-sm">
+    <aside className="flex h-full w-[142px] shrink-0 flex-col border-l-0 border-border bg-card/95 backdrop-blur-sm">
       <div className="flex items-center justify-between border-b border-border p-2">
         <p className="text-sm font-medium text-foreground">Pages</p>
         <Button
           type="button"
           variant="outline"
           size="icon"
-          className="h-8 w-8 shrink-0 border border-border"
+          className="h-8 w-8 shrink-0 !border-0 bg-transparent "
           onClick={onClose}
           aria-label="close-thumbnails-panel"
         >
@@ -303,7 +303,7 @@ function ThumbnailsPanel({ onClose }: { onClose: () => void }) {
 
       <div
         ref={panelRef}
-        className="flex-1 overflow-y-auto overflow-x-hidden px-1 py-3 scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent"
+        className="flex-1 overflow-y-auto overflow-x-hidden px-2 py-3 scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent"
       >
         <div className="flex flex-col items-center gap-2">
           {Array.from({ length: totalPages }, (_, index) => {
@@ -495,8 +495,8 @@ function PdfViewerContent({
       }
     >
       <div className="relative flex h-full min-h-0 w-full">
-        <div className="pointer-events-none fixed right-4 top-20 z-20 ">
-          <div className="pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-3 app-radius-md border border-border bg-card/95 px-3 py-1.5 shadow-2xl backdrop-blur-xl">
+        <div className="pointer-events-none fixed right-2.5 top-[4.4rem] z-20">
+          <div className="pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-3 app-radius-md border border-border bg-card/95 px-3 py-1.5 backdrop-blur-xl">
             <div className="flex items-center gap-0">
               <Button
                 type="button"
@@ -518,7 +518,7 @@ function PdfViewerContent({
                 variant="outline"
                 size="icon"
                 className={cn(
-                  "h-8 w-8 border-y border-r border-border !rounded-none",
+                  "h-8 w-8 border-y !border-l-0 border-border !rounded-none",
                   panelMode === "thumbnails" && "bg-muted text-foreground",
                 )}
                 onClick={() =>
@@ -598,6 +598,17 @@ export default function PdfViewerPageClient({ pdfId }: { pdfId: Id<"pdfs"> }) {
   const viewerHostRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (!pdf?.title) return;
+
+    const originalTitle = document.title;
+    document.title = `${pdf.title} - Notevo`;
+
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [pdf?.title]);
+
+  useEffect(() => {
     setIsViewerReady(false);
     const frame = window.requestAnimationFrame(() => {
       setIsViewerReady(true);
@@ -646,7 +657,7 @@ export default function PdfViewerPageClient({ pdfId }: { pdfId: Id<"pdfs"> }) {
   if (pdf === undefined) {
     return (
       <div className="flex h-full max-w-full min-h-0 flex-col px-0 py-0 mx-0">
-        <div className="flex-1 rounded-2xl border border-border bg-card animate-pulse" />
+        <div className="flex-1 rounded-none border border-border bg-card animate-pulse" />
       </div>
     );
   }

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -94,8 +94,8 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
-        <div className="z-[10] relative w-full flex items-center justify-start px-4 gap-3 mx-auto rounded-tl-lg border-none py-2.5 ">
-          <div className="flex justify-between items-center w-full">
+        <div className="z-[10] relative w-full flex min-h-12 items-center justify-start  gap-3 mx-auto bg-background rounded-tl-lg border-none ">
+          <div className="  flex justify-between items-center w-full px-4 py-2 ">
             <div className="flex justify-start items-center gap-3">
               {(!open || isMobile) && <SidebarTrigger />}
               <BreadcrumbWithCustomSeparator />
@@ -138,7 +138,9 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
             <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: showTopFade ? 1 : 0 }}
-              transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
+              transition={
+                showTopFade ? fadeTransition.show : fadeTransition.hide
+              }
               className="sticky -top-12 left-0 w-full h-28 bg-gradient-to-b from-background from-25% to-transparent to-100% z-[5] pointer-events-none -mb-32"
               aria-hidden
             />

--- a/components/home-components/NoteContextMenu.tsx
+++ b/components/home-components/NoteContextMenu.tsx
@@ -339,7 +339,7 @@ export default function NoteContextMenu({
                   }}
                   aria-label="delete-note"
                 >
-                  <FaRegTrashCan size={14} className="text-current" />
+                  <FaRegTrashCan size={14} className="text-muted-foreground" />
                   Delete
                 </Button>
 

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -377,7 +377,7 @@ export default function NoteSettings({
               onClick={initiateDelete}
               aria-label="delete-note"
             >
-              <FaRegTrashCan size={14} className="text-current" />
+              <FaRegTrashCan size={14} className="text-muted-foreground" />
               Delete
             </Button>
 

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -288,7 +288,7 @@ export default function PdfSettings({
               }}
               aria-label="delete-upload"
             >
-              <FaRegTrashCan size={14} className="text-current" />
+              <FaRegTrashCan size={14} className="text-muted-foreground" />
               Delete
             </Button>
 

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDownUp,
   Undo2,
   Clock,
+  File,
   FileText,
   Search,
   ChevronRight,
@@ -72,15 +73,37 @@ function SearchLoadingSkeleton() {
 
 function HighlightedText({ text, query }: { text: string; query: string }) {
   if (!query) return <>{text}</>;
-  const index = text.toLowerCase().indexOf(query.toLowerCase());
-  if (index === -1) return <>{text}</>;
+
+  const normalizedQuery = query.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (!normalizedQuery) return <>{text}</>;
+
+  const chars = Array.from(text);
+  const normalizedChars: string[] = [];
+  const originalIndexes: number[] = [];
+
+  chars.forEach((char, index) => {
+    const normalizedChar = char.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (!normalizedChar) return;
+    normalizedChars.push(normalizedChar);
+    originalIndexes.push(index);
+  });
+
+  const normalizedText = normalizedChars.join("");
+  const normalizedIndex = normalizedText.indexOf(normalizedQuery);
+
+  if (normalizedIndex === -1) return <>{text}</>;
+
+  const start = originalIndexes[normalizedIndex];
+  const end =
+    originalIndexes[normalizedIndex + normalizedQuery.length - 1] ?? start;
+
   return (
     <>
-      {text.slice(0, index)}
+      {text.slice(0, start)}
       <span className="text-secondary bg-secondary-foreground font-extrabold">
-        {text.slice(index, index + query.length)}
+        {text.slice(start, end + 1)}
       </span>
-      {text.slice(index + query.length)}
+      {text.slice(end + 1)}
     </>
   );
 }
@@ -123,6 +146,56 @@ function NoteItem({
   );
 }
 
+function buildPdfSlug(title?: string) {
+  if (!title) return "untitled-pdf";
+
+  return (
+    title
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "untitled-pdf"
+  );
+}
+
+function PdfItem({
+  pdf,
+  onClick,
+  isSelected,
+  query,
+  onIntentPrefetch,
+  indented = false,
+}: any) {
+  const href = `/home/${pdf.workingSpaceId}/pdf/${pdf.slug}?pdfId=${pdf._id}`;
+  return (
+    <div
+      onClick={onClick}
+      onPointerEnter={() => onIntentPrefetch?.(href)}
+      onMouseEnter={() => onIntentPrefetch?.(href)}
+      onFocus={() => onIntentPrefetch?.(href)}
+      onTouchStart={() => onIntentPrefetch?.(href)}
+      className={cn(
+        "flex items-center gap-3 mb-px py-1.5 px-2 cursor-pointer app-radius-lg transition-all",
+        indented && "ml-7",
+        isSelected ? "bg-border" : "hover:bg-border",
+      )}
+    >
+      <div className="border-border bg-muted text-muted-foreground flex h-7 w-7 shrink-0 items-center justify-center app-radius-lg border transition-colors">
+        <File size={14} />
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <p className="text-sm text-foreground font-medium truncate transition-colors">
+          <HighlightedText text={pdf.title || "Untitled"} query={query} />
+        </p>
+      </div>
+      <div className="flex items-center gap-1 text-xs shrink-0 text-muted-foreground">
+        <Clock className="h-3 w-3" />
+        <span>{getRelativeTime(new Date(pdf.createdAt))}</span>
+      </div>
+    </div>
+  );
+}
+
 // Tables are now collapsible — each manages its own open/close state
 function TableSection({
   table,
@@ -134,6 +207,15 @@ function TableSection({
 }: any) {
   const [isExpanded, setIsExpanded] = useState(true);
   const notes: any[] = table.notes ?? [];
+  const pdfs: any[] = table.pdfs ?? [];
+  const items = [
+    ...notes.map((note) => ({ ...note, kind: "note" as const })),
+    ...pdfs.map((pdf) => ({
+      ...pdf,
+      kind: "pdf" as const,
+      slug: buildPdfSlug(pdf.title),
+    })),
+  ].sort((a, b) => b.createdAt - a.createdAt);
 
   return (
     <div>
@@ -161,26 +243,44 @@ function TableSection({
       {isExpanded && (
         <div className=" relative ">
           <div className=" ml-5 absolute top-0 left-0 h-full w-px bg-muted-foreground/30" />
-          {notes.length === 0 ? (
+          {items.length === 0 ? (
             <p className="text-[11px] text-muted-foreground/40 text-center py-2 ml-6">
-              {query ? `No notes match "${query}" here.` : "No notes here."}
+              {query
+                ? `No notes or uploads match "${query}" here.`
+                : "No notes or uploads here."}
             </p>
           ) : (
-            notes.map((note: any) => (
-              <NoteItem
-                key={note._id}
-                note={{
-                  ...note,
-                  workingSpaceName: workspace.name,
-                  tableName: table.name,
-                }}
-                onClick={() => onNoteClick(note)}
-                isSelected={selectedNoteId === String(note._id)}
-                query={query}
-                onIntentPrefetch={onIntentPrefetch}
-                indented
-              />
-            ))
+            items.map((item: any) =>
+              item.kind === "pdf" ? (
+                <PdfItem
+                  key={item._id}
+                  pdf={{
+                    ...item,
+                    workingSpaceName: workspace.name,
+                    tableName: table.name,
+                  }}
+                  onClick={() => onNoteClick(item)}
+                  isSelected={selectedNoteId === String(item._id)}
+                  query={query}
+                  onIntentPrefetch={onIntentPrefetch}
+                  indented
+                />
+              ) : (
+                <NoteItem
+                  key={item._id}
+                  note={{
+                    ...item,
+                    workingSpaceName: workspace.name,
+                    tableName: table.name,
+                  }}
+                  onClick={() => onNoteClick(item)}
+                  isSelected={selectedNoteId === String(item._id)}
+                  query={query}
+                  onIntentPrefetch={onIntentPrefetch}
+                  indented
+                />
+              ),
+            )
           )}
         </div>
       )}
@@ -316,13 +416,21 @@ export default function SearchDialog({
   const allNotes = useMemo<any[]>(() => {
     if (!searchTargets) return [];
     return searchTargets.flatMap((ws) =>
-      (ws.tables ?? []).flatMap((t: any) =>
-        (t.notes ?? []).map((n: any) => ({
+      (ws.tables ?? []).flatMap((t: any) => [
+        ...(t.notes ?? []).map((n: any) => ({
           ...n,
+          kind: "note" as const,
           workingSpaceName: ws.name,
           tableName: t.name,
         })),
-      ),
+        ...(t.pdfs ?? []).map((pdf: any) => ({
+          ...pdf,
+          kind: "pdf" as const,
+          slug: buildPdfSlug(pdf.title),
+          workingSpaceName: ws.name,
+          tableName: t.name,
+        })),
+      ]),
     );
   }, [searchTargets]);
 
@@ -385,7 +493,11 @@ export default function SearchDialog({
     if (!open) return;
     const note = allNotes[selectedIndex];
     if (!note) return;
-    prefetchOnce(`/home/${note.workingSpaceId}/${note.slug}?id=${note._id}`);
+    const href =
+      note.kind === "pdf"
+        ? `/home/${note.workingSpaceId}/pdf/${note.slug}?pdfId=${note._id}`
+        : `/home/${note.workingSpaceId}/${note.slug}?id=${note._id}`;
+    prefetchOnce(href);
   }, [open, allNotes, selectedIndex, prefetchOnce]);
 
   const toggleWorkspace = (workspaceId: string) => {
@@ -398,6 +510,10 @@ export default function SearchDialog({
 
   const handleNoteClick = (note: any) => {
     setOpen(false);
+    if (note.kind === "pdf") {
+      router.push(`/home/${note.workingSpaceId}/pdf/${note.slug}?pdfId=${note._id}`);
+      return;
+    }
     router.push(`/home/${note.workingSpaceId}/${note.slug}?id=${note._id}`);
   };
 

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -232,7 +232,7 @@ export default function TableSettings({
                 onClick={initiateDelete}
                 aria-label="delete-table"
               >
-                <FaRegTrashCan size={14} className="text-current" />
+                <FaRegTrashCan size={14} className="text-muted-foreground" />
                 Delete
               </Button>
               <DropdownMenuSeparator />

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -367,10 +367,10 @@ const Sidebar = React.memo(
       const resizeHandle =
         state === "expanded" && !isMobile ? (
           <div
-            className="group/resize absolute -right-px top-0 h-full w-2.5 cursor-col-resize "
+            className="group/resize absolute right-0 top-0 h-full w-2.5 cursor-col-resize "
             onMouseDown={handleMouseDown}
           >
-            <div className="absolute -right-px top-0 h-full w-px cursor-col-resize bg-gradient-to-t from-transparent from-5% to-95% to-transparent via-50% group-hover/resize:via-primary" />
+            <div className="absolute right-0 top-0 h-full w-px cursor-col-resize bg-gradient-to-t from-transparent from-5% to-95% to-transparent via-50% group-hover/resize:via-primary" />
           </div>
         ) : null;
 
@@ -906,7 +906,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "flex h-7 min-w-0 -translate-x-px items-center gep-2 overflow-hidden rounded-lg px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -12,6 +12,10 @@ const NOTE_PREVIEW_MAX_CHARS = 200;
 const TREE_NOTES_PER_TABLE = 3;
 const TREE_TABLES_PER_WORKSPACE = 3;
 
+function normalizeSearchText(value: string | undefined) {
+  return (value ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 function computeNotePreview(body: string | undefined): string | undefined {
   if (!body) return undefined;
   const text = extractTextFromTiptap(body).replace(/\s+/g, " ").trim();
@@ -338,9 +342,9 @@ export const getNoteByUserId = query({
         .order("desc")
         .collect();
 
-      const lowerQuery = searchQuery.toLowerCase();
+      const lowerQuery = normalizeSearchText(searchQuery);
       const matchedNotes = allNotes.filter((note) => {
-        return note.title?.toLowerCase().includes(lowerQuery);
+        return normalizeSearchText(note.title).includes(lowerQuery);
       });
 
       return {
@@ -417,7 +421,7 @@ export const getWorkspaceTree = query({
       throw new ConvexError("Not authenticated");
     }
 
-    const normalizedQuery = searchQuery?.trim().toLowerCase() ?? "";
+    const normalizedQuery = normalizeSearchText(searchQuery?.trim());
     const isSearching = normalizedQuery.length > 0;
 
     const workspaces = await ctx.db
@@ -454,9 +458,17 @@ export const getWorkspaceTree = query({
                 )
                 .order("desc")
                 .collect();
+              const allPdfs = await ctx.db
+                .query("pdfs")
+                .withIndex("by_notesTableId", (q) =>
+                  q.eq("notesTableId", table._id),
+                )
+                .order("desc")
+                .collect();
               return {
                 ...table,
                 notes: allNotes.map(({ body, ...rest }) => rest),
+                pdfs: allPdfs,
               };
             }
 
@@ -468,10 +480,18 @@ export const getWorkspaceTree = query({
               )
               .order("desc")
               .take(TREE_NOTES_PER_TABLE);
+            const firstPdfs = await ctx.db
+              .query("pdfs")
+              .withIndex("by_notesTableId", (q) =>
+                q.eq("notesTableId", table._id),
+              )
+              .order("desc")
+              .take(TREE_NOTES_PER_TABLE);
 
             return {
               ...table,
               notes: firstNotes.map(({ body, ...rest }) => rest),
+              pdfs: firstPdfs,
             };
           }),
         );
@@ -481,22 +501,29 @@ export const getWorkspaceTree = query({
         }
 
         // Filter by query
-        const workspaceMatches = workspace.name
-          .toLowerCase()
-          .includes(normalizedQuery);
+        const workspaceMatches = normalizeSearchText(workspace.name).includes(
+          normalizedQuery,
+        );
 
         const filteredTables = tablesWithNotes
           .map((table) => {
-            const tableMatches = table.name
-              ?.toLowerCase()
-              .includes(normalizedQuery);
+            const tableMatches = normalizeSearchText(table.name).includes(
+              normalizedQuery,
+            );
             const matchingNotes = table.notes.filter((note: any) =>
-              note.title?.toLowerCase().includes(normalizedQuery),
+              normalizeSearchText(note.title).includes(normalizedQuery),
+            );
+            const matchingPdfs = (table.pdfs ?? []).filter((pdf: any) =>
+              normalizeSearchText(pdf.title).includes(normalizedQuery),
             );
 
             if (tableMatches) return table;
-            if (matchingNotes.length > 0)
-              return { ...table, notes: matchingNotes };
+            if (matchingNotes.length > 0 || matchingPdfs.length > 0)
+              return {
+                ...table,
+                notes: matchingNotes,
+                pdfs: matchingPdfs,
+              };
             return null;
           })
           .filter(Boolean);


### PR DESCRIPTION
## what changed

**pdf support in search**
- `getWorkspaceTree` now fetches pdfs per table alongside notes and returns them in the tree  both in the full list and in the `take(TREE_NOTES_PER_TABLE)` preview slice
- `SearchDialog` builds a unified `items` array per table by merging `table.notes` and `table.pdfs`, tagging each with `kind: "note"` or `kind: "pdf"`, then sorting by `createdAt` desc
- added a `PdfItem` component that mirrors `NoteItem` in structure  shows a file icon, title with highlight, and relative time
- `buildPdfSlug` util constructs the slug from the pdf title client-side so the href is correct without an extra query
- keyboard navigation (`selectedIndex`), intent prefetch on hover/focus, and click routing in `handleNoteClick` all branch on `kind` to build the right url (`/pdf/[slug]?pdfId=` vs `/${slug}?id=`)
- `allNotes` memo (used for keyboard nav) now includes pdfs so arrow keys work across both types
- search filtering in `getWorkspaceTree` returns `matchingPdfs` alongside `matchingNotes` so pdf-only matches still surface the table
- empty state inside a collapsed table now says "no notes or uploads match" / "no notes or uploads here"

**better search highlighting**
- `HighlightedText` used to do a simple `indexOf` on the raw string, which broke for filenames with hyphens, dots, or other non-alphanumeric chars (e.g. searching "report" wouldn't highlight in "report-2024.pdf")
- now both the query and source text are mapped character by character — normalized chars are matched, but the original character positions are tracked so the highlight slice is taken from the real string
- same `normalizeSearchText` helper (`toLowerCase + replace(/[^a-z0-9]/g, "")`) applied on the backend in `getNoteByUserId` and `getWorkspaceTree` so server-side filtering and client-side highlighting are consistent

**pdf viewer polish**
- `document.title` is set to `"{pdf.title} - Notevo"` when the viewer mounts and restored on unmount via a `useEffect` cleanup  tabs now show the pdf name instead of the route
- loading skeleton swapped from `rounded-2xl` to `rounded-none` so it matches the flush edges of the actual viewer
- toolbar nudged from `right-4 top-20` to `right-2.5 top-[4.4rem]` and `shadow-2xl` removed  sits tighter against the edge and feels less heavy
- search and thumbnails panel close buttons changed from `variant="outline"` with a visible border to `!border-0 bg-transparent`  they were visually competing with the panel header
- thumbnails panel horizontal padding increased from `px-1` to `px-2` so thumbnails have a bit more breathing room
- left border on thumbnails panel changed to `border-l-0` since the panel sits flush against the left edge and the border was doubling up
- thumbnail toggle button (`Pg`) gets `!border-l-0` so there's no double-border between it and the search button

**misc**
- trash icon in `NoteSettings`, `NoteContextMenu`, `TableSettings`, and `PdfSettings` changed from `text-current` to `text-muted-foreground`  it was inheriting the destructive red from the button text, making it look double-red
- removed the "open this file in a new tab to read or review it" placeholder text from `PdfGridCard`  it was filler that added no value
- sidebar resize handle changed from `-right-px` to `right-0` to avoid a subpixel layout shift on some screens
- minor formatting cleanup: `fadeTransition` ternary in `HomeClientLayout` wrapped for readability, `IntentPrefetchLink` children inline in `PdfGridCard`