### PR TITLE
AppSideBar :pinned section expand indicators

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -549,13 +549,8 @@ const PinnedNotesList = memo(function PinnedNotesList({
           onClick={() => setIsExpanded((currentValue) => !currentValue)}
           className=" px-0 h-6 text-xs gap-0.5 text-muted-foreground flex items-center justify-center"
         >
-          {isExpanded ? (
-            <ChevronUp size="14" className="mb-[3px]" />
-          ) : (
-            <ChevronDown size="14" className="mb-[3px]" />
-          )}
-
           <span>Pinned Notes</span>
+          {isExpanded ? <ChevronDown size="13" /> : <ChevronRight size="13" />}
         </Button>
       </SidebarGroupLabel>
       {isExpanded &&
@@ -828,13 +823,8 @@ const PinnedUploadsList = memo(function PinnedUploadsList({
           onClick={() => setIsExpanded((currentValue) => !currentValue)}
           className=" px-0 h-6 text-xs gap-0.5 text-muted-foreground flex items-center justify-center"
         >
-          {isExpanded ? (
-            <ChevronUp size="14" className="mb-[3px]" />
-          ) : (
-            <ChevronDown size="14" className="mb-[3px]" />
-          )}
-
           <span>Pinned Uploads</span>
+          {isExpanded ? <ChevronDown size="13" /> : <ChevronRight size="13" />}
         </Button>
       </SidebarGroupLabel>
       {isExpanded &&


### PR DESCRIPTION
## what changed
before : 
<img width="129" height="85" alt="image" src="https://github.com/user-attachments/assets/e59a599e-ef58-42b4-8aca-5a9cd44f9b77" />

now : 
<img width="236" height="338" alt="image" src="https://github.com/user-attachments/assets/5ee5b4f1-b44b-40c8-a6a4-287e01d21c06" />

much better 

Updated the expand/collapse indicators for pinned notes and pinned uploads in the sidebar.

* Moved the chevron icons to appear after the section label
* Replaced the up/down toggle with right/down indicators
* Slightly reduced icon size and removed custom spacing adjustments

The previous icons made the sections feel more like vertical movement instead of expandable groups. Using right/down chevrons matches common expand/collapse patterns and makes the interaction easier to understand.
