### PR TITLE
replace scattered tooltip state with useHoverTooltip hook

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -21,10 +21,12 @@ import { parseSlug } from "@/lib/parseSlug";
 import { formatUserNoteTitle } from "@/lib/utils";
 import { ReadOnlyWarning } from "@/components/readOnly-warning";
 import NoteDownloadDropdown from "@/components/home-components/NoteDownloadDropdown";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
+  const themeTooltip = useHoverTooltip(200);
 
   const cycleTheme = () => {
     if (resolvedTheme === "light") setTheme("dark");
@@ -121,13 +123,14 @@ export default function PublicNotePage() {
               noteBody={JSON.stringify(content)}
               noteTitle={getNote.title ?? "note"}
             />
-            <Tooltip disableHoverableContent>
+            <Tooltip open={themeTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     className="w-8 h-8 mt-0.5"
                     size="icon"
                     onClick={cycleTheme}
+                    {...themeTooltip.triggerProps}
                   >
                     {getThemeIcon()}
                     <span className="sr-only">Toggle theme</span>

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -65,6 +65,7 @@ import {
   truncateText as parseTiptapContentTruncateText,
 } from "@/lib/parse-tiptap-content";
 import { generateSlug } from "@/lib/generateSlug";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 const getContentPreviewFromBody = (body: any) => {
   if (!body) return "No content yet. Click to start writing...";
   try {
@@ -173,6 +174,7 @@ const STORAGE_KEYS = {
 };
 
 function TableTab({ table }: { table: any }) {
+  const deleteTooltip = useHoverTooltip(100);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [editedName, setEditedName] = useState(table.name || "Untitled");
   const [isHovered, setIsHovered] = useState(false);
@@ -351,7 +353,7 @@ function TableTab({ table }: { table: any }) {
                 isHovered ? "opacity-100 " : "opacity-0 pointer-events-none",
               )}
             >
-              <Tooltip delayDuration={100} disableHoverableContent>
+              <Tooltip open={deleteTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
@@ -363,6 +365,7 @@ function TableTab({ table }: { table: any }) {
                     }}
                     className=" px-1 h-6 text-foreground hover:text-destructive"
                     aria-label="delete-table"
+                    {...deleteTooltip.triggerProps}
                   >
                     <X size={16} />
                   </Button>

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -49,6 +49,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/legacy/build/pdf.worker.mjs",
@@ -473,6 +474,8 @@ function PdfViewerContent({
 }) {
   const [query, setQuery] = useState("");
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
+  const searchTooltip = useHoverTooltip(100);
+  const thumbnailsTooltip = useHoverTooltip(100);
 
   return (
     <LectorSearch
@@ -486,7 +489,7 @@ function PdfViewerContent({
         <div className="pointer-events-none absolute inset-x-0 top-1 z-50">
           <div className="pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-3 app-radius-lg border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl">
             <div className="flex items-center gap-0">
-              <Tooltip delayDuration={100} disableHoverableContent>
+              <Tooltip open={searchTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
@@ -500,6 +503,7 @@ function PdfViewerContent({
                     }
                     aria-label="show-search-panel"
                     aria-pressed={panelMode === "search"}
+                    {...searchTooltip.triggerProps}
                   >
                     {panelMode === "search" ? (
                       <X size={16} />
@@ -512,7 +516,7 @@ function PdfViewerContent({
                   {panelMode === "search" ? "Close Search" : "Open Search"}
                 </TooltipContent>
               </Tooltip>
-              <Tooltip delayDuration={100} disableHoverableContent>
+              <Tooltip open={thumbnailsTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
@@ -526,6 +530,7 @@ function PdfViewerContent({
                     }
                     aria-label="show-thumbnails-panel"
                     aria-pressed={panelMode === "thumbnails"}
+                    {...thumbnailsTooltip.triggerProps}
                   >
                     {panelMode === "thumbnails" ? (
                       <X size={16} />

--- a/components/PublicNote.tsx
+++ b/components/PublicNote.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/tooltip";
 import Link from "next/link";
 import { useMediaQuery } from "react-responsive";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 interface PublicNoteProp {
   noteId: Id<"notes">;
@@ -47,9 +48,9 @@ export default function PublicNote({
 
   const isMobile = useMediaQuery({ maxWidth: 640 });
   const [open, setOpen] = useState(false);
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
-  const [isCopyTooltipOpen, setIsCopyTooltipOpen] = useState(false);
+  const tooltip = useHoverTooltip();
+  const copyTooltip = useHoverTooltip(200);
 
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
     (local, args) => {
@@ -91,26 +92,28 @@ export default function PublicNote({
         `https://notevo.me/public/document/${noteId}`,
       );
       setIsCopied(true);
-      setIsCopyTooltipOpen(false);
+      copyTooltip.hide();
       setTimeout(() => setIsCopied(false), 2000);
     } catch (err) {
       console.error("Failed to copy text: ", err);
     }
   };
 
-  const handleTooltipMouseEnter = () => setIsTooltipOpen(true);
-  const handleTooltipMouseLeave = () => setIsTooltipOpen(false);
-
   return (
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <Tooltip open={isTooltipOpen} disableHoverableContent>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (next) tooltip.hide();
+        }}
+      >
+        <Tooltip open={tooltip.open}>
           <DropdownMenuTrigger asChild>
             <TooltipTrigger asChild>
               <Button
                 variant="ghost"
                 className={cn("h-8 px-2 text-sm mt-0.5 gap-1", BtnClassName)}
-                onMouseEnter={handleTooltipMouseEnter}
-                onMouseLeave={handleTooltipMouseLeave}
+                {...tooltip.triggerProps}
               >
                 {getNote?.published ? (
                   <>
@@ -161,17 +164,12 @@ export default function PublicNote({
                     className="h-9 truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-85% to-transparent to-80% text-transparent bg-clip-text"
                     disabled
                   />
-                  <Tooltip
-                    open={isCopyTooltipOpen}
-                    onOpenChange={setIsCopyTooltipOpen}
-                    delayDuration={200}
-                  >
+                  <Tooltip open={copyTooltip.open}>
                     <TooltipTrigger asChild>
                       <Button
                         onMouseDown={handleCopy}
                         onPointerMove={(e) => e.stopPropagation()}
-                        onMouseEnter={() => setIsCopyTooltipOpen(true)}
-                        onMouseLeave={() => setIsCopyTooltipOpen(false)}
+                        {...copyTooltip.triggerProps}
                         className={`w-fit h-8 absolute top-1/2 -translate-y-1/2 right-0  text-primary hover:text-primary`}
                         disabled={isCopied && true}
                         variant="Trigger"

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -69,6 +69,7 @@ import { ThemeToggle } from "../ThemeToggle";
 import { UserIcon } from "lucide-react";
 import Feedback from "./Feedback";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import { usePaginatedQuery } from "@/cache/usePaginatedQuery";
 import { z } from "zod";
 import { generateSlug } from "@/lib/generateSlug";
@@ -252,6 +253,7 @@ interface PinnedNoteItemProps {
 
 const PinnedNoteItem = memo(
   function PinnedNoteItem({ note, pathname, open }: PinnedNoteItemProps) {
+    const titleTooltip = useHoverTooltip(300);
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editedTitle, setEditedTitle] = useState(note.title || "Untitled");
@@ -372,7 +374,7 @@ const PinnedNoteItem = memo(
                 className="flex-1 h-8 pl-7 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
-              <Tooltip delayDuration={200} disableHoverableContent>
+              <Tooltip open={titleTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="SidebarMenuButton"
@@ -381,6 +383,7 @@ const PinnedNoteItem = memo(
                     }`}
                     asChild
                     onDoubleClick={handleDoubleClick}
+                    {...titleTooltip.triggerProps}
                   >
                     <IntentPrefetchLink
                       href={noteHref}
@@ -550,6 +553,7 @@ interface PinnedUploadItemProps {
 
 const PinnedUploadItem = memo(
   function PinnedUploadItem({ pdf, pathname, open }: PinnedUploadItemProps) {
+    const titleTooltip = useHoverTooltip(300);
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editedTitle, setEditedTitle] = useState(pdf.title || "Untitled");
@@ -649,7 +653,7 @@ const PinnedUploadItem = memo(
                 className="flex-1 h-8 pl-7 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
-              <Tooltip delayDuration={200} disableHoverableContent>
+              <Tooltip open={titleTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="SidebarMenuButton"
@@ -658,6 +662,7 @@ const PinnedUploadItem = memo(
                     }`}
                     asChild
                     onDoubleClick={handleDoubleClick}
+                    {...titleTooltip.triggerProps}
                   >
                     <IntentPrefetchLink
                       href={pdfHref}
@@ -815,6 +820,7 @@ interface WorkspaceItemProps {
 
 const WorkspaceItem = memo(
   function WorkspaceItem({ workingSpace, pathname, open }: WorkspaceItemProps) {
+    const titleTooltip = useHoverTooltip(300);
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editedName, setEditedName] = useState(
@@ -954,7 +960,7 @@ const WorkspaceItem = memo(
                 className="flex-1 h-8 pl-7 pr-2 py-0 my-0.5 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
-              <Tooltip delayDuration={200} disableHoverableContent>
+              <Tooltip open={titleTooltip.open}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="SidebarMenuButton"
@@ -963,6 +969,7 @@ const WorkspaceItem = memo(
                     }`}
                     asChild
                     onDoubleClick={handleDoubleClick}
+                    {...titleTooltip.triggerProps}
                   >
                     <IntentPrefetchLink
                       href={workspaceHref}
@@ -1027,14 +1034,19 @@ const WorkspacesList = memo(function WorkspacesList({
   pathname,
   open,
 }: WorkspacesListProps) {
+  const addWorkspaceTooltip = useHoverTooltip(300);
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel className="text-muted-foreground flex items-center justify-between">
         <span>Workspaces</span>
       </SidebarGroupLabel>
-      <Tooltip delayDuration={200} disableHoverableContent>
+      <Tooltip open={addWorkspaceTooltip.open}>
         <TooltipTrigger asChild>
-          <SidebarGroupAction onClick={handleCreateWorkingSpace}>
+          <SidebarGroupAction
+            onClick={handleCreateWorkingSpace}
+            {...addWorkspaceTooltip.triggerProps}
+          >
             <Plus size={16} className=" text-muted-foreground" />{" "}
             <span className="sr-only">Add Workspace</span>
           </SidebarGroupAction>

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useNoteDownload, type DownloadFormat } from "@/hooks/useNoteDownload";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 interface NoteDownloadDropdownProps {
   noteBody: string | undefined | null;
@@ -31,6 +32,7 @@ export default function NoteDownloadDropdown({
   className,
 }: NoteDownloadDropdownProps) {
   const { handleDownload } = useNoteDownload({ noteBody, noteTitle });
+  const tooltip = useHoverTooltip();
 
   const formats: {
     label: string;
@@ -60,23 +62,24 @@ export default function NoteDownloadDropdown({
   ];
 
   return (
-    <DropdownMenu>
-      <Tooltip disableHoverableContent>
-          <DropdownMenuTrigger asChild>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={`w-8 h-8 mt-0.5 ${className ?? ""}`}
-              >
-                <Download className="h-[1.2rem] w-[1.2rem]" />
-                <span className="sr-only">Download note</span>
-              </Button>
-            </TooltipTrigger>
-          </DropdownMenuTrigger>
-          <TooltipContent align="end" side="bottom">
-            Download note
-          </TooltipContent>
+    <DropdownMenu onOpenChange={(next) => next && tooltip.hide()}>
+      <Tooltip open={tooltip.open}>
+        <DropdownMenuTrigger asChild>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`w-8 h-8 mt-0.5 ${className ?? ""}`}
+              {...tooltip.triggerProps}
+            >
+              <Download className="h-[1.2rem] w-[1.2rem]" />
+              <span className="sr-only">Download note</span>
+            </Button>
+          </TooltipTrigger>
+        </DropdownMenuTrigger>
+        <TooltipContent align="end" side="bottom">
+          Download note
+        </TooltipContent>
       </Tooltip>
 
       <DropdownMenuContent align={align} side="bottom" className="w-44">

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -51,6 +51,7 @@ import {
 import { Label } from "../ui/label";
 import { useNoteWidth } from "@/hooks/useNoteWidth";
 import { useNoteDownload } from "@/hooks/useNoteDownload";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import MoveNoteDialog from "./MoveNoteDialog";
 
 interface NoteSettingsProps {
@@ -95,8 +96,8 @@ export default function NoteSettings({
   const [inputValue, setInputValue] = useState(noteTitle);
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+  const tooltip = useHoverTooltip();
 
   const { noteWidth, toggleWidth } = useNoteWidth();
 
@@ -224,20 +225,22 @@ export default function NoteSettings({
     setIsMoveDialogOpen(true);
   };
 
-  const handleTooltipMouseEnter = () => setIsTooltipOpen(true);
-  const handleTooltipMouseLeave = () => setIsTooltipOpen(false);
-
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <Tooltip open={isTooltipOpen}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (next) tooltip.hide();
+        }}
+      >
+        <Tooltip open={tooltip.open}>
             <DropdownMenuTrigger asChild>
               <TooltipTrigger asChild>
                 <Button
                   variant="Trigger"
                   className={cn("px-0.5 h-8 mt-0.5", BtnClassName)}
-                  onMouseEnter={handleTooltipMouseEnter}
-                  onMouseLeave={handleTooltipMouseLeave}
+                  {...tooltip.triggerProps}
                   aria-label="note-options"
                 >
                   {IconVariant === "vertical_icon" ? (

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -23,6 +23,7 @@ import { useQuery } from "@/cache/useQuery";
 import { Button } from "@/components/ui/button";
 import { SquarePen, X, Pin, PinOff } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import {
   redirect,
   useRouter,
@@ -108,18 +109,22 @@ export default function NoteSettingsSidbar({
     });
   };
 
+  const pinTooltip = useHoverTooltip(200);
+  const deleteTooltip = useHoverTooltip(200);
+
   return (
     <>
       <div
         className={cn("flex justify-end items-center px-1", ContainerClassName)}
       >
-        <Tooltip delayDuration={200} disableHoverableContent>
+        <Tooltip open={pinTooltip.open}>
           <TooltipTrigger asChild>
             <Button
               onClick={handleFavoritePin}
               variant="SidebarMenuButton"
               className="px-2 h-7 hover:bg-card"
               aria-label="pin-note"
+              {...pinTooltip.triggerProps}
             >
               {getNote?.favorite ? (
                 <PinOff size={16} className="text-muted-foreground" />
@@ -133,13 +138,14 @@ export default function NoteSettingsSidbar({
           </TooltipContent>
         </Tooltip>
 
-        <Tooltip delayDuration={200} disableHoverableContent>
+        <Tooltip open={deleteTooltip.open}>
           <TooltipTrigger asChild>
             <Button
               onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
               className="px-2 h-7 hover:bg-card"
               aria-label="delete-note"
+              {...deleteTooltip.triggerProps}
             >
               <X size={16} />
             </Button>

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -44,6 +44,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import MovePdfDialog from "./MovePdfDialog";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 interface PdfSettingsProps {
   pdfId: Id<"pdfs">;
@@ -81,8 +82,8 @@ export default function PdfSettings({
   const [inputValue, setInputValue] = useState(pdfTitle || "Untitled");
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+  const tooltip = useHoverTooltip();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });
@@ -162,15 +163,20 @@ export default function PdfSettings({
 
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <Tooltip open={isTooltipOpen}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (next) tooltip.hide();
+        }}
+      >
+        <Tooltip open={tooltip.open}>
             <DropdownMenuTrigger asChild>
               <TooltipTrigger asChild>
                 <Button
                   variant="Trigger"
                   className={cn("px-0.5 h-8 mt-0.5", btnClassName)}
-                  onMouseEnter={() => setIsTooltipOpen(true)}
-                  onMouseLeave={() => setIsTooltipOpen(false)}
+                  {...tooltip.triggerProps}
                   aria-label="upload-options"
                 >
                   {iconVariant === "vertical_icon" ? (

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -23,6 +23,7 @@ import { useQuery } from "@/cache/useQuery";
 import { Button } from "@/components/ui/button";
 import { Pin, PinOff, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 interface PdfSettingsSidebarProps {
   pdfId: Id<"pdfs">;
@@ -46,6 +47,9 @@ export default function PdfSettingsSidebar({
     });
   };
 
+  const pinTooltip = useHoverTooltip(200);
+  const deleteTooltip = useHoverTooltip(200);
+
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     try {
@@ -65,13 +69,14 @@ export default function PdfSettingsSidebar({
             containerClassName,
           )}
         >
-          <Tooltip disableHoverableContent>
+          <Tooltip open={pinTooltip.open}>
             <TooltipTrigger asChild>
               <Button
                 onClick={handleFavoritePin}
                 variant="SidebarMenuButton"
                 className="px-2 h-7 hover:bg-card"
                 aria-label="pin-upload"
+                {...pinTooltip.triggerProps}
               >
                 {pdf?.favorite ? (
                   <PinOff size={16} className="text-muted-foreground" />
@@ -85,13 +90,14 @@ export default function PdfSettingsSidebar({
             </TooltipContent>
           </Tooltip>
 
-          <Tooltip disableHoverableContent>
+          <Tooltip open={deleteTooltip.open}>
             <TooltipTrigger asChild>
               <Button
                 onMouseDown={() => setIsAlertOpen(true)}
                 variant="SidebarMenuButton_destructive"
                 className="px-2 h-7 hover:bg-card"
                 aria-label="delete-upload"
+                {...deleteTooltip.triggerProps}
               >
                 <X size={16} />
               </Button>

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -31,6 +31,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Label } from "../ui/label";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 interface TableSettingsProps {
   notesTableId: Id<"notesTables"> | any; // Strongly typed Id
   tableName: string | any;
@@ -179,28 +180,25 @@ export default function TableSettings({
       setIsAlertOpen(false); // Close Alert after deletion
     }
   };
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
-
-  const handleTooltipMouseEnter = () => {
-    setIsTooltipOpen(true);
-  };
-
-  const handleTooltipMouseLeave = () => {
-    setIsTooltipOpen(false);
-  };
+  const tooltip = useHoverTooltip();
   const createdAtText = formatTimestamp(table?.createdAt);
   const updatedAtText = formatTimestamp(table?.updatedAt);
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <Tooltip open={isTooltipOpen}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (next) tooltip.hide();
+        }}
+      >
+        <Tooltip open={tooltip.open}>
             <DropdownMenuTrigger asChild>
               <TooltipTrigger asChild>
                 <Button
                   variant="Trigger"
                   className="pl-0.5 pr-0 h-9 mb-0.5 opacity-80"
-                  onMouseEnter={handleTooltipMouseEnter}
-                  onMouseLeave={handleTooltipMouseLeave}
+                  {...tooltip.triggerProps}
                   aria-label="table-options"
                 >
                   <FaEllipsisVertical size={18} />

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -32,6 +32,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Label } from "../ui/label";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 interface WorkingSpaceSettings {
   workingSpaceId: Id<"workingSpaces">;
   className?: string;
@@ -61,7 +62,7 @@ export default function WorkingSpaceSettings({
   const [isDeleting, setIsDeleting] = useState(false);
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const tooltip = useHoverTooltip();
   const inputRef = useRef<HTMLInputElement>(null); // Ref for the input
 
   useEffect(() => {
@@ -207,19 +208,22 @@ export default function WorkingSpaceSettings({
   const hasContent = tableCount > 0;
   const createdAtText = formatTimestamp(workspace?.createdAt);
   const updatedAtText = formatTimestamp(workspace?.updatedAt);
-  const handleTooltipMouseEnter = () => setIsTooltipOpen(true);
-  const handleTooltipMouseLeave = () => setIsTooltipOpen(false);
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <Tooltip open={isTooltipOpen}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (next) tooltip.hide();
+        }}
+      >
+        <Tooltip open={tooltip.open}>
             <DropdownMenuTrigger asChild>
               <TooltipTrigger asChild>
                 <Button
                   variant="Trigger"
                   className={cn("px-1.5 h-8", className)}
-                  onMouseEnter={handleTooltipMouseEnter}
-                  onMouseLeave={handleTooltipMouseLeave}
+                  {...tooltip.triggerProps}
                   aria-label="workspace-options"
                 >
                   <FaEllipsis size={22} />

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -26,6 +26,7 @@ import { Button } from "../ui/button";
 import { X } from "lucide-react";
 import { Settings, Users, Trash2 } from "lucide-react";
 import { usePathname, useRouter, redirect } from "next/navigation";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 interface WorkingSpaceSettingsSidbarProps {
   workingSpaceId: Id<"workingSpaces">;
@@ -95,19 +96,21 @@ export default function WorkingSpaceSettingsSidbar({
 
   const tableCount = tables?.length || 0;
   const hasContent = tableCount > 0;
+  const deleteTooltip = useHoverTooltip(200);
 
   return (
     <>
       <div
         className={cn("flex justify-end items-center px-1", ContainerClassName)}
       >
-        <Tooltip delayDuration={200} disableHoverableContent>
+        <Tooltip open={deleteTooltip.open}>
           <TooltipTrigger asChild>
             <Button
               onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
               className="px-2 h-7 hover:bg-card"
               aria-label="delete-workspace"
+              {...deleteTooltip.triggerProps}
             >
               <X size={16} />
             </Button>

--- a/components/selectors/text-buttons.tsx
+++ b/components/selectors/text-buttons.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
@@ -5,6 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import {
   BoldIcon,
   CodeIcon,
@@ -24,6 +26,33 @@ const isMac =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad/.test(navigator.platform);
 const mod = isMac ? "⌘" : "Ctrl";
+
+function ToolbarTooltipButton({
+  label,
+  shortcut,
+  ...buttonProps
+}: {
+  label: string;
+  shortcut: string;
+} & ComponentProps<typeof Button>) {
+  const tooltip = useHoverTooltip(300);
+
+  return (
+    <Tooltip open={tooltip.open}>
+      <TooltipTrigger asChild>
+        <Button {...buttonProps} {...tooltip.triggerProps} />
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        className=" flex justify-center items-center px-1.5"
+        sideOffset={6}
+      >
+        <span>{label}</span>
+        <ShortcutBadge keys={shortcut} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 export const TextButtons = () => {
   const { editor } = useEditor();
@@ -108,68 +137,45 @@ export const TextButtons = () => {
               item.command(editor);
             }}
           >
-            <Tooltip delayDuration={300} disableHoverableContent>
-              <TooltipTrigger asChild>
-                <Button
-                  size="sm"
-                  className="border-none px-2 h-8"
-                  variant="SidebarMenuButton"
-                  type="button"
-                >
-                  <item.icon
-                    className={cn("h-4 w-4", {
-                      "text-primary": item.isActive(editor),
-                      "text-foreground": !item.isActive(editor),
-                    })}
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="top"
-                className=" flex justify-center items-center px-1.5"
-                sideOffset={6}
-              >
-                <span>{item.label}</span>
-                <ShortcutBadge keys={item.shortcut} />
-              </TooltipContent>
-            </Tooltip>
+            <ToolbarTooltipButton
+              label={item.label}
+              shortcut={item.shortcut}
+              size="sm"
+              className="border-none px-2 h-8"
+              variant="SidebarMenuButton"
+              type="button"
+            >
+              <item.icon
+                className={cn("h-4 w-4", {
+                  "text-primary": item.isActive(editor),
+                  "text-foreground": !item.isActive(editor),
+                })}
+              />
+            </ToolbarTooltipButton>
           </EditorBubbleItem>
         ))}
 
         {alignItems.map((item) => (
-          <Tooltip
+          <ToolbarTooltipButton
             key={item.name}
-            delayDuration={300}
-            disableHoverableContent
+            label={item.label}
+            shortcut={item.shortcut}
+            size="sm"
+            className="border-none px-2 h-8"
+            variant="SidebarMenuButton"
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              (editor.commands as any).setTextAlign(item.align);
+            }}
           >
-            <TooltipTrigger asChild>
-              <Button
-                size="sm"
-                className="border-none px-2 h-8"
-                variant="SidebarMenuButton"
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  (editor.commands as any).setTextAlign(item.align);
-                }}
-              >
-                <item.icon
-                  className={cn("h-4 w-4", {
-                    "text-primary": item.isActive(editor),
-                    "text-foreground": !item.isActive(editor),
-                  })}
-                />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent
-              side="top"
-              className=" flex justify-center items-center px-1.5"
-              sideOffset={6}
-            >
-              <span>{item.label}</span>
-              <ShortcutBadge keys={item.shortcut} />
-            </TooltipContent>
-          </Tooltip>
+            <item.icon
+              className={cn("h-4 w-4", {
+                "text-primary": item.isActive(editor),
+                "text-foreground": !item.isActive(editor),
+              })}
+            />
+          </ToolbarTooltipButton>
         ))}
       </div>
   );

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -738,6 +739,7 @@ const SidebarMenuButton = React.forwardRef<
   ) => {
     const Comp = asChild ? Slot : "button";
     const { isMobile, state } = useSidebar();
+    const hoverTooltip = useHoverTooltip(0);
 
     const button = (
       <Comp
@@ -746,6 +748,7 @@ const SidebarMenuButton = React.forwardRef<
         data-size={size}
         data-active={isActive}
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+        {...(tooltip ? hoverTooltip.triggerProps : {})}
         {...props}
       />
     );
@@ -761,7 +764,7 @@ const SidebarMenuButton = React.forwardRef<
     }
 
     return (
-      <Tooltip delayDuration={0}>
+      <Tooltip open={hoverTooltip.open}>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent
           side="right"

--- a/hooks/useHoverTooltip.ts
+++ b/hooks/useHoverTooltip.ts
@@ -1,0 +1,44 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+export function useHoverTooltip(delayDuration = 0) {
+  const [open, setOpen] = useState(false);
+  const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearShowTimeout = useCallback(() => {
+    if (showTimeoutRef.current) {
+      clearTimeout(showTimeoutRef.current);
+      showTimeoutRef.current = null;
+    }
+  }, []);
+
+  const show = useCallback(() => {
+    clearShowTimeout();
+    if (delayDuration <= 0) {
+      setOpen(true);
+      return;
+    }
+    showTimeoutRef.current = setTimeout(() => {
+      setOpen(true);
+      showTimeoutRef.current = null;
+    }, delayDuration);
+  }, [clearShowTimeout, delayDuration]);
+
+  const hide = useCallback(() => {
+    clearShowTimeout();
+    setOpen(false);
+  }, [clearShowTimeout]);
+
+  useEffect(() => clearShowTimeout, [clearShowTimeout]);
+
+  return {
+    open,
+    delayDuration,
+    setOpen,
+    show,
+    hide,
+    triggerProps: {
+      onMouseEnter: show,
+      onMouseLeave: hide,
+    },
+  };
+}


### PR DESCRIPTION
## what changed

every component that was managing tooltip open state manually  with `useState<boolean>` + `onMouseEnter`/`onMouseLeave` handlers  has been migrated to a shared `useHoverTooltip(delayMs?)` hook. the hook returns `{ open, hide, triggerProps }` where `triggerProps` contains `onMouseEnter`, `onMouseLeave`, and `onFocus`/`onBlur` so you spread it onto the trigger element instead of writing the handlers inline.

**components migrated**
- `NoteSettings`  tooltip on the settings trigger button; dropdown `onOpenChange` now calls `tooltip.hide()` when the menu opens so the tooltip doesn't stay visible underneath the open dropdown
- `PdfSettings`  same pattern as `NoteSettings`
- `TableSettings`  same; removed the old `handleTooltipMouseEnter` / `handleTooltipMouseLeave` named functions
- `WorkingSpaceSettings`  same
- `WorkingSpaceSettingsSidbar`  delete button tooltip
- `NoteSettingsSidbar` pin and delete button tooltips, each with their own `useHoverTooltip(200)` instance
- `PdfSettingsSidebar`  pin and delete button tooltips
- `PublicNote`  two separate tooltips: one on the share/publish button (hides when the dropdown opens), one on the copy-link button (`copyTooltip.hide()` called on successful copy so the tooltip dismisses immediately instead of lingering)
- `NoteDownloadDropdown`  tooltip on the download button; dropdown `onOpenChange` hides the tooltip when it opens
- `AppSidebar`  four separate instances: pinned note item titles (300ms delay), pinned upload item titles (300ms), workspace item titles (300ms), and the "add workspace" action button (300ms)
- `TableTab` in `WorkingSpacePageClient`  delete-table button tooltip (100ms)
- `PdfViewerPageClient`  search panel toggle and thumbnails panel toggle buttons each get their own instance (100ms)
- `PublicNotePage` theme toggle button tooltip (200ms)
- `SidebarMenuButton` in `sidebar.tsx`  the built-in tooltip that shows the button label when the sidebar is collapsed now uses `useHoverTooltip(0)` and spreads `triggerProps` conditionally (only when a `tooltip` prop is present)

**`ToolbarTooltipButton` component in `text-buttons.tsx`**
- extracted a new `ToolbarTooltipButton` component that wraps `Button` + `Tooltip` + `TooltipContent` internally and owns its own `useHoverTooltip(300)` instance
- all the formatting buttons (bold, italic, code, etc.) and alignment buttons in the bubble menu now use `ToolbarTooltipButton` instead of duplicating the `<Tooltip><TooltipTrigger><Button>...</Button></TooltipTrigger><TooltipContent>...</TooltipContent></Tooltip>` pattern inline  cuts ~60 lines and makes adding new toolbar buttons much simpler

## why

**the old pattern was broken in a subtle way.** radix `<Tooltip>` with `disableHoverableContent` and no explicit `open` prop manages its own open state internally  but radix tooltips don't automatically close when a dropdown opens over them. so in practice, if you hovered a settings button and then clicked to open the dropdown, the tooltip would stay rendered underneath the open menu. the old fix was to set `delayDuration={0}` or `disableHoverableContent`, which helped but didn't fully solve it.

**taking manual control of `open`** is the clean fix. by controlling `open` ourselves and calling `tooltip.hide()` in the dropdown's `onOpenChange`, we guarantee the tooltip is gone before the menu appears no flicker, no overlap.

**the duplication was also a maintenance problem.** every component had its own `isTooltipOpen` state, `handleTooltipMouseEnter`, and `handleTooltipMouseLeave`  all identical. one typo or missing handler (e.g. forgetting `onMouseLeave` on a button) would cause a tooltip to get stuck open. centralizing this in a hook means the behavior is consistent everywhere and there's one place to fix if something changes.

## ui changes

no visual change  tooltips look and animate identically. the only behavioral difference is that tooltips now reliably dismiss when a dropdown opens over them instead of occasionally staying visible.