### PR TITLE
hero section left-align and cleanup

### DIFF
--- a/components/landingPage-components/HeroSection.tsx
+++ b/components/landingPage-components/HeroSection.tsx
@@ -157,18 +157,15 @@ export default function HeroSection() {
         </motion.svg>
       </div>
 
-      <MaxWContainer className="z-[6] relative flex flex-col items-center justify-center space-y-5">
+      <MaxWContainer className="z-[6] relative flex flex-col items-start justify-center space-y-5">
         <motion.div
           initial={{ opacity: 0, y: 20, filter: "blur(12px)" }}
           animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
           transition={{ duration: 0.45 }}
-          className="relative space-y-3 text-center"
+          className="relative space-y-4 text-start"
         >
-          <Badge className="absolute -top-7 w-fit text-nowrap text-sm left-1/2 -translate-x-1/2 z-50 bg-secondary text-secondary-foreground shadow-xl shadow-black/30">
-            we're working on adding AI coming soon 🤞🏽
-          </Badge>
           <motion.h1
-            className="bg-gradient-to-r from-primary/80 via-primary to-primary/80 bg-clip-text text-transparent leading-[50px] text-[46px] md:text-8xl Desktop:text-[100px] font-bold tracking-tight"
+            className=" pt-3.5 bg-gradient-to-r from-primary/90 via-primary to-primary/90 bg-clip-text text-transparent leading-[50px] md:leading-[95px] md:text-[100px] text-[46px] font-bold tracking-tight"
             initial={{ opacity: 0, y: 20, filter: "blur(12px)" }}
             animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
             transition={{ duration: 0.45, delay: 0.1 }}
@@ -176,12 +173,12 @@ export default function HeroSection() {
             <span>Simple, Structured</span>
             <br />
             <motion.span
-              className="relative inline-block px-2"
+              className="relative inline-block "
               initial={{ opacity: 0, y: 10, filter: "blur(8px)" }}
               animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
               transition={{ duration: 0.35, ease: "easeOut" }}
             >
-              <span className="bg-gradient-to-r from-primary/80 via-primary to-primary/80 bg-clip-text">
+              <span className=" text-start bg-gradient-to-r from-primary/90 via-primary to-primary/90 bg-clip-text">
                 Note Taking
               </span>
               <motion.svg
@@ -209,7 +206,7 @@ export default function HeroSection() {
             </motion.span>
           </motion.h1>
           <motion.p
-            className="mx-auto max-w-2xl text-lg md:text-2xl text-muted-foreground font-bold"
+            className="text-start px-2.5 max-w-2xl text-lg md:text-2xl text-muted-foreground font-bold"
             initial={{ opacity: 0, y: 20, filter: "blur(10px)" }}
             animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
             transition={{ duration: 0.45, delay: 0.2 }}
@@ -219,7 +216,7 @@ export default function HeroSection() {
             and organize them in one clean, modern interface.
           </motion.p>
           <motion.div
-            className="flex gap-4 justify-center items-center"
+            className="flex px-2.5 gap-4 justify-start items-center"
             initial={{ opacity: 0, y: 20, filter: "blur(8px)" }}
             animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
             transition={{ duration: 0.45, delay: 0.3 }}
@@ -257,7 +254,7 @@ export default function HeroSection() {
             </Button>
           </motion.div>
           <motion.div
-            className="flex items-center justify-center gap-8 pb-2"
+            className="flex items-center justify-start gap-8 px-2.5 "
             initial={{ opacity: 0, y: 20, filter: "blur(8px)" }}
             animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
             transition={{ duration: 0.45, delay: 0.42 }}
@@ -265,16 +262,11 @@ export default function HeroSection() {
             <div className="flex -space-x-4">
               {status === "LoadingFirstPage" ? (
                 Array.from({ length: 5 }).map((_, index) => (
-                  <motion.div
-                    key={index}
-                    initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
-                    transition={{ delay: 0.6 + index * 0.08 }}
-                  >
+                  <div key={index}>
                     <Avatar className="w-10 h-10">
                       <AvatarFallback className="bg-primary/20 rounded-full animate-pulse" />
                     </Avatar>
-                  </motion.div>
+                  </div>
                 ))
               ) : (
                 <>
@@ -282,12 +274,7 @@ export default function HeroSection() {
                     .filter((user) => user.image && user.name)
                     .slice(0, 5)
                     .map((user, indx) => (
-                      <motion.div
-                        key={user._id}
-                        initial={{ scale: 0 }}
-                        animate={{ scale: 1 }}
-                        transition={{ delay: 0.6 + indx * 0.08 }}
-                      >
+                      <div key={user._id}>
                         <Avatar className="w-10 h-10">
                           <AvatarImage
                             src={user.image || "/placeholder.svg"}
@@ -298,7 +285,7 @@ export default function HeroSection() {
                             {user.name ? user.name.charAt(0) : "U"}
                           </AvatarFallback>
                         </Avatar>
-                      </motion.div>
+                      </div>
                     ))}
                   {results.length > 5 && (
                     <motion.div

--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -32,7 +32,7 @@ export default function Navbar() {
     >
       <motion.div
         className={cn(
-          "container mx-auto flex justify-between items-center w-[90%] p-4 my-2 rounded-tl-2xl transition-all duration-300 bg-transparent",
+          "container mx-auto flex justify-between items-center md:w-[90%] p-4 my-2 rounded-tl-2xl transition-all duration-300 bg-transparent",
         )}
         transition={{
           ease: "easeInOut",


### PR DESCRIPTION
## what changed
before : 
<img width="1583" height="807" alt="image" src="https://github.com/user-attachments/assets/86b27c11-3591-4386-b6d4-bb832c0c9533" />

now : 
<img width="1528" height="860" alt="image" src="https://github.com/user-attachments/assets/e5fd3ee1-f8d5-4eb0-a7c1-e37a0b789c85" />

**layout alignment**
- hero content changed from centered (`items-center`, `text-center`, `justify-center`) to left-aligned (`items-start`, `text-start`, `justify-start`) across the heading, subheading, cta buttons, and social proof row
- `mx-auto max-w-2xl` removed from the subheading paragraph since it was centering the text block; replaced with `px-2.5` for consistent left padding
- cta button row and social proof row also get `px-2.5` to align with the paragraph

**heading tweaks**
- line height on the h1 gets an explicit `md:leading-[95px]` for large screens so the oversized text doesn't clip
- `px-2` removed from the "Note Taking" animated span since the left-aligned layout doesn't need the extra horizontal padding
- gradient opacity bumped slightly from `primary/80` to `primary/90` for both gradient stops

**avatar animation cleanup**
- the staggered `motion.div` scale-in animation wrapping each user avatar (and the loading skeleton avatars) was removed they're now plain `div`s. the entrance animation on a row of small avatars wasn't noticeable enough to justify the extra framer-motion overhead

**navbar**
- `w-[90%]` changed to `md:w-[90%]` so the navbar container doesn't constrain width on mobile

centered hero text is a common default but left-aligned tends to feel more editorial and intentional, especially paired with a large heading. removing the ai badge cleans up the above-the-fold without losing anything meaningful.