### PR TITLE
persist tab list scroll position across navigation

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -452,6 +452,13 @@ function SliderTabsList({
   const [canScrollRight, setCanScrollRight] = useState(false);
   const canScroll = canScrollLeft || canScrollRight;
 
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const saved = sessionStorage.getItem("slider-tabs-scrollX");
+    if (saved) el.scrollLeft = parseInt(saved);
+  }, []);
+
   const checkScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -471,6 +478,20 @@ function SliderTabsList({
       ro.disconnect();
     };
   }, [checkScroll, tables]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    sessionStorage.setItem("slider-tabs-scrollX", String(el.scrollLeft));
+    checkScroll();
+  }, [checkScroll]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
 
   const scroll = (dir: "left" | "right") => {
     const el = scrollRef.current;
@@ -549,7 +570,11 @@ function SliderTabsList({
             }
           >
             {tables.map((table) => (
-              <TableTab key={table._id} table={table} />
+              <TableTab
+                key={table._id}
+                data-table-id={table._id}
+                table={table}
+              />
             ))}
           </div>
         </TabsList>


### PR DESCRIPTION
## what changed

- `SliderTabsList` now saves the tab strip's `scrollLeft` to `sessionStorage` on every scroll event (key: `"slider-tabs-scrollX"`)
- on mount, it reads that value back and restores `scrollLeft` before the first paint, so the strip lands in the same position the user left it
- the scroll listener is registered with `{ passive: true }` and cleaned up on unmount
- `handleScroll` is memoized with `useCallback` and also calls the existing `checkScroll` so the left/right arrow visibility stays accurate after restoring position
- each `TableTab` now receives a `data-table-id` attribute for easier targeting if we need to scroll a specific tab into view later

## well why you ask ? 

if you had a lot of tables and scrolled the tab strip to the right to reach one, navigating away and coming back would snap the strip back to the far left. saving and restoring the scroll position means the strip stays where you left it for the duration of the session, which feels a lot less disorienting.