### PR TITLE
cleanup create note button and tweak sidebar padding

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -250,124 +250,63 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
           <Plus size={16} /> Create Workspace
         </Button>
       )}
-      {getWorkingSpaces?.length === 1 || getWorkingSpaces?.length === 0 ? (
-        getWorkingSpaces.map((workingSpace) => (
-          <Button
-            key={workingSpace._id}
-            variant="outline"
-            className="font-medium w-full h-9 flex justify-start items-center gap-2 bg-primary text-primary-foreground hover:bg-primary/80"
-            disabled={loading}
-            onMouseDown={() => void createNoteInWorkspace(workingSpace)}
-          >
-            {loading ? (
-              <>
-                <LoadingAnimation className=" h-3 w-3" />
-                redirecting...
-              </>
-            ) : (
-              <>
-                {" "}
-                <Plus size={16} className="font-bold" />
-                Create Note
-              </>
-            )}
-          </Button>
-        ))
-      ) : createNoteWorkspace ? (
-        <div className="flex h-9 w-full items-center overflow-hidden app-radius-lg">
-          <Button
-            variant="outline"
-            className="font-medium h-9 flex-1 justify-start gap-2 !rounded-r-none bg-primary text-primary-foreground hover:bg-primary/90"
-            disabled={loading}
-            onClick={() => void createNoteInWorkspace(createNoteWorkspace)}
-          >
-            {loading ? (
-              <>
-                <LoadingAnimation className=" h-3 w-3" />
-                redirecting...
-              </>
-            ) : (
-              <>
-                <Plus size={16} className="font-bold" />
-                Create Note
-              </>
-            )}
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+      {getWorkingSpaces?.length === 1 || getWorkingSpaces?.length === 0
+        ? getWorkingSpaces.map((workingSpace) => (
+            <Button
+              key={workingSpace._id}
+              variant="outline"
+              className="font-medium w-full h-9 flex justify-start items-center gap-2 bg-primary text-primary-foreground hover:bg-primary/80"
+              disabled={loading}
+              onMouseDown={() => void createNoteInWorkspace(workingSpace)}
+            >
+              {loading ? <>redirecting...</> : <> Create Note</>}
+            </Button>
+          ))
+        : createNoteWorkspace && (
+            <div className="flex h-9 w-full items-center overflow-hidden app-radius-lg">
               <Button
                 variant="outline"
-                className="h-9 px-2 !rounded-l-none border-l-0 bg-primary text-primary-foreground hover:bg-primary/90"
+                className="font-medium h-9 flex-1 justify-start gap-2 !rounded-r-none bg-primary text-primary-foreground hover:bg-primary/90"
                 disabled={loading}
-                aria-label="select-create-note-workspace"
+                onClick={() => void createNoteInWorkspace(createNoteWorkspace)}
               >
-                <ChevronDown size={16} className="font-bold" />
+                {loading ? <>redirecting...</> : <>Create Note</>}
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              side="bottom"
-              align="end"
-              className="app-radius-lg p-1 bg-background/90 backdrop-blur border border-solid border-border w-52"
-            >
-              <DropdownMenuGroup className="flex-col">
-                {getWorkingSpaces?.map((workingSpace) => (
-                  <DropdownMenuItem
-                    key={workingSpace._id}
-                    className="relative flex-1 px-2 py-1.5 data-[highlighted]:bg-foreground app-radius-lg"
-                    onSelect={() => void createNoteInWorkspace(workingSpace)}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className=" font-medium h-9 px-2 !rounded-l-none border-l-0 bg-primary text-primary-foreground hover:bg-primary/90"
                     disabled={loading}
+                    aria-label="select-create-note-workspace"
                   >
-                    <FolderClosed size="16" className="mr-2" />
-                    <span>{formatWorkspaceName(workingSpace.name)}</span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              className="font-medium w-full h-9 flex justify-between items-center gap-1 bg-primary text-primary-foreground hover:bg-primary/90"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <LoadingAnimation className=" h-3 w-3" />
-                  redirecting...
-                </>
-              ) : (
-                <>
-                  {" "}
-                  Create Note
-                  <ChevronDown size={16} className="font-bold" />
-                </>
-              )}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            side="bottom"
-            align="end"
-            className="app-radius-lg m-2 p-1.5 bg-background/90 backdrop-blur border border-solid border-border w-[--radix-popper-anchor-width]"
-          >
-            <DropdownMenuGroup className="flex-col">
-              {getWorkingSpaces?.map((workingSpace) => (
-                <DropdownMenuItem
-                  key={workingSpace._id}
-                  className="relative flex-1 px-2 py-1.5 data-[highlighted]:bg-foreground app-radius-lg"
-                  onSelect={() => void createNoteInWorkspace(workingSpace)}
-                  disabled={loading}
+                    <ChevronDown size={16} className="font-bold" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="bottom"
+                  align="end"
+                  className="app-radius-xl p-1 bg-background/90 backdrop-blur border border-solid border-border w-52"
                 >
-                  <FolderClosed size="16" className="mr-2" />
-                  <span>{formatWorkspaceName(workingSpace.name)}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+                  <DropdownMenuGroup className="flex-col">
+                    {getWorkingSpaces?.map((workingSpace) => (
+                      <DropdownMenuItem
+                        key={workingSpace._id}
+                        className="relative flex-1 px-2 h-7 py-1.5 data-[highlighted]:bg-foreground app-radius-lg"
+                        onSelect={() =>
+                          void createNoteInWorkspace(workingSpace)
+                        }
+                        disabled={loading}
+                      >
+                        <FolderClosed size="16" className="mr-2" />
+                        <span>{formatWorkspaceName(workingSpace.name)}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
     </SidebarHeader>
   );
 });

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -355,7 +355,7 @@ const Sidebar = React.memo(
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             "group-data-[collapsible=offcanvas]:opacity-0 group-data-[collapsible=offcanvas]:pointer-events-none",
             variant === "floating" || variant === "inset"
-              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+              ? "py-2 px-0.5 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] ",
             className,
           ),


### PR DESCRIPTION
the create note button had three separate render paths with a lot of duplicated markup. cleaned that up and adjusted some padding.

before : 
<img width="289" height="146" alt="image" src="https://github.com/user-attachments/assets/dba7873d-1c40-4f95-9246-52a54d09e751" />

now : 
<img width="242" height="161" alt="image" src="https://github.com/user-attachments/assets/d5c1afd3-28c7-41e9-adc6-bd518bc5c092" />

not much but you know my ocd brain 

what changed just so you know :
- collapsed the three-branch conditional (single workspace / saved workspace / no saved workspace) into two cleaner cases
- removed the loading spinner and icon from button labels  just shows text now, keeping it minimal
- the "no saved workspace" fallback dropdown is gone; `createNoteWorkspace` always resolves to something (saved or first workspace) so the split button is always shown when there are multiple workspaces
- dropdown content radius updated to `app-radius-xl` and items get a fixed `h-7`
- sidebar inner padding changed from `p-2` to `py-2 px-0.5` so items sit closer to the edges horizontally
