### PR TITLE
pinned sections collapse button redesign

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -496,15 +496,20 @@ const PinnedNotesList = memo(function PinnedNotesList({
   const [isExpanded, setIsExpanded] = useState(true);
   return (
     <SidebarGroup>
-      <SidebarGroupLabel className="text-muted-foreground flex items-center justify-between">
-        <span>Pinned Notes</span>
+      <SidebarGroupLabel>
         <Button
-          variant="ghost"
+          variant="Trigger"
           size="sm"
           onClick={() => setIsExpanded(!isExpanded)}
-          className=" px-1 h-6"
+          className=" px-0 h-6 text-xs gap-0.5 text-muted-foreground flex items-center justify-center"
         >
-          {isExpanded ? <ChevronUp size="16" /> : <ChevronDown size="16" />}
+          {isExpanded ? (
+            <ChevronUp size="14" className="mb-[3px]" />
+          ) : (
+            <ChevronDown size="14" className="mb-[3px]" />
+          )}
+
+          <span>Pinned Notes</span>
         </Button>
       </SidebarGroupLabel>
       {isExpanded &&
@@ -766,15 +771,20 @@ const PinnedUploadsList = memo(function PinnedUploadsList({
   const [isExpanded, setIsExpanded] = useState(true);
   return (
     <SidebarGroup>
-      <SidebarGroupLabel className="text-muted-foreground flex items-center justify-between">
-        <span>Pinned Uploads</span>
+      <SidebarGroupLabel>
         <Button
-          variant="ghost"
+          variant="Trigger"
           size="sm"
           onClick={() => setIsExpanded(!isExpanded)}
-          className=" px-1 h-6"
+          className=" px-0 h-6 text-xs gap-0.5 text-muted-foreground flex items-center justify-center"
         >
-          {isExpanded ? <ChevronUp size="16" /> : <ChevronDown size="16" />}
+          {isExpanded ? (
+            <ChevronUp size="14" className="mb-[3px]" />
+          ) : (
+            <ChevronDown size="14" className="mb-[3px]" />
+          )}
+
+          <span>Pinned Uploads</span>
         </Button>
       </SidebarGroupLabel>
       {isExpanded &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notevo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",


### PR DESCRIPTION
pinned sections collapse button redesign
before : 
<img width="250" height="403" alt="image" src="https://github.com/user-attachments/assets/dfcfdddb-8a20-4ae5-8366-96fb40d64cf6" />

Now : 
<img width="275" height="367" alt="image" src="https://github.com/user-attachments/assets/ea44beee-b9f7-45c3-82dd-4c3d9daf6219" />

## what changed

- the "pinned notes" and "pinned uploads" section headers in the sidebar are now a single clickable button instead of a label with a separate chevron button on the right
- the whole label area is now a `variant="Trigger"` button with the chevron on the left and the section name as text, so the entire row is the click target
- chevron size reduced from `16` to `14` and gets `mb-[3px]` to optically align it with the label text
- `SidebarGroupLabel` no longer needs custom flex/justify classes since the button handles its own layout

toggles are now more compact and visually cleaner. cleanup stuff my fav thing to do 