### PR TITLE
normalize border radius on a couple small ui elements

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -143,14 +143,14 @@ const TailwindAdvancedEditor = ({
                   <button
                     type="button"
                     aria-label="Insert block below"
-                    className="flex h-5 w-5 items-center justify-center text-muted-foreground rounded-tl-lg opacity-50 transition-colors hover:bg-border"
+                    className="flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-md opacity-50 transition-colors hover:bg-border"
                     onMouseDown={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
                       insertBlockBelowWithSlashMenu(editorInstance);
                     }}
                   >
-                    <Plus className="h-4 w-4 mt-0.5" />
+                    <Plus className="h-4 w-4 " />
                   </button>
                   <div className="flex h-5 w-5 items-center justify-center">
                     <svg

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -645,7 +645,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center app-radius-lg p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-border hover:text-muted-foreground focus-visible:ring-0 [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-border hover:text-muted-foreground focus-visible:ring-0 [&>svg]:size-4 [&>svg]:shrink-0",
         "after:absolute after:-inset-2 after:md:hidden",
         "group-data-[collapsible=icon]:hidden",
         className,


### PR DESCRIPTION
normalize border radius on a couple small ui elements
before :
<img width="193" height="119" alt="image" src="https://github.com/user-attachments/assets/ba281e15-4612-413c-8936-d8b38905aafc" />
 
after : 
<img width="224" height="249" alt="image" src="https://github.com/user-attachments/assets/8455c0f4-a8ac-4a46-8c98-9216db8ddbb0" />
<img width="204" height="59" alt="image" src="https://github.com/user-attachments/assets/1e3dbb54-8d4e-4c71-9969-e4c4bdd30541" />

two small components had inconsistent or overly specific border radius values that didn't match the rest of the ui.

what changed:
- editor insert block button: `rounded-tl-lg` (top-left only) → `rounded-md`
- sidebar group action button: `app-radius-lg` (custom class) → `rounded-md`

`rounded-tl-lg` on just one corner looked off and was probably unintentional. `app-radius-lg` on the sidebar action added a custom class where a standard tailwind utility is fine. both are now consistent with how other small buttons are styled across the app.