### PR TITLE
simplify theme toggle to a binary switch

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,10 +1,11 @@
 "use client";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { DesktopIcon, MoonIcon, SunIcon } from "@radix-ui/react-icons";
+import { Toggle } from "@/components/ui/toggle";
+import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
+
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   // Prevent hydration mismatch
   useEffect(() => {
@@ -15,40 +16,29 @@ export function ThemeToggle() {
     return null;
   }
 
+  const isDarkMode = resolvedTheme === "dark";
+  const nextTheme = isDarkMode ? "light" : "dark";
+  const Icon = isDarkMode ? Sun : Moon;
+
   return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      onValueChange={(value) => {
-        if (value) {
-          setTheme(value);
-        }
-      }}
-      value={theme}
-      className="w-full border border-border bg-muted rounded-tl-md px-[3px] h-[31px] justify-center items-center flex-1 gap-1"
-      variant="SidebarMenuButton"
+    <Toggle
+      pressed={isDarkMode}
+      onPressedChange={() => setTheme(nextTheme)}
+      aria-label={`Switch to ${nextTheme} mode`}
+      className="group flex h-8 w-full min-w-0 items-center justify-between gap-2 px-2 text-sm font-normal text-foreground hover:bg-border data-[state=on]:border-transparent data-[state=on]:bg-transparent data-[state=on]:text-foreground"
     >
-      <ToggleGroupItem
-        value="light"
-        aria-label="Light"
-        className="flex-1 px-1 h-6 rounded-md"
+      <span className="flex min-w-0 items-center">
+        <Icon className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="truncate capitalize text-foreground">
+          {nextTheme} mode
+        </span>
+      </span>
+      <span
+        className="relative h-5 w-9 shrink-0 rounded-full bg-border/70 transition-colors group-data-[state=on]:bg-primary"
+        aria-hidden
       >
-        <SunIcon className="h-3 w-3 text-muted-foreground" />
-      </ToggleGroupItem>
-      <ToggleGroupItem
-        value="dark"
-        aria-label="Dark"
-        className="flex-1 px-1 h-6 rounded-md"
-      >
-        <MoonIcon className="h-3 w-3 text-muted-foreground " />
-      </ToggleGroupItem>
-      <ToggleGroupItem
-        value="system"
-        aria-label="System"
-        className="flex-1 px-1 h-6 rounded-md"
-      >
-        <DesktopIcon className="h-3 w-3 text-muted-foreground " />
-      </ToggleGroupItem>
-    </ToggleGroup>
+        <span className="absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-background shadow-sm transition-transform group-data-[state=on]:translate-x-4" />
+      </span>
+    </Toggle>
   );
 }

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -1238,17 +1238,13 @@ const UserAccountSection = memo(function UserAccountSection({
                 </div>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <div className="w-full p-1">
-                <div className=" flex items-center justify-between">
-                  <p className=" text-sm flex items-center flex-1 text-nowrap truncate">
-                    Theme :
-                  </p>
-                  <ThemeToggle />
-                </div>
-              </div>
+              <ThemeToggle />
               <DropdownMenuSeparator />
               <Feedback />
-              <DropdownMenuItem onClick={handleSignOut}>
+              <DropdownMenuItem
+                onClick={handleSignOut}
+                className="group flex h-8 w-full min-w-0 items-center justify-start gap-0 px-2 text-sm font-normal text-foreground "
+              >
                 <LogOut
                   size="16"
                   className="mr-2 h-4 w-4 text-muted-foreground"

--- a/components/home-components/Feedback.tsx
+++ b/components/home-components/Feedback.tsx
@@ -77,7 +77,10 @@ export default function Feedback() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="SidebarMenuButton" className=" px-2 h-8 ">
+        <Button
+          variant="SidebarMenuButton"
+          className="group flex h-8 w-full min-w-0 items-center justify-start gap-0 px-2 text-sm font-normal text-foreground "
+        >
           <MessageCircleHeart
             size="16"
             className="mr-2 h-4 w-4 text-muted-foreground"

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -12,6 +12,8 @@ const toggleVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
+        Trigger:
+          "group relative h-5 w-9 min-w-9 rounded-full border-border bg-border/70 p-0 hover:bg-border data-[state=on]:border-primary data-[state=on]:bg-primary",
         SidebarMenuButton:
           "flex justify-center items-center gap-2 bg-none w-full text-foreground hover:bg-card/80",
         outline:


### PR DESCRIPTION
replaced the 3-option toggle group (light / dark / system) with a single toggle that flips between light and dark. also cleaned up how the toggle is placed in the sidebar dropdown and aligned the feedback button and sign out item styles to match.

before : 
<img width="241" height="252" alt="image" src="https://github.com/user-attachments/assets/94a2272d-13b9-4c09-b5a9-734e2de58f96" />

now : 
<img width="244" height="262" alt="image" src="https://github.com/user-attachments/assets/8c06805d-1bf4-4cfe-a820-8c8cabb3fb07" />


what changed:
- swapped `ToggleGroup` + 3 items for a single `Toggle` component
- switched from `theme` to `resolvedTheme` so the ui always reflects the actual active theme, not just the stored preference
- the toggle now shows the current icon (sun/moon) and labels what mode you'll switch to
- added a visual pill switch inside the button for a clearer on/off state
- removed the wrapper div around `ThemeToggle` in the sidebar, it now drops in directly as a menu item
- unified button styles across `ThemeToggle`, `Feedback`, and the sign out `DropdownMenuItem`
- added a `Trigger` variant to `toggle.tsx` for the pill style

why:
the system theme option wasn't doing much from a ux standpoint and the old layout had extra wrapper divs with a "Theme :" label that felt out of place. this is simpler, more consistent with the rest of the menu items, and the resolved theme fix means the toggle state is always accurate on load.