### PR TITLE
tighten spacing on sidebar items and settings panels

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -532,7 +532,7 @@ const PinnedNoteItem = memo(
 
     const content = (
       <SidebarGroupContent
-        className="relative h-8 w-full flex justify-between items-center overflow-hidden group/item"
+        className="relative h-8 my-0.5 w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
         onMouseLeave={handleContentMouseLeave}
       >
@@ -817,7 +817,7 @@ const PinnedUploadItem = memo(
 
     return (
       <SidebarGroupContent
-        className="relative h-8 w-full flex justify-between items-center overflow-hidden group/item"
+        className="relative h-8 my-0.5 w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
         onMouseLeave={handleContentMouseLeave}
       >
@@ -1135,7 +1135,7 @@ const WorkspaceItem = memo(
 
     return (
       <SidebarGroupContent
-        className="relative h-8 w-full flex justify-between items-center overflow-hidden group/item"
+        className="relative h-8 my-0.5 w-full flex justify-between items-center overflow-hidden group/item"
         onMouseEnter={handleContentMouseEnter}
         onMouseLeave={handleContentMouseLeave}
       >

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -115,7 +115,10 @@ export default function NoteSettingsSidbar({
   return (
     <>
       <div
-        className={cn("flex justify-end items-center px-1", ContainerClassName)}
+        className={cn(
+          "flex justify-end items-center px-0.5",
+          ContainerClassName,
+        )}
       >
         <Tooltip open={pinTooltip.open}>
           <TooltipTrigger asChild>

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -63,50 +63,50 @@ export default function PdfSettingsSidebar({
 
   return (
     <>
-        <div
-          className={cn(
-            "flex justify-end items-center px-1",
-            containerClassName,
-          )}
-        >
-          <Tooltip open={pinTooltip.open}>
-            <TooltipTrigger asChild>
-              <Button
-                onClick={handleFavoritePin}
-                variant="SidebarMenuButton"
-                className="px-2 h-7 hover:bg-card"
-                aria-label="pin-upload"
-                {...pinTooltip.triggerProps}
-              >
-                {pdf?.favorite ? (
-                  <PinOff size={16} className="text-muted-foreground" />
-                ) : (
-                  <Pin size={16} className="text-muted-foreground" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={5}>
-              {pdf?.favorite ? "Unpin upload" : "Pin upload"}
-            </TooltipContent>
-          </Tooltip>
+      <div
+        className={cn(
+          "flex justify-end items-center px-0.5",
+          containerClassName,
+        )}
+      >
+        <Tooltip open={pinTooltip.open}>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={handleFavoritePin}
+              variant="SidebarMenuButton"
+              className="px-2 h-7 hover:bg-card"
+              aria-label="pin-upload"
+              {...pinTooltip.triggerProps}
+            >
+              {pdf?.favorite ? (
+                <PinOff size={16} className="text-muted-foreground" />
+              ) : (
+                <Pin size={16} className="text-muted-foreground" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={5}>
+            {pdf?.favorite ? "Unpin upload" : "Pin upload"}
+          </TooltipContent>
+        </Tooltip>
 
-          <Tooltip open={deleteTooltip.open}>
-            <TooltipTrigger asChild>
-              <Button
-                onMouseDown={() => setIsAlertOpen(true)}
-                variant="SidebarMenuButton_destructive"
-                className="px-2 h-7 hover:bg-card"
-                aria-label="delete-upload"
-                {...deleteTooltip.triggerProps}
-              >
-                <X size={16} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={5}>
-              Delete upload
-            </TooltipContent>
-          </Tooltip>
-        </div>
+        <Tooltip open={deleteTooltip.open}>
+          <TooltipTrigger asChild>
+            <Button
+              onMouseDown={() => setIsAlertOpen(true)}
+              variant="SidebarMenuButton_destructive"
+              className="px-2 h-7 hover:bg-card"
+              aria-label="delete-upload"
+              {...deleteTooltip.triggerProps}
+            >
+              <X size={16} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={5}>
+            Delete upload
+          </TooltipContent>
+        </Tooltip>
+      </div>
 
       <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
         <AlertDialogContent className="bg-card border border-border text-card-foreground">

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -101,7 +101,10 @@ export default function WorkingSpaceSettingsSidbar({
   return (
     <>
       <div
-        className={cn("flex justify-end items-center px-1", ContainerClassName)}
+        className={cn(
+          "flex justify-end items-center px-0.5",
+          ContainerClassName,
+        )}
       >
         <Tooltip open={deleteTooltip.open}>
           <TooltipTrigger asChild>


### PR DESCRIPTION
small visual polish pass across a few sidebar components.
JUST FOR MY OCD BRAIN 
before : 
<img width="246" height="74" alt="image" src="https://github.com/user-attachments/assets/1089d175-7f70-40b4-b77a-ee95b8b0c313" />
<img width="56" height="61" alt="image" src="https://github.com/user-attachments/assets/e3af3a2d-679b-4b79-91ea-cc0d8ec0b6ec" />

after : 
<img width="332" height="60" alt="image" src="https://github.com/user-attachments/assets/dbe9d3a1-269e-41e4-88cb-977cb0bcbcf1" />
<img width="228" height="95" alt="image" src="https://github.com/user-attachments/assets/e8bf8949-adc1-4775-81b2-97eafc6946c2" />

what changed:
- added `my-0.5` to pinned notes, pinned uploads, and workspace items for a bit of vertical breathing room between rows
- reduced container padding from `px-1` to `px-0.5` in `NoteSettingsSidebar`, `PdfSettingsSidebar`, and `WorkingSpaceSettingsSidebar` to better align the action buttons with the sidebar edge
- fixed indentation in `PdfSettingsSidebar` where the JSX was over-indented inside the fragment