### PR TITLE
default create note to first workspace when nothing is saved

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -145,7 +145,9 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
   handleCreateWorkingSpace,
   loading,
 }: SidebarHeaderSectionProps) {
-  const [savedWorkspaceId, setSavedWorkspaceId] = useState<string | null>(null);
+  const [savedWorkspaceId, setSavedWorkspaceId] = useState<
+    string | null | undefined
+  >(undefined);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -161,6 +163,25 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
     );
   }, [getWorkingSpaces, savedWorkspaceId]);
 
+  const firstCreatedWorkspace = useMemo(() => {
+    return getWorkingSpaces?.reduce<Doc<"workingSpaces"> | undefined>(
+      (oldestWorkspace, workingSpace) => {
+        if (!oldestWorkspace) return workingSpace;
+
+        const oldestCreatedAt =
+          oldestWorkspace.createdAt ?? oldestWorkspace._creationTime;
+        const workingSpaceCreatedAt =
+          workingSpace.createdAt ?? workingSpace._creationTime;
+
+        return workingSpaceCreatedAt < oldestCreatedAt
+          ? workingSpace
+          : oldestWorkspace;
+      },
+      undefined,
+    );
+  }, [getWorkingSpaces]);
+
+  const createNoteWorkspace = savedWorkspace ?? firstCreatedWorkspace;
   useEffect(() => {
     if (
       typeof window === "undefined" ||
@@ -174,6 +195,20 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
     window.localStorage.removeItem(CREATE_NOTE_WORKSPACE_STORAGE_KEY);
     setSavedWorkspaceId(null);
   }, [getWorkingSpaces, savedWorkspace, savedWorkspaceId]);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      savedWorkspaceId !== null ||
+      !firstCreatedWorkspace
+    ) {
+      return;
+    }
+
+    const workspaceId = String(firstCreatedWorkspace._id);
+    window.localStorage.setItem(CREATE_NOTE_WORKSPACE_STORAGE_KEY, workspaceId);
+    setSavedWorkspaceId(workspaceId);
+  }, [firstCreatedWorkspace, savedWorkspaceId]);
 
   const createNoteInWorkspace = useCallback(
     async (workingSpace: Doc<"workingSpaces">) => {
@@ -238,13 +273,13 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
             )}
           </Button>
         ))
-      ) : savedWorkspace ? (
+      ) : createNoteWorkspace ? (
         <div className="flex h-9 w-full items-center overflow-hidden app-radius-lg">
           <Button
             variant="outline"
             className="font-medium h-9 flex-1 justify-start gap-2 !rounded-r-none bg-primary text-primary-foreground hover:bg-primary/90"
             disabled={loading}
-            onClick={() => void createNoteInWorkspace(savedWorkspace)}
+            onClick={() => void createNoteInWorkspace(createNoteWorkspace)}
           >
             {loading ? (
               <>


### PR DESCRIPTION
previously the split button only showed if the user had already created a note (and thus had a saved workspace in localStorage). on a fresh session or new user, it would fall through to the full dropdown every time.

what changed:
- added `firstCreatedWorkspace` memo that finds the oldest workspace by `createdAt` (falling back to `_creationTime`)
- `createNoteWorkspace` is now `savedWorkspace ?? firstCreatedWorkspace` uses the saved preference if it exists, otherwise falls back to the oldest workspace
- added an effect that auto-saves the first workspace to localStorage when `savedWorkspaceId` is `null` (no saved value, not just uninitialized)
- changed `savedWorkspaceId` initial state from `null` to `undefined` to distinguish "not yet loaded from storage" from "loaded and nothing saved"  prevents the auto-save effect from firing too early
- the split button now shows immediately for users with workspaces, even before they've ever picked one

why:
the dropdown-every-time experience was the default for new users and fresh sessions, which defeated the purpose of the split button. defaulting to the first workspace makes the flow consistent from day one.