### PR TITLE
unlink btn link hover card, version info userMenu

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -12,6 +12,8 @@ import {
   ChevronUp,
   FolderClosed,
   FolderOpen,
+  Globe,
+  Pickaxe,
 } from "lucide-react";
 import { TbSelector } from "react-icons/tb";
 import {
@@ -76,6 +78,8 @@ import { generateSlug } from "@/lib/generateSlug";
 import { useQuery } from "@/cache/useQuery";
 import SkeletonSidebar from "../ui/skeleton-sidebar";
 import NoteContextMenu from "./NoteContextMenu";
+import { FaGithub } from "react-icons/fa6";
+
 interface SidebarHeaderSectionProps {
   getWorkingSpaces: Doc<"workingSpaces">[] | undefined;
   handleCreateNote: (
@@ -1205,6 +1209,25 @@ const UserAccountSection = memo(function UserAccountSection({
                 />
                 Sign out
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <div className="px-1.5 pt-0.5 *:text-[10px] leading-4 text-nowrap space-y-1 *:text-muted-foreground/80">
+                <Link
+                  href="https://github.com/notevome"
+                  target="_blank"
+                  className=" flex justify-start items-center gap-1 hover:underline"
+                >
+                  <FaGithub size={12} className="inline mt-px" />
+                  Version {process.env.NEXT_PUBLIC_APP_VERSION}
+                </Link>
+                <Link
+                  href="https://www.mohammedh.dev/"
+                  target="_blank"
+                  className=" flex justify-start items-center gap-1 hover:underline"
+                >
+                  <Pickaxe size={12} className="inline mt-px" />
+                  @Mohammed H.
+                </Link>
+              </div>
             </DropdownMenuContent>
           </DropdownMenu>
         </SidebarMenuItem>

--- a/components/link-hover-card.tsx
+++ b/components/link-hover-card.tsx
@@ -10,6 +10,7 @@ import { Check, Copy, Globe } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
+import { Unlink } from "lucide-react";
 
 type LinkHoverCardProps = {
   editor: EditorInstance | null;
@@ -37,7 +38,6 @@ export function LinkHoverCard({
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const hideTimerRef = useRef<number | null>(null);
   const copiedTimerRef = useRef<number | null>(null);
-
   const clearHideTimer = useCallback(() => {
     if (hideTimerRef.current !== null) {
       window.clearTimeout(hideTimerRef.current);
@@ -201,7 +201,7 @@ export function LinkHoverCard({
         align="start"
         side="bottom"
         sideOffset={0}
-        className="z-[10002] flex w-[320px] items-center rounded-tl-xl border-border bg-muted p-0 text-popover-foreground"
+        className="z-[10002] flex w-[300px] items-center rounded-tl-xl border-border bg-muted p-0 text-popover-foreground"
         onOpenAutoFocus={(event) => event.preventDefault()}
         onCloseAutoFocus={(event) => event.preventDefault()}
         onMouseEnter={clearHideTimer}
@@ -230,6 +230,29 @@ export function LinkHoverCard({
           ) : (
             <Copy className="h-3.5 w-3.5" />
           )}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-8 px-2 text-xs !rounded-none"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => {
+            if (!editor || !hoveredAnchorRef.current) return;
+
+            const pos = editor.view.posAtDOM(hoveredAnchorRef.current, 0);
+
+            editor
+              .chain()
+              .setTextSelection(pos)
+              .extendMarkRange("link")
+              .unsetLink()
+              .run();
+
+            hideCard();
+          }}
+        >
+          <Unlink className="h-3.5 w-3.5" />
         </Button>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
unlink button in link hover card and version info in user menu

before : 
<img width="240" height="224" alt="image" src="https://github.com/user-attachments/assets/1029926c-16cb-45f1-87ee-991b57cffdab" />
<img width="385" height="105" alt="image" src="https://github.com/user-attachments/assets/d035d32c-12e5-4302-9489-d3d2450c3e2a" />

now : 

<img width="241" height="283" alt="image" src="https://github.com/user-attachments/assets/9a50adce-ff75-49e0-8b09-fe1522cf7e4a" />
<img width="588" height="180" alt="image" src="https://github.com/user-attachments/assets/44b8b70c-1067-404c-bbcc-1e77ccf6c772" />

## what changed

**unlink button in the link hover card**
- added an `Unlink` button as the third action in the link hover card popover, sitting after the copy button
- clicking it finds the hovered anchor's position in the editor, extends the selection to cover the full link mark, then calls `unsetLink()` and hides the card — removes the link without deleting the text
- popover width reduced from `320px` to `300px` to fit the extra button without wrapping

**version info and credits in the user account dropdown**
- added a small footer section below the sign-out item (separated by a `DropdownMenuSeparator`) with two links:
  - github link showing `Version {NEXT_PUBLIC_APP_VERSION}` with the `FaGithub` icon
  - a link to the developer's site attributed to `@Mohammed H.` with a `Pickaxe` icon
- both links are `10px`, `text-muted-foreground/80`, and underline on hover