### PR TITLE
fix inconsistent height on sidebar list items

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -532,7 +532,7 @@ const PinnedNoteItem = memo(
 
     const content = (
       <SidebarGroupContent
-        className="relative w-full flex justify-between items-center overflow-hidden group/item"
+        className="relative h-8 w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
         onMouseLeave={handleContentMouseLeave}
       >
@@ -817,7 +817,7 @@ const PinnedUploadItem = memo(
 
     return (
       <SidebarGroupContent
-        className="relative w-full flex justify-between items-center overflow-hidden group/item"
+        className="relative h-8 w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
         onMouseLeave={handleContentMouseLeave}
       >
@@ -1135,7 +1135,7 @@ const WorkspaceItem = memo(
 
     return (
       <SidebarGroupContent
-        className="relative w-full flex justify-between items-center overflow-hidden group/item"
+        className="relative h-8 w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
         onMouseLeave={handleContentMouseLeave}
       >


### PR DESCRIPTION
added `h-8` to the three sidebar item types  pinned notes, pinned uploads, and workspaces  so they all have a consistent fixed height instead of relying on content to size them.

without an explicit height the items could render at slightly different sizes depending on content, making the sidebar feel uneven. `h-8` matches the standard row height used elsewhere in the sidebar.