### PR TITLE
fix sidebar background color, mobile sheet z-index

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -255,6 +255,10 @@ input[type=number] {
   -moz-appearance: textfield;
 }
 
+div[role="dialog"][data-state="open"]:has([data-sidebar="header"]) {
+  background: hsl(var(--muted)) !important;
+  z-index: 90000 !important;
+}
 
 .pdf-viewer-shell ::selection,
 .pdf-viewer-shell .textLayer ::selection,

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -507,7 +507,7 @@ const SidebarInset = React.forwardRef<
     <main
       ref={ref}
       className={cn(
-        "relative flex min-h-svh flex-1 flex-col bg-background",
+        "relative flex min-h-svh flex-1 flex-col bg-muted",
         "peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-lg md:peer-data-[variant=inset]:shadow",
         className,
       )}


### PR DESCRIPTION
before : 
<img width="297" height="134" alt="image" src="https://github.com/user-attachments/assets/5a50fb65-d26e-4c4a-90c0-fb25ba06ee37" />

now : 
<img width="344" height="143" alt="image" src="https://github.com/user-attachments/assets/b41217cd-2838-4ae9-83a3-b3d155a16168" />


what changed:
- `SidebarInset` background changed from `bg-background` to `bg-muted` so the main content area matches the sidebar's muted tone instead of the stark default background
- added a global css rule to force the sidebar sheet dialog (on mobile) to use `bg-muted` and a high `z-index` of `90000` when open  targets `div[role=dialog]` containing a sidebar header specifically to avoid affecting other dialogs
- 
the background mismatch made the sidebar and content area feel disconnected. the z-index fix addresses the mobile sheet getting covered by other stacking elements.