### PR TITLE
fix z-index: clean up tabs scroll buttons,layout layers

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -512,7 +512,7 @@ function SliderTabsList({
           onClick={() => scroll("left")}
           aria-label="scroll-tabs-left"
           className={cn(
-            "absolute left-1 top-1/2 -translate-y-1/2 z-20 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-sm",
+            "absolute left-1 top-1/2 -translate-y-1/2 z-10 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-sm",
             canScrollLeft
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none",
@@ -527,7 +527,7 @@ function SliderTabsList({
           onClick={() => scroll("right")}
           aria-label="scroll-tabs-right"
           className={cn(
-            "absolute right-1 top-1/2 -translate-y-1/2 z-20 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-sm",
+            "absolute right-1 top-1/2 -translate-y-1/2 z-10 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-sm",
             canScrollRight
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none",
@@ -537,7 +537,7 @@ function SliderTabsList({
         </Button>
 
         <div
-          className="absolute left-0 top-0 bottom-0 w-32 z-10 pointer-events-none transition-opacity duration-200"
+          className="absolute left-0 top-0 bottom-0 w-32 z-[5] pointer-events-none transition-opacity duration-200"
           style={{
             opacity: canScrollLeft ? 1 : 0,
             background:
@@ -545,7 +545,7 @@ function SliderTabsList({
           }}
         />
         <div
-          className="absolute right-0 top-0 bottom-0 w-32 z-10 pointer-events-none transition-opacity duration-200"
+          className="absolute right-0 top-0 bottom-0 w-32 z-[5] pointer-events-none transition-opacity duration-200"
           style={{
             opacity: canScrollRight ? 1 : 0,
             background:
@@ -797,7 +797,7 @@ export default function WorkingSpacePageClient({
             <CreateTableBtn
               label="New Table"
               workingSpaceId={workingSpaceId}
-              className=" z-50 absolute -bottom-[0.04rem] right-0 h-9 rounded-tr-none rounded-b-none hover:translate-x-[-2px] hover:translate-y-[-2px] hover:rounded-b-none hover:rounded-tr-none hover:shadow-[2px_2px_0px]"
+              className=" z-10 absolute -bottom-[0.04rem] right-0 h-9 rounded-tr-none rounded-b-none hover:translate-x-[-2px] hover:translate-y-[-2px] hover:rounded-b-none hover:rounded-tr-none hover:shadow-[2px_2px_0px]"
               aria-label="create-table"
             />
           )}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -94,7 +94,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
-        <div className="z-[10] absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
+        <div className="z-50 absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
           <div className="flex justify-between items-center w-full px-4 py-2 ">
             <div className="flex justify-start items-center gap-3">
               {(!open || isMobile) && <SidebarTrigger />}
@@ -138,7 +138,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
             initial={{ opacity: 0 }}
             animate={{ opacity: showTopFade ? 1 : 0 }}
             transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
-            className="rounded-tl-lg absolute top-0 left-0 w-full h-[7rem] bg-gradient-to-b from-background from-10% via-background/55 via-55% to-100% to-transparent z-[5] pointer-events-none -mb-16"
+            className="rounded-tl-lg absolute top-0 left-0 w-full h-[7rem] bg-gradient-to-b from-background from-10% via-background/55 via-55% to-100% to-transparent z-20 pointer-events-none -mb-16"
             aria-hidden
           />
           {children}


### PR DESCRIPTION
adjusted z-index values across a few components:

before : 
<img width="1307" height="234" alt="image" src="https://github.com/user-attachments/assets/21dee837-0734-4a6b-9eda-a7752bebb4b0" />

now : 
<img width="1315" height="278" alt="image" src="https://github.com/user-attachments/assets/7f251bb9-8255-4a24-8b15-1e69d80d2fd7" />


- lowered scroll buttons and fade gradients in the workspace tabs
- raised the top navigation bar and top fade gradient in the home layout

this prevents unwanted overlaps and makes the overall layering cleaner and more consistent.
