### PR TITLE
move dialog redesign and color consistency

### DIFF
--- a/components/home-components/Feedback.tsx
+++ b/components/home-components/Feedback.tsx
@@ -134,8 +134,12 @@ export default function Feedback() {
                   </FormItem>
                 )}
               />
-              <DialogFooter>
-                <Button type="submit" disabled={loading}>
+              <DialogFooter className=" pb-6 relative">
+                <Button
+                  className=" absolute -bottom-6 -right-6"
+                  type="submit"
+                  disabled={loading}
+                >
                   {loading ? "Sending..." : "Submit"}
                 </Button>
               </DialogFooter>

--- a/components/home-components/MoveNoteDialog.tsx
+++ b/components/home-components/MoveNoteDialog.tsx
@@ -216,7 +216,7 @@ export default function MoveNoteDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="p-0 overflow-hidden bg-muted border-border md:min-w-[500px] gap-0 shadow-2xl">
         <DialogHeader className="px-5 pt-4 pb-3 border-b border-border">
-          <p className="text-[10px] font-semibold uppercase tracking-widest text-primary/70 mb-1">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-foreground mb-1">
             Move note
           </p>
           <DialogTitle className="text-[15px] font-medium text-foreground leading-snug">
@@ -228,7 +228,7 @@ export default function MoveNoteDialog({
         </DialogHeader>
         <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-1 bg-muted">
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <Search className="h-4 w-4 shrink-0 text-primary/70" />
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
             <Input
               ref={searchInputRef}
               value={query}
@@ -266,7 +266,7 @@ export default function MoveNoteDialog({
             </div>
           ) : !hasResults ? (
             <div className="flex min-h-[360px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
-              <Folder className="mb-4 h-10 w-10 text-primary/50" />
+              <Folder className="mb-4 h-10 w-10 text-muted-foreground" />
               <p className="font-medium text-foreground">
                 {debouncedQuery
                   ? `No targets found for "${debouncedQuery}"`
@@ -285,24 +285,25 @@ export default function MoveNoteDialog({
                 return (
                   <div
                     key={workspace._id}
-                    className="overflow-hidden app-radius-lg transition-colors"
+                    className=" relative overflow-hidden app-radius-lg transition-colors"
                   >
+                    <div className=" absolute left-3.5 top-8 h-full w-px bg-border" />
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-primary/10 hover:border-2 hover:bg-transparent"
+                      className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-transparent hover:border-2 hover:bg-transparent"
                       onClick={() => toggleWorkspace(workspaceId)}
                     >
                       <ChevronRight
                         className={cn(
-                          "h-3.5 w-3.5 shrink-0 transition-transform text-primary/60",
+                          "h-3.5 w-3.5 shrink-0 transition-transform text-muted-foreground",
                           isExpanded && "rotate-90",
                         )}
                       />
                       {isExpanded ? (
-                        <FolderOpen className="h-3.5 w-3.5 shrink-0 text-primary/80" />
+                        <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       ) : (
-                        <Folder className="h-3.5 w-3.5 shrink-0 text-primary/60" />
+                        <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       )}
                       <span className="truncate text-sm font-medium text-foreground">
                         <HighlightedText
@@ -322,7 +323,7 @@ export default function MoveNoteDialog({
                               variant="secondary"
                               size="sm"
                               label="Table"
-                              className="h-8 shrink-0 gap-1 px-2 text-muted-foreground"
+                              className="h-7 shrink-0 gap-1 px-2 text-muted-foreground"
                               onCreated={() => {
                                 setExpandedWorkspaceIds((prev) =>
                                   prev.includes(workspaceId)
@@ -341,45 +342,50 @@ export default function MoveNoteDialog({
                               movingTableId === String(table._id);
 
                             return (
-                              <button
+                              <div
                                 key={table._id}
-                                type="button"
-                                onClick={() =>
-                                  handleMove(workspace._id, table._id)
-                                }
-                                disabled={isCurrentTarget || isMoving}
-                                className={cn(
-                                  "flex w-full items-center justify-between app-radius-lg px-3 py-2 text-left transition-colors",
-                                  isCurrentTarget
-                                    ? "cursor-not-allowed bg-primary/10"
-                                    : " hover:bg-primary/10",
-                                )}
+                                className="flex w-full items-center justify-between mx-auto text-left "
                               >
-                                <div className="flex min-w-0 items-center gap-2">
-                                  <span className="ml-4 h-px w-3 bg-muted-foreground/60" />
-                                  <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-                                  <span className="truncate text-[13px] font-medium">
-                                    <HighlightedText
-                                      text={table.name || "Untitled"}
-                                      query={debouncedQuery}
-                                    />
-                                  </span>
-                                </div>
-
-                                <span className="shrink-0 text-[11px] text-muted-foreground/60">
-                                  {isMoving ? (
-                                    <LoadingAnimation className="h-4 w-4 text-primary" />
-                                  ) : isCurrentTarget ? (
-                                    <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
-                                      current
-                                    </span>
-                                  ) : (
-                                    <span className="text-[11px] text-muted-foreground/50 group-hover:text-primary/60">
-                                      move
-                                    </span>
+                                <button
+                                  key={table._id}
+                                  type="button"
+                                  onClick={() =>
+                                    handleMove(workspace._id, table._id)
+                                  }
+                                  disabled={isCurrentTarget || isMoving}
+                                  aria-label=" handle-move-target"
+                                  className={cn(
+                                    "flex w-full items-center justify-between app-radius-lg mx-4 px-2 py-2 text-left transition-colors",
+                                    isCurrentTarget
+                                      ? "cursor-not-allowed bg-muted"
+                                      : " hover:bg-border",
                                   )}
-                                </span>
-                              </button>
+                                >
+                                  <div className="flex min-w-0 items-center gap-2">
+                                    <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+                                    <span className="truncate text-[13px] font-medium">
+                                      <HighlightedText
+                                        text={table.name || "Untitled"}
+                                        query={debouncedQuery}
+                                      />
+                                    </span>
+                                  </div>
+
+                                  <span className="shrink-0 text-[11px] text-muted-foreground/60">
+                                    {isMoving ? (
+                                      <LoadingAnimation className="h-4 w-4 text-primary" />
+                                    ) : isCurrentTarget ? (
+                                      <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
+                                        current
+                                      </span>
+                                    ) : (
+                                      <span className="text-[11px] text-muted-foreground/50 group-hover:text-primary/60">
+                                        move
+                                      </span>
+                                    )}
+                                  </span>
+                                </button>
+                              </div>
                             );
                           })
                         )}

--- a/components/home-components/MovePdfDialog.tsx
+++ b/components/home-components/MovePdfDialog.tsx
@@ -207,7 +207,7 @@ export default function MovePdfDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="p-0 overflow-hidden bg-muted border-border md:min-w-[500px] gap-0 shadow-2xl">
         <DialogHeader className="px-5 pt-4 pb-3 border-b border-border">
-          <p className="text-[10px] font-semibold uppercase tracking-widest text-primary/70 mb-1">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-foreground mb-1">
             Move upload
           </p>
           <DialogTitle className="text-[15px] font-medium text-foreground leading-snug">
@@ -219,7 +219,7 @@ export default function MovePdfDialog({
         </DialogHeader>
         <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-1 bg-muted">
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <Search className="h-4 w-4 shrink-0 text-primary/70" />
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
             <Input
               ref={searchInputRef}
               value={query}
@@ -257,7 +257,7 @@ export default function MovePdfDialog({
             </div>
           ) : !hasResults ? (
             <div className="flex min-h-[360px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
-              <Folder className="mb-4 h-10 w-10 text-primary/50" />
+              <Folder className="mb-4 h-10 w-10 text-muted-foreground" />
               <p className="font-medium text-foreground">
                 {debouncedQuery
                   ? `No targets found for "${debouncedQuery}"`
@@ -276,24 +276,25 @@ export default function MovePdfDialog({
                 return (
                   <div
                     key={workspace._id}
-                    className="overflow-hidden app-radius-lg transition-colors"
+                    className=" relative overflow-hidden app-radius-lg transition-colors"
                   >
+                    <div className=" absolute left-3.5 top-8 h-full w-px bg-border" />
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-primary/10 hover:border-2 hover:bg-transparent"
+                      className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-transparent hover:border-2 hover:bg-transparent"
                       onClick={() => toggleWorkspace(workspaceId)}
                     >
                       <ChevronRight
                         className={cn(
-                          "h-3.5 w-3.5 shrink-0 transition-transform text-primary/60",
+                          "h-3.5 w-3.5 shrink-0 transition-transform text-muted-foreground",
                           isExpanded && "rotate-90",
                         )}
                       />
                       {isExpanded ? (
-                        <FolderOpen className="h-3.5 w-3.5 shrink-0 text-primary/80" />
+                        <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       ) : (
-                        <Folder className="h-3.5 w-3.5 shrink-0 text-primary/60" />
+                        <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       )}
                       <span className="truncate text-sm font-medium text-foreground">
                         <HighlightedText
@@ -313,7 +314,7 @@ export default function MovePdfDialog({
                               variant="secondary"
                               size="sm"
                               label="Table"
-                              className="h-8 shrink-0 gap-1 px-2 text-muted-foreground"
+                              className="h-7 shrink-0 gap-1 px-2 text-muted-foreground"
                               onCreated={() => {
                                 setExpandedWorkspaceIds((prev) =>
                                   prev.includes(workspaceId)
@@ -332,45 +333,49 @@ export default function MovePdfDialog({
                               movingTableId === String(table._id);
 
                             return (
-                              <button
+                              <div
                                 key={table._id}
-                                type="button"
-                                onClick={() =>
-                                  handleMove(workspace._id, table._id)
-                                }
-                                disabled={isCurrentTarget || isMoving}
-                                className={cn(
-                                  "flex w-full items-center justify-between app-radius-lg px-3 py-2 text-left transition-colors",
-                                  isCurrentTarget
-                                    ? "cursor-not-allowed bg-primary/10"
-                                    : "hover:bg-primary/10",
-                                )}
+                                className="flex w-full items-center justify-between mx-auto text-left "
                               >
-                                <div className="flex min-w-0 items-center gap-2">
-                                  <span className="ml-4 h-px w-3 bg-muted-foreground/60" />
-                                  <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-                                  <span className="truncate text-[13px] font-medium">
-                                    <HighlightedText
-                                      text={table.name || "Untitled"}
-                                      query={debouncedQuery}
-                                    />
-                                  </span>
-                                </div>
-
-                                <span className="shrink-0 text-[11px] text-muted-foreground/60">
-                                  {isMoving ? (
-                                    <LoadingAnimation className="h-4 w-4 text-primary" />
-                                  ) : isCurrentTarget ? (
-                                    <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
-                                      current
-                                    </span>
-                                  ) : (
-                                    <span className="text-[11px] text-muted-foreground/50 group-hover:text-primary/60">
-                                      move
-                                    </span>
+                                <button
+                                  key={table._id}
+                                  type="button"
+                                  onClick={() =>
+                                    handleMove(workspace._id, table._id)
+                                  }
+                                  disabled={isCurrentTarget || isMoving}
+                                  className={cn(
+                                    "flex w-full items-center justify-between app-radius-lg mx-4 px-2 py-2 text-left transition-colors",
+                                    isCurrentTarget
+                                      ? "cursor-not-allowed bg-muted"
+                                      : "hover:bg-border",
                                   )}
-                                </span>
-                              </button>
+                                >
+                                  <div className="flex min-w-0 items-center gap-2">
+                                    <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+                                    <span className="truncate text-[13px] font-medium">
+                                      <HighlightedText
+                                        text={table.name || "Untitled"}
+                                        query={debouncedQuery}
+                                      />
+                                    </span>
+                                  </div>
+
+                                  <span className="shrink-0 text-[11px] text-muted-foreground/60">
+                                    {isMoving ? (
+                                      <LoadingAnimation className="h-4 w-4 text-primary" />
+                                    ) : isCurrentTarget ? (
+                                      <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
+                                        current
+                                      </span>
+                                    ) : (
+                                      <span className="text-[11px] text-muted-foreground/50 group-hover:text-primary/60">
+                                        move
+                                      </span>
+                                    )}
+                                  </span>
+                                </button>
+                              </div>
                             );
                           })
                         )}


### PR DESCRIPTION
## what changed

**move note/pdf dialog layout rework**
- both `MoveNoteDialog` and `MovePdfDialog` got the same treatment, so they're visually in sync now
- each workspace row is now `relative` with an absolutely positioned vertical `w-px bg-border` line running from below the workspace header down through its table list  gives a clear visual tree structure showing which tables belong to which workspace
- the table rows were restructured: the outer `<button>` became a `<div>` wrapper, and the clickable `<button>` inside gets `mx-4` indent and `px-2 py-2` padding, so the hover/active area is properly inset and aligned with the tree line
- removed the old `ml-4 h-px w-3` horizontal connector span that was sitting between the indent and the folder icon  the vertical line handles the hierarchy now and the connector felt redundant
- hover and current-target backgrounds changed from `bg-primary/10` to `hover:bg-border` / `bg-muted` so they use semantic tokens instead of tinted primary colors, which looks better in both light and dark themes
- "create table" button height reduced from `h-8` to `h-7` to better match the compact density of the table rows

**color consistency across both dialogs**
- the "move note" / "move upload" label at the top of the dialog changed from `text-primary/70` to `text-foreground` — it was too faint and didn't need the primary tint
- search icon changed from `text-primary/70` to `text-muted-foreground`
- empty state folder icon changed from `text-primary/50` to `text-muted-foreground`
- chevron, folder, and folder-open icons on workspace rows changed from `text-primary/60` and `text-primary/80` to `text-muted-foreground`  consistent with how icons look everywhere else in the app
- workspace row border changed from `border-primary/10` to `border-transparent` so there's no phantom colored border on non-hovered rows

**feedback dialog submit button**
- submit button repositioned to `absolute -bottom-6 -right-6` inside a `relative pb-6` footer  visually tucks it into the bottom-right corner of the dialog for a more intentional layout rather than the default footer flow

**why**
- the `primary/N` opacity colors were inconsistent with the rest of the ui and made the dialogs look different depending on the theme
- the old table row structure had a visual indent (the horizontal line span) that didn't line up cleanly with the workspace header, making the hierarchy feel loose  the vertical tree line approach is cleaner and scales better when there are many tables