### PR TITLE
landing page navbar scroll bg-animatoin

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,6 @@ export default async function HomePage() {
     // Force light mode for the entire landing page regardless of user theme
     <div className="force-light">
       <div className="relative flex flex-col min-h-screen bg-background text-foreground">
-        <div className="pointer-events-none fixed bottom-0 left-0 h-16 Desktop:h-[4.2rem] bg-transparent frosted-area w-full z-[9000000]" />
         <Navbar />
         <div className="flex-grow flex-1">
           <HeroSection />

--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -32,20 +32,17 @@ export default function Navbar() {
     >
       <motion.div
         className={cn(
-          "container mx-auto flex justify-between items-center border-solid border p-4 my-2 rounded-tl-2xl transition-all duration-300",
-          inView
-            ? "border-border bg-background/50 backdrop-blur-xl"
-            : "border-transparent bg-transparent",
+          "container mx-auto flex justify-between items-center p-4 my-2 rounded-tl-2xl transition-all duration-300 bg-transparent",
         )}
-        animate={{
-          width: inView && !isMobile ? "60%" : "90%",
-        }}
         transition={{
           ease: "easeInOut",
           duration: 0.1,
           delay: 0,
         }}
       >
+        {inView && (
+          <div className=" fixed top-0 w-full min-h-24 bg-gradient-to-b from-background via-background/75 from-15% via-40% to-100% to-transparent -z-50 left-0 pointer-events-none" />
+        )}
         <div className="flex justify-center items-center gap-4">
           <Link
             href="/"
@@ -136,7 +133,7 @@ export default function Navbar() {
         </div>
 
         <button
-          className="lg:hidden p-2 hover:bg-primary/10 rounded-lg transition-colors relative group"
+          className="lg:hidden p-2 hover:bg-border app-radius-lg transition-colors relative group"
           onClick={() => setIsMenuOpen(!isMenuOpen)}
           aria-label="Toggle menu"
         >
@@ -176,13 +173,13 @@ export default function Navbar() {
           exit={{ opacity: 0, y: -10 }}
           className="lg:hidden absolute top-full left-0 right-0 mt-2 mx-4"
         >
-          <div className="bg-background/95 backdrop-blur-xl border border-border rounded-2xl p-4 shadow-lg">
+          <div className="bg-background/95 backdrop-blur-xl border border-border app-radius-xl p-4 shadow-lg">
             <nav className="flex flex-col gap-2">
               {NavLinks.map((link, i) => (
                 <Link
                   key={i}
                   href={link.path}
-                  className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-primary/10 rounded-lg transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-border app-radius-md transition-colors"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   {link.Name}
@@ -213,3 +210,4 @@ export default function Navbar() {
     </motion.header>
   );
 }
+3;


### PR DESCRIPTION
## what changed

- removed the animated pill behavior where the navbar would shrink to 60% width on desktop when in view  the container is now always full width with `bg-transparent`
- replaced the conditional border + backdrop blur on the navbar container with a fixed full-width gradient div (`from-background via-background/75 to-transparent`) that appears when the navbar is in view  gives a softer fade into the page content instead of a hard bordered pill
- removed the frosted area overlay div from `app/page.tsx` that was sitting at the bottom of the page
- mobile menu toggle button hover changed from `hover:bg-primary/10 rounded-lg` to `hover:bg-border app-radius-lg` for consistency
- mobile menu dropdown container changed from `rounded-2xl` to `app-radius-xl`
- mobile nav links hover changed from `hover:bg-primary/10 rounded-lg` to `hover:bg-border app-radius-md`
- stray `3;` accidentally left at the bottom of the file should be removed before merging

before 
<img width="1578" height="814" alt="image" src="https://github.com/user-attachments/assets/9df05418-787d-4474-8b56-688927727925" />

after 
<img width="1538" height="666" alt="image" src="https://github.com/user-attachments/assets/5343162b-6575-4845-bd24-a7fcbf90c931" />

the shrinking pill navbar looked a bit overdone and the width animation could feel janky on slower connections. the gradient approach achieves the same "navbar floats above content" feeling with less motion and no layout shift.