### PR TITLE
public note: width toggle, creation date,utils cleanup

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -11,22 +11,31 @@ import NoteLoadingSkeletonUI from "@/components/ui/NoteLoadingSkeletonUI";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
 import Link from "next/link";
-import { Moon, Sun, Slash } from "lucide-react";
+import {
+  Moon,
+  Sun,
+  Slash,
+  ChevronsLeftRightEllipsis,
+  ChevronsRightLeft,
+} from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { parseSlug } from "@/lib/parseSlug";
-import { formatUserNoteTitle } from "@/lib/utils";
+import { cn, formatNoteTimestamp, formatUserNoteTitle } from "@/lib/utils";
 import { ReadOnlyWarning } from "@/components/readOnly-warning";
 import NoteDownloadDropdown from "@/components/home-components/NoteDownloadDropdown";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import { useNoteWidth } from "@/hooks/useNoteWidth";
 
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
-  const themeTooltip = useHoverTooltip(200);
+  const themeTooltip = useHoverTooltip(100);
+  const noteWidthTooltip = useHoverTooltip(100);
+  const { noteWidth, toggleWidth } = useNoteWidth();
 
   const cycleTheme = () => {
     if (resolvedTheme === "light") setTheme("dark");
@@ -115,30 +124,59 @@ export default function PublicNotePage() {
       <header className=" sticky top-0 left-0 w-full z-[10000]">
         <div className=" px-4 p-3 flex justify-between items-center bg-gradient-to-b from-background from-20% to-transparent w-full">
           <ReadOnlyWarning />
-          <p className="text-sm text-foreground w-full px-1.5 py-1.5 h-8">
+          <p className=" flex flex-col justify-center items-start text-md text-foreground w-full px-1.5 mt-2.5 h-8">
             {PublicNoteTitle}
+            <span className="px-1 pt-0.5 text-[10px] leading-4 text-nowrap text-muted-foreground">
+              Created {formatNoteTimestamp(getNote.createdAt)}
+            </span>
           </p>
           <div className="flex justify-end items-center gap-1 w-full">
+            <Tooltip open={noteWidthTooltip.open}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="w-8 h-8 pt-0.5"
+                  size="icon"
+                  onClick={toggleWidth}
+                  aria-label="toggle-note-width"
+                  {...noteWidthTooltip.triggerProps}
+                >
+                  {noteWidth === "false" ? (
+                    <>
+                      <ChevronsLeftRightEllipsis className="h-[1.4rem] w-[1.4rem]" />
+                    </>
+                  ) : (
+                    <>
+                      <ChevronsRightLeft className="h-[1.4rem] w-[1.4rem]" />
+                    </>
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent align="end" side="bottom">
+                Width toggle
+              </TooltipContent>
+            </Tooltip>
+
             <NoteDownloadDropdown
               noteBody={JSON.stringify(content)}
               noteTitle={getNote.title ?? "note"}
             />
             <Tooltip open={themeTooltip.open}>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="w-8 h-8 mt-0.5"
-                    size="icon"
-                    onClick={cycleTheme}
-                    {...themeTooltip.triggerProps}
-                  >
-                    {getThemeIcon()}
-                    <span className="sr-only">Toggle theme</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent align="end" side="bottom">
-                  Toggle theme
-                </TooltipContent>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="w-8 h-8 pt-0.5"
+                  size="icon"
+                  onClick={cycleTheme}
+                  {...themeTooltip.triggerProps}
+                >
+                  {getThemeIcon()}
+                  <span className="sr-only">Toggle theme</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent align="end" side="bottom">
+                Toggle theme
+              </TooltipContent>
             </Tooltip>
             <Button variant="secondary" className="text-sm px-1.5 py-1.5 h-8">
               <Link
@@ -153,7 +191,12 @@ export default function PublicNotePage() {
         </div>
       </header>
 
-      <MaxWContainer className="Desktop:container Desktop:mx-auto flex-1">
+      <MaxWContainer
+        className={cn(
+          noteWidth === "false" ? " Desktop:w-[900px] w-full px-4" : "px-6",
+          " pb-28 mx-auto",
+        )}
+      >
         <TailwindAdvancedEditor
           editorBubblePlacement={true}
           initialContent={parsedContent}

--- a/app/home/[id]/pdf/[pdfId]/loading.tsx
+++ b/app/home/[id]/pdf/[pdfId]/loading.tsx
@@ -8,8 +8,8 @@ function Skeleton({ className = "" }: { className?: string }) {
 
 export default function Loading() {
   return (
-    <div className="flex h-full max-w-full min-h-0 flex-col px-0 py-0 mx-0">
+    <MaxWContainer className="flex h-full w-[900px] flex-col px-0 py-0 mx-0">
       <div className="flex-1 rounded-none border border-border bg-card animate-pulse" />
-    </div>
+    </MaxWContainer>
   );
 }

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -32,7 +32,7 @@ export default function NoteDownloadDropdown({
   className,
 }: NoteDownloadDropdownProps) {
   const { handleDownload } = useNoteDownload({ noteBody, noteTitle });
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(100);
 
   const formats: {
     label: string;
@@ -69,7 +69,7 @@ export default function NoteDownloadDropdown({
             <Button
               variant="ghost"
               size="icon"
-              className={`w-8 h-8 mt-0.5 ${className ?? ""}`}
+              className={`w-8 h-8 pt-0.5 ${className ?? ""}`}
               {...tooltip.triggerProps}
             >
               <Download className="h-[1.2rem] w-[1.2rem]" />

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -53,6 +53,7 @@ import { useNoteWidth } from "@/hooks/useNoteWidth";
 import { useNoteDownload } from "@/hooks/useNoteDownload";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import MoveNoteDialog from "./MoveNoteDialog";
+import { formatNoteTimestamp } from "@/lib/utils";
 
 interface NoteSettingsProps {
   noteId: Id<"notes">;
@@ -66,18 +67,6 @@ interface NoteSettingsProps {
 }
 
 const NOTE_TITLE_MAX_LENGTH = 55;
-
-const formatNoteTimestamp = (timestamp?: number) => {
-  if (!timestamp) return "";
-
-  return new Date(timestamp).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-};
 
 export default function NoteSettings({
   noteId,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -53,3 +53,15 @@ export const formatTableName = (TableName: string) => {
   const max = getMaxTableNameLength();
   return TableName.length > max ? `${TableName.slice(0, max)}...` : TableName;
 };
+
+export const formatNoteTimestamp = (timestamp?: number) => {
+  if (!timestamp) return "";
+
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};


### PR DESCRIPTION
## what changed

before :
<img width="1284" height="510" alt="image" src="https://github.com/user-attachments/assets/4a2dd3a0-8bf4-4b68-849c-d969dc9b75af" />

after : 
<img width="1288" height="883" alt="image" src="https://github.com/user-attachments/assets/f803877f-c63d-4fef-9080-e1fc52146324" />


**width toggle on the public note page**
- added a width toggle button to the public note header using the existing `useNoteWidth` hook, so readers get the same narrow/wide layout control that exists in the private editor
- button shows `ChevronsLeftRightEllipsis` when in narrow mode and `ChevronsRightLeft` when wide, matching the icon convention used elsewhere
- `MaxWContainer` on the public page now applies the same conditional width logic: `Desktop:w-[900px] w-full px-4` for narrow, `px-6` for wide

**creation date in the header**
- the note title in the public page header now shows a second line with `"Created {date}"` using `formatNoteTimestamp`  gives readers basic context without cluttering the layout

**`formatNoteTimestamp` moved to `lib/utils`**
- the function was previously defined inline inside `NoteSettings.tsx`. it's now exported from `lib/utils.ts` and imported in both `NoteSettings` and the public note page  single source of truth, no duplication

**minor button alignment fix**

**pdf loading skeleton**
- `loading.tsx` for the pdf route now wraps the skeleton in `MaxWContainer` with `w-[900px]` instead of a plain `div`, so the loading state matches the actual pdf viewer dimensions

**tooltip delay**
- `useHoverTooltip` delay on `NoteDownloadDropdown` reduced from default to `100ms` to match the rest of the header buttons