### PR TITLE
pdf toolbar: pagenav polish,PdfSettings variant prop

### DIFF
--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -417,45 +417,48 @@ function PageNavigator() {
   }, [currentPage, pageNumber]);
 
   return (
-    <div className="flex items-center gap-0 text-sm text-muted-foreground">
+    <div className=" flex items-center gap-0 text-sm text-muted-foreground ">
       <Button
         type="button"
         variant="outline"
         size="icon"
-        className="h-8 w-8 "
+        className="h-8 w-8 border-border"
         onClick={handlePreviousPage}
         disabled={currentPage <= 1}
         aria-label="previous-page"
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
-      <Input
-        type="number"
-        value={pageNumber}
-        onChange={(e) => setPageNumber(e.target.value)}
-        onBlur={(e) => {
-          const value = Number(e.target.value);
-          if (value >= 1 && value <= pages && currentPage !== value) {
-            jumpToPage(value, { behavior: "auto" });
-          } else {
-            setPageNumber(currentPage);
-          }
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.currentTarget.blur();
-          }
-        }}
-        inputMode="numeric"
-        aria-label="current-page-input"
-        className="h-7 w-7 p-0 mx-1 mb-0 bg-transparent border-0 text-center text-sm font-medium text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-      />
-      <span className=" mr-3"> of {pages || 1}</span>
+      <div className="flex justify-center items-center bg-background border-t border-b border-border h-8 ">
+        <Input
+          type="number"
+          value={pageNumber}
+          onChange={(e) => setPageNumber(e.target.value)}
+          onBlur={(e) => {
+            const value = Number(e.target.value);
+            if (value >= 1 && value <= pages && currentPage !== value) {
+              jumpToPage(value, { behavior: "auto" });
+            } else {
+              setPageNumber(currentPage);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.currentTarget.blur();
+            }
+          }}
+          inputMode="numeric"
+          aria-label="current-page-input"
+          className="h-7 w-7 p-0 mx-1 mb-0 bg-transparent border-0 text-center text-sm font-medium text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+        />
+        <span className=" mr-3"> of {pages || 1}</span>
+      </div>
+
       <Button
         type="button"
         variant="outline"
         size="icon"
-        className="h-8 w-8"
+        className="h-8 w-8 border-border !rounded-none"
         onClick={handleNextPage}
         disabled={currentPage >= pages}
         aria-label="next-page"
@@ -540,7 +543,7 @@ function PdfViewerContent({
                     {panelMode === "thumbnails" ? (
                       <X size={16} />
                     ) : (
-                      <span className="text-[11px] pb-1 font-semibold">Pg</span>
+                      <span className="text-[11px] font-semibold">Pg</span>
                     )}
                   </Button>
                 </TooltipTrigger>
@@ -559,6 +562,8 @@ function PdfViewerContent({
               iconVariant="horizontal_icon"
               dropdownMenuContentAlign="end"
               tooltipContentAlign="end"
+              btnVariant="outline"
+              btnClassName="h-8 w-8 mt-0 px-1 border-border"
             />
           </div>
         </div>

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -51,6 +51,11 @@ interface PdfSettingsProps {
   pdfTitle?: string;
   iconVariant: "vertical_icon" | "horizontal_icon";
   btnClassName?: string;
+  btnVariant?:
+    | "outline"
+    | "SidebarMenuButton"
+    | "SidebarMenuButton_destructive"
+    | "Trigger";
   dropdownMenuContentAlign: "end" | "start";
   tooltipContentAlign: "end" | "start";
   onDelete?: (pdfId: Id<"pdfs">) => void;
@@ -75,6 +80,7 @@ export default function PdfSettings({
   pdfTitle,
   iconVariant,
   btnClassName,
+  btnVariant,
   dropdownMenuContentAlign,
   tooltipContentAlign,
   onDelete,
@@ -174,8 +180,8 @@ export default function PdfSettings({
           <DropdownMenuTrigger asChild>
             <TooltipTrigger asChild>
               <Button
-                variant="outline"
-                className="h-8 w-8 "
+                variant={btnVariant || "Trigger"}
+                className={cn("px-0.5 h-8 mt-0.5", btnClassName)}
                 size="icon"
                 {...tooltip.triggerProps}
                 aria-label="upload-options"


### PR DESCRIPTION
## what changed
before : 
<img width="1670" height="176" alt="image" src="https://github.com/user-attachments/assets/5159618f-8c96-4e27-ab40-1aa18acc058b" />

now : 
<img width="544" height="121" alt="image" src="https://github.com/user-attachments/assets/512a29a5-a694-4f97-ba5d-9f2f4f2e8fc9" />

**page navigator layout**
- the page input and "of N" label are now wrapped in a shared `div` with `border-t border-b border-border h-8 bg-background` so they form a continuous bordered segment between the prev/next buttons, making the navigator read as a single connected control
- prev button border classes cleaned up (`!border-l-0 !border-t-0 !border-b-0` replaced with just `border-border`)
- next button gets `!rounded-none` so the right edge is square and butts up against the `PdfSettings` button cleanly

**`PdfSettings` trigger button now accepts a `btnVariant` prop**
- added an optional `btnVariant` prop (`"outline" | "SidebarMenuButton" | "SidebarMenuButton_destructive" | "Trigger"`) so callers can control the button style without overriding classes
- defaults to `"Trigger"` to preserve existing behavior everywhere the component is already used
- in the viewer toolbar, it's called with `btnVariant="outline"` and `btnClassName="h-8 w-8 mt-0 px-1 border-border"` so the settings button matches the outline style of the other toolbar buttons

**minor**
- removed `pb-1` from the thumbnails "Pg" label that was added in a previous pass  it was causing the text to sit slightly low inside the button