### PR TITLE
landing page step card icon tweak

### DIFF
--- a/components/landingPage-components/HowToStartSection.tsx
+++ b/components/landingPage-components/HowToStartSection.tsx
@@ -484,14 +484,11 @@ export default function HowToStartSection() {
 
                   {/* Card content */}
                   <div className="p-5 flex flex-col flex-1">
-                    <span className="absolute top-2 left-2 inline-flex items-center bg-secondary text-secondary-foreground app-radius-md px-2.5 py-0.5 text-[11px] font-bold mb-3">
-                      {step.StepNum}
+                    <span className="absolute top-2 left-2 inline-flex items-center bg-secondary text-secondary-foreground app-radius-md border border-primary/20 p-1.5 text-[11px] font-bold mb-3">
+                      <Icon className="w-4 h-4 text-primary" />
                     </span>
 
                     <div className="flex items-center gap-2 mb-2">
-                      <div className="w-7 h-7 app-radius-sm bg-primary/10 flex items-center justify-center transition-colors">
-                        <Icon className="w-4 h-4 text-primary" />
-                      </div>
                       <h3 className="text-base font-bold text-foreground">
                         {step.Title}
                       </h3>


### PR DESCRIPTION
## what changed

- the step badge (top-left corner of each card) used to show a text label like "step 1". it now shows the step's icon instead, with a `border-primary/20` border and `p-1.5` padding to give it a cleaner pill shape
- the separate icon container below the badge (`w-7 h-7 bg-primary/10` div) was removed since the icon is now already surfaced in the badge  no need to show it twice
- the step title sits directly in the flex row without the icon wrapper, so the heading alignment is simpler
### it just didn't make any sense 
before : 
<img width="1407" height="680" alt="image" src="https://github.com/user-attachments/assets/f251b658-7f12-49eb-877d-dd0644fd10d1" />

now : 
<img width="1439" height="624" alt="image" src="https://github.com/user-attachments/assets/537cfc3d-d4cd-4528-a589-e626eefedde0" />

- having both a step number badge and a separate icon box was visually noisy and redundant
- showing the icon in the badge is more scannable at a glance and saves vertical space in the card header