### PR TITLE
pdf viewer toolbar positioning, gradient layering fixes

### DIFF
--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -486,7 +486,7 @@ function PdfViewerContent({
       }
     >
       <div className=" relative min-w-full min-h-full bg-transparent ">
-        <div className="pointer-events-none absolute inset-x-0 top-1 z-50">
+        <div className="pointer-events-none absolute inset-x-0 top-10 z-50">
           <div className="pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-3 app-radius-lg border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl">
             <div className="flex items-center gap-0">
               <Tooltip open={searchTooltip.open}>
@@ -568,6 +568,10 @@ function PdfViewerContent({
           </div>
         ) : null}
         <div className=" absolute inset-y-0 right-0 z-30 flex h-screen w-full items-center justify-center border-b border-border bg-background">
+          <div
+            className=" absolute top-0 left-0 w-full h-[4rem] bg-gradient-to-b from-background from-0% via-background/75 via-45% to-100% to-transparent z-[900000] pointer-events-none"
+            aria-hidden
+          />
           <Pages className="h-full min-h-0 w-full transition-all scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
             <Page>
               <CanvasLayer />
@@ -592,7 +596,7 @@ function PdfViewerShell({
     <Root
       source={fileUrl}
       isZoomFitWidth
-      className="pdf-viewer-shell relative h-full w-full overflow-hidden rounded-none border-0 bg-background flex flex-col justify-stretch"
+      className="rounded-tl-lg pdf-viewer-shell relative h-full w-full overflow-hidden rounded-none border-0 bg-background flex flex-col justify-stretch"
       loader={
         <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
           Loading PDF...

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -94,7 +94,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
-        <div className="z-50 absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
+        <div className="z-[60000] absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
           <div className="flex justify-between items-center w-full px-4 py-2 ">
             <div className="flex justify-start items-center gap-3">
               {(!open || isMobile) && <SidebarTrigger />}
@@ -131,14 +131,14 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         <div
           ref={scrollContainerRef}
           className={`min-h-0 flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent ${
-            isPdfRoute ? "overflow-hidden pt-12" : "overflow-y-auto pt-16"
+            isPdfRoute ? "overflow-hidden pt-0" : "overflow-y-auto pt-16"
           }`}
         >
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: showTopFade ? 1 : 0 }}
             transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
-            className="rounded-tl-lg absolute top-0 left-0 w-full h-[7rem] bg-gradient-to-b from-background from-10% via-background/55 via-55% to-100% to-transparent z-20 pointer-events-none -mb-16"
+            className="rounded-tl-lg absolute top-0 left-0 w-full h-[4rem] bg-gradient-to-b from-background from-0% via-background/65 via-45% to-100% to-transparent z-[50000] pointer-events-none -mb-16"
             aria-hidden
           />
           {children}


### PR DESCRIPTION
## what changed

**pdf viewer toolbar nudged down**
- toolbar container moved from `top-1` to `top-10` so it clears the app header bar and doesn't overlap the breadcrumb/settings row

**gradient fade inside the pdf viewer**
- added a `h-[4rem]` gradient div at the top of the pages container (`from-background via-background/75 to-transparent`) so the toolbar floats visually above the pdf content without a hard edge
- this gradient sits at `z-[900000]` inside the pages wrapper, above the pdf canvas layers

**z-index fixes**
- global header (`HomeClientLayout`) bumped from `z-50` to `z-[60000]` so it renders above the pdf viewer's internal layers, which were creeping up with higher z-values
- scroll fade gradient in `HomeClientLayout` changed from `z-20` to `z-[50000]` and its height reduced from `7rem` to `4rem` to match the tighter header height; gradient stops adjusted to `from-0% via-45%` for a slightly sharper fade
- pdf route scroll container top padding changed from `pt-12` to `pt-0` since the header is now absolutely positioned above the viewer and doesn't need padding compensation

**pdf viewer shell corner**
- `rounded-tl-lg` added to `PdfViewerShell`'s root element so the viewer respects the same corner radius as the main content area when the sidebar is open