### PR TITLE
delete pdfs, storage files when deleting a workspace

### DIFF
--- a/convex/workingSpaces.ts
+++ b/convex/workingSpaces.ts
@@ -124,9 +124,36 @@ export const deleteWorkingSpace = mutation({
       .withIndex("by_workingSpaceId", (q) => q.eq("workingSpaceId", _id))
       .collect();
 
+    const pdfsByWorkspace = await ctx.db
+      .query("pdfs")
+      .withIndex("by_workingSpaceId", (q) => q.eq("workingSpaceId", _id))
+      .collect();
+
+    const pdfsByTable = (
+      await Promise.all(
+        tables.map((table) =>
+          ctx.db
+            .query("pdfs")
+            .withIndex("by_notesTableId", (q) => q.eq("notesTableId", table._id))
+            .collect(),
+        ),
+      )
+    ).flat();
+
+    const pdfsToDelete = [...pdfsByWorkspace, ...pdfsByTable].filter(
+      (pdf, index, pdfs) =>
+        pdfs.findIndex((candidate) => candidate._id === pdf._id) === index,
+    );
+
     // Delete all notes
     for (const note of notes) {
       await ctx.db.delete(note._id);
+    }
+
+    // Delete all PDFs and their stored files
+    for (const pdf of pdfsToDelete) {
+      await ctx.storage.delete(pdf.storageId);
+      await ctx.db.delete(pdf._id);
     }
 
     // Delete all tables


### PR DESCRIPTION
### what changed

- `deleteWorkingSpace` now collects all pdfs associated with the workspace before deleting it, covering two cases:
  - pdfs linked directly via `by_workingSpaceId` index
  - pdfs linked to a table within the workspace via `by_notesTableId` index
- both sets are merged and deduplicated (in case a pdf has both a `workingSpaceId` and a `notesTableId` pointing to the same workspace)
- for each pdf, `ctx.storage.delete` is called first to remove the actual file from convex storage, then `ctx.db.delete` removes the record
- this runs before the tables are deleted so the `notesTableId` references are still valid during the storage cleanup

#### why

before this, deleting a workspace left orphaned pdf records in the db and their files sitting in convex storage indefinitely since there was no owner left to clean them up.