### PR TITLE
error and 404 page cleanup

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -26,16 +26,16 @@ export default function Error({
       : "An unexpected error occurred. Please try again.";
 
   return (
-    <section className="relative flex min-h-svh flex-col items-center justify-center bg-gradient-to-br from-background via-muted to-background p-6 overflow-hidden">
+    <section className="relative flex min-h-svh flex-col items-center justify-center bg-background p-6 overflow-hidden">
       <MaxWContainer className="flex flex-col items-center justify-center gap-3 *:text-center relative px-4 sm:px-6 lg:px-8">
-        <Card className="overflow-hidden bg-card/90 backdrop-blur-md border-border ">
+        <Card className="overflow-hidden bg-card border-border ">
           <CardContent className="relative pt-4 pb-16">
             <div className="flex flex-col justify-center">
               <div className="  flex flex-col items-center justify-center gap-4 text-center">
-                <h2 className="text-3xl md:text-6xl bg-gradient-to-b from-foreground to-transparent bg-clip-text text-transparent font-semibold">
+                <h2 className="text-3xl md:text-6xl text-muted-foreground font-bold">
                   Something went wrong!
                 </h2>
-                <p className="  text-muted-foreground text-xs md:text-sm font-medium lg:font-medium px-2 py-1">
+                <p className="text-muted-foreground text-xs md:text-sm font-medium px-2 py-1">
                   {errorMessage}
                 </p>
               </div>
@@ -45,7 +45,7 @@ export default function Error({
             </Button>
           </CardContent>
         </Card>
-        <div className=" w-full flex justify-start items-center ">
+        <div className=" w-full flex justify-center items-center ">
           <Image
             src={imgsrc}
             alt="Notevo Logo"

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,43 +2,38 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import imgsrc from "@/public/Notevo-logo.svg";
 import Image from "next/image";
-import Section from "@/components/ui/Section";
 import MaxWContainer from "@/components/ui/MaxWContainer";
 import { Card, CardContent } from "@/components/ui/card";
 
 export default function NotFound() {
   return (
-    <section className="relative flex min-h-svh flex-col items-center justify-center bg-gradient-to-br from-background via-background/95 to-background/90 p-6 md:p-10 overflow-hidden">
+    <section className="relative flex min-h-svh flex-col items-center justify-center bg-background  p-6 md:p-10 overflow-hidden">
       <MaxWContainer className="flex flex-col items-center justify-center gap-4 *:text-center relative px-4 sm:px-6 lg:px-8">
-        <Card className="overflow-hidden bg-card/70 backdrop-blur-md border-border shadow-lg hover:shadow-xl transition-all duration-300">
-          <CardContent>
-            <div className="p-6 md:p-8">
-              <div className="flex flex-col justify-center">
-                <div className="flex flex-col items-center justify-center gap-4 text-center">
-                  <h2 className="text-2xl sm:text-4xl lg:text-7xl pb-3 lg:pb-5 bg-gradient-to-b from-foreground to-transparent bg-clip-text text-transparent font-semibold">
-                    404 Not Found
-                  </h2>
-                  <p className="text-muted-foreground text-sm sm:text-lg lg:text-xl font-medium lg:font-medium px-2">
-                    Could not find requested resource
-                  </p>
-                  <Button className="w-full sm:w-auto mt-4 ">
-                    <Link href="/">Return Home</Link>
-                  </Button>
-                </div>
-              </div>
+        <Card className="overflow-hidden bg-card border-border">
+          <CardContent className="relative pt-4 pb-16">
+            <div className="flex flex-col items-center justify-center gap-4 text-center">
+              <h2 className="text-3xl md:text-7xl text-muted-foreground font-bold">
+                404 Not Found
+              </h2>
+              <p className="text-muted-foreground text-sm md:text-base font-medium px-2 py-1">
+                Could not find requested resource
+              </p>
             </div>
+            <Button className=" absolute bottom-0 right-0 w-auto mt-4 h-9">
+              <Link href="/">Return Home</Link>
+            </Button>
           </CardContent>
         </Card>
-        <div className="w-full flex justify-center items-center py-5">
+        <div className="w-full flex justify-center items-center">
           <Image
             src={imgsrc}
             alt="Notevo Logo"
             priority
-            width={20}
-            height={20}
+            width={16}
+            height={16}
           />
           <p className="text-muted-foreground text-xs font-medium px-2">
-            {` ! Hi this is Notevo team we're really sorry for this `}
+            {` ! Hi this is Notevo team we're really sorry for this | go back to the home page `}
           </p>
         </div>
       </MaxWContainer>


### PR DESCRIPTION
## what changed
before : 
<img width="726" height="598" alt="image" src="https://github.com/user-attachments/assets/b4426757-0543-4b24-b9bd-a04e3f0cd305" />

Now : 
<img width="735" height="399" alt="image" src="https://github.com/user-attachments/assets/a202b8db-e4be-4c05-81a0-faa9b3ebf09d" />

**both pages**
- background changed from `bg-gradient-to-br from-background via-muted to-background` / `via-background/95` to a flat `bg-background`
- card changed from `bg-card/90 backdrop-blur-md` / `bg-card/70 backdrop-blur-md shadow-lg hover:shadow-xl` to a plain `bg-card` with no blur or hover shadow
- logo image centered on both pages (`justify-center` instead of `justify-start` on the error page)

**error page**
- heading changed from a gradient clip-text (`bg-gradient-to-b from-foreground to-transparent`) to `text-muted-foreground font-bold` for a simpler, more readable look

**404 page**
- layout simplified: removed the extra wrapping `div` + `p-6 md:p-8` padding layer and aligned it with the error page structure (`pt-4 pb-16`, absolute-positioned button at bottom-right)
- heading bumped to `text-3xl md:text-7xl` and also switched to `text-muted-foreground font-bold` to match the error page
- `Section` import removed (was unused after the layout change)
- logo size reduced from `20x20` to `16x16`
- footer message updated to add `| go back to the home page` so it's a bit more actionable