### PR TITLE
pdf viewer sidebar-aware rounding and small polish

### DIFF
--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -51,6 +51,8 @@ import {
 } from "@/components/ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import PdfSettings from "@/components/home-components/PdfSettings";
+import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
+import BreadcrumbWithCustomSeparator from "@/components/home-components/BreadcrumbWithCustomSeparator";
 
 GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/legacy/build/pdf.worker.mjs",
@@ -480,6 +482,7 @@ function PdfViewerContent({
   pdfId: Id<"pdfs">;
   pdftitle: string;
 }) {
+  const { open, isMobile } = useSidebar();
   const [query, setQuery] = useState("");
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
   const searchTooltip = useHoverTooltip(100);
@@ -494,8 +497,10 @@ function PdfViewerContent({
       }
     >
       <div className=" relative min-w-full min-h-full bg-transparent ">
-        <div className="pointer-events-none absolute inset-x-0 top-1 z-50">
-          <div className="pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-1 app-radius-lg border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl">
+        <div className=" pointer-events-none absolute inset-x-0 top-1 z-50">
+          <div
+            className={`pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-1 ${open && !isMobile ? ` app-radius-lg` : null} border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl`}
+          >
             <div className="flex items-center gap-0">
               <Tooltip open={searchTooltip.open}>
                 <TooltipTrigger asChild>
@@ -610,11 +615,13 @@ function PdfViewerShell({
   pdfId: Id<"pdfs">;
   pdftitle: string;
 }) {
+  const { open, isMobile } = useSidebar();
+
   return (
     <Root
       source={fileUrl}
       isZoomFitWidth
-      className="rounded-tl-lg pdf-viewer-shell relative h-full w-full overflow-hidden rounded-none border-0 bg-background flex flex-col justify-stretch"
+      className={`${open && !isMobile ? `app-radius-lg` : null} pdf-viewer-shell relative h-full w-full overflow-hidden rounded-none border-0 bg-background flex flex-col justify-stretch`}
       loader={
         <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
           Loading PDF...

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -97,7 +97,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         <div className="z-[60000] absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
           <div className="flex justify-between items-center w-full px-4 py-2 ">
             <div className="flex justify-start items-center gap-3">
-              {(!open || isMobile) && <SidebarTrigger />}
+              {(!open || isMobile) && !isPdfRoute && <SidebarTrigger />}
               {!isPdfRoute ? <BreadcrumbWithCustomSeparator /> : null}
             </div>
             <div>

--- a/components/home-components/MoveNoteDialog.tsx
+++ b/components/home-components/MoveNoteDialog.tsx
@@ -189,10 +189,10 @@ export default function MoveNoteDialog({
         title: "Note moved successfully ",
         description: "hey go and take a look at your stuff !!",
         action: (
-          <Button variant="secondary" className="px-4 " size="sm">
+          <Button variant="secondary" className="px-3 h-8" size="sm">
             <IntentPrefetchLink
               href={`/home/${result.workingSpaceId}/${result.slug}?id=${note._id}`}
-              className="flex justify-center items-center gap-2"
+              className="flex justify-center items-center gap-2 text-xs"
             >
               <FileSymlink size={16} />
               Checkout

--- a/components/home-components/MovePdfDialog.tsx
+++ b/components/home-components/MovePdfDialog.tsx
@@ -180,7 +180,7 @@ export default function MovePdfDialog({
         title: "Upload moved successfully",
         description: "Jump straight to the file in its new location.",
         action: (
-          <Button variant="secondary" className="px-4" size="sm" asChild>
+          <Button variant="secondary" className="px-3 h-8" size="sm" asChild>
             <IntentPrefetchLink
               href={`/home/${result.workingSpaceId}/pdf/${pdfSlug}?pdfId=${pdf._id}`}
               className="flex justify-center items-center gap-2"

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -25,7 +25,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative backdrop-blur-sm flex w-full items-center justify-between space-x-2 overflow-hidden app-radius-md border p-2.5 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative backdrop-blur-sm flex w-full items-center justify-between space-x-2 overflow-hidden app-radius-md border p-2.5 pr-7 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
@@ -78,7 +78,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 app-radius-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-0.5 top-0.5 p-0.5 app-radius-md text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className,
     )}
     toast-close=""


### PR DESCRIPTION
## main changes
before : 
<img width="131" height="87" alt="image" src="https://github.com/user-attachments/assets/a524c89d-ad7d-4fe2-ab22-a59715da3026" />
<img width="101" height="80" alt="image" src="https://github.com/user-attachments/assets/1f214242-fd90-4522-a42f-f0f35a983343" />
<img width="76" height="109" alt="image" src="https://github.com/user-attachments/assets/55994b9e-3387-4275-a364-f0a1f858891b" />

now : 
<img width="107" height="75" alt="image" src="https://github.com/user-attachments/assets/a8906ff6-8c7e-45e5-bf2d-18a7e12dd20a" />
<img width="90" height="95" alt="image" src="https://github.com/user-attachments/assets/c5b437c2-3d3a-4dfc-9c2d-c3f9e1f22f43" />


**pdf viewer adapts to sidebar state**
- `PdfViewerShell` and `PdfViewerContent` now read `{ open, isMobile }` from `useSidebar` and apply `app-radius-lg` only when the sidebar is open and not on mobile  so the viewer corner rounds when the sidebar is expanded (matching the main content area) and goes flush when it's collapsed or on mobile
- same logic applied to the toolbar pill inside `PdfViewerContent`

**sidebar trigger hidden on pdf routes**
- `SidebarTrigger` in `HomeClientLayout` is now suppressed on pdf routes (`!isPdfRoute`) since the pdf viewer renders its own sidebar-aware chrome and the trigger in the global header was overlapping it

**move dialogs toast action button**
- `MoveNoteDialog` and `MovePdfDialog` success toast action button padding changed from `px-4` to `px-3 h-8`, and link text gets `text-xs` in `MoveNoteDialog`  fits better inside the compact toast layout

**toast close button**
- close button position tightened from `right-1 top-1 p-1` to `right-0.5 top-0.5 p-0.5` so it sits closer to the corner
- toast right padding bumped from `pr-6` to `pr-7` to compensate and prevent content from running under the close button