### PR TITLE
floating header and scroll fade cleanup

### DIFF
--- a/components/home-components/BreadcrumbWithCustomSeparator.tsx
+++ b/components/home-components/BreadcrumbWithCustomSeparator.tsx
@@ -54,7 +54,7 @@ export default function BreadcrumbWithCustomSeparator() {
   };
 
   return (
-    <div className="bg-background py-2">
+    <div className="py-2">
       <Breadcrumb>
         <BreadcrumbList className="flex flex-nowrap overflow-x-auto whitespace-nowrap text-primary scrollbar-thin">
           {pathSegments.map((segment, index) => {

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -94,8 +94,8 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
-        <div className="z-[10] relative w-full flex min-h-12 items-center justify-start  gap-3 mx-auto bg-background rounded-tl-lg border-none ">
-          <div className="  flex justify-between items-center w-full px-4 py-2 ">
+        <div className="z-[10] absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
+          <div className="flex justify-between items-center w-full px-4 py-2 ">
             <div className="flex justify-start items-center gap-3">
               {(!open || isMobile) && <SidebarTrigger />}
               <BreadcrumbWithCustomSeparator />
@@ -131,20 +131,16 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         <div
           ref={scrollContainerRef}
           className={`min-h-0 flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent ${
-            isPdfRoute ? "overflow-hidden py-0" : "overflow-y-auto py-6"
+            isPdfRoute ? "overflow-hidden pt-12" : "overflow-y-auto pt-16"
           }`}
         >
-          {!isPdfRoute ? (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: showTopFade ? 1 : 0 }}
-              transition={
-                showTopFade ? fadeTransition.show : fadeTransition.hide
-              }
-              className="sticky -top-12 left-0 w-full h-28 bg-gradient-to-b from-background from-25% to-transparent to-100% z-[5] pointer-events-none -mb-32"
-              aria-hidden
-            />
-          ) : null}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: showTopFade ? 1 : 0 }}
+            transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
+            className="rounded-tl-lg absolute top-0 left-0 w-full h-[7rem] bg-gradient-to-b from-background from-10% via-background/55 via-55% to-100% to-transparent z-[5] pointer-events-none -mb-16"
+            aria-hidden
+          />
           {children}
         </div>
         <MobileWarning />

--- a/components/slash-command.tsx
+++ b/components/slash-command.tsx
@@ -67,7 +67,7 @@ function YoutubeDialog({
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent>
+      <DialogContent className=" pb-2.5 px-4">
         <DialogHeader>
           <DialogTitle>Embed YouTube Video</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## what changed

**header now floats over content**
- the header bar (`z-[10]`) changed from `relative` with a fixed min-height to `absolute top-0 left-0` with no background, so it sits on top of the scroll container instead of pushing content down
- `bg-background` removed from the header so it's transparent by default
- `bg-background` also removed from `BreadcrumbWithCustomSeparator`'s wrapper for the same reason
- scroll container top padding adjusted to `pt-16` (non-pdf routes) and `pt-12` (pdf route) to compensate for the now-overlapping header, so content doesn't start hidden underneath it

**scroll fade simplified**
- the top-of-scroll gradient was previously conditional  it was skipped entirely on pdf routes. now it always renders
- gradient changed from `from-background from-25%` to a three-stop `from-background from-10% via-background/55 via-55% to-transparent` which gives a softer, more gradual fade and works better over the floating header
- gradient div changed from `sticky -top-12 ... -mb-32` (a sticky trick to keep it in the flow) to `absolute top-0 left-0` which is simpler and doesn't affect scroll layout
- `rounded-tl-lg` added to match the main content area's corner

**youtube embed dialog**
- padding adjusted to `pb-2.5 px-4` so the dialog content has tighter, more balanced spacing

before 
<img width="1383" height="256" alt="image" src="https://github.com/user-attachments/assets/09798ed2-9301-4f66-8ed2-146c12474998" />

now 
<img width="1399" height="317" alt="image" src="https://github.com/user-attachments/assets/94cae612-ffad-4285-ada7-20116056e4d3" />


the old header was part of the document flow, which meant the scroll container had to account for its height explicitly and the sticky gradient trick was needed to cover the gap. making the header absolutely positioned simplifies this: the scroll container owns the full height, the header floats above it, and the gradient naturally covers the header area as you scroll.