### PR TITLE
polish navbar, fix back button navigation, and tweak faq spacing

### DIFF
--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -241,25 +241,25 @@ export default function PrivacyPage() {
               These changes are effective immediately upon posting.
             </SubSection>
           </SectionBlock>
-        </MaxWContainer>
-        <div
-          className={cn(
-            "pointer-events-auto w-full flex items-center justify-center mt-12 py-1.5",
-          )}
-        >
-          <Button
-            aria-label="Home"
-            variant="link"
-            className="cursor-pointer relative group flex justify-center items-center gap-0.5 text-foreground transition-all ease-in-out duration-150 hover:text-primary hover:no-underline"
-            onMouseDown={() => router.back()}
+          <div
+            className={cn(
+              "pointer-events-auto w-full flex items-center justify-center mt-12 py-1.5",
+            )}
           >
-            <ChevronLeft
-              size={16}
-              className="transition-all ease-in-out duration-150 text-foreground absolute top-2.5 -left-0.5 group-hover:text-primary group-hover:-left-1.5"
-            />
-            Home
-          </Button>
-        </div>
+            <Button
+              aria-label="Home"
+              variant="link"
+              className="cursor-pointer relative group flex justify-center items-center gap-0.5 text-foreground transition-all ease-in-out duration-150 hover:text-primary hover:no-underline"
+              onMouseDown={() => router.push("/")}
+            >
+              <ChevronLeft
+                size={16}
+                className="transition-all ease-in-out duration-150 text-foreground absolute top-3 -left-0.5 group-hover:text-primary group-hover:-left-1.5"
+              />
+              Home
+            </Button>
+          </div>
+        </MaxWContainer>
       </div>
     </div>
   );

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -268,25 +268,25 @@ export default function TermsPage() {
               agreement to be bound by the modified terms.
             </SubSection>
           </SectionBlock>
-        </MaxWContainer>
-        <div
-          className={cn(
-            "pointer-events-auto w-full flex items-center justify-center mt-12 py-1.5",
-          )}
-        >
-          <Button
-            aria-label="Home"
-            variant="link"
-            className="cursor-pointer relative group flex justify-center items-center gap-0.5 text-foreground transition-all ease-in-out duration-150 hover:text-primary hover:no-underline"
-            onMouseDown={() => router.back()}
+          <div
+            className={cn(
+              "pointer-events-auto w-full flex items-center justify-center mt-12 py-1.5",
+            )}
           >
-            <ChevronLeft
-              size={16}
-              className="transition-all ease-in-out duration-150 text-foreground absolute top-2.5 -left-0.5 group-hover:text-primary group-hover:-left-1.5"
-            />
-            Home
-          </Button>
-        </div>
+            <Button
+              aria-label="Home"
+              variant="link"
+              className="cursor-pointer relative group flex justify-center items-center gap-0.5 text-foreground transition-all ease-in-out duration-150 hover:text-primary hover:no-underline"
+              onMouseDown={() => router.push("/")}
+            >
+              <ChevronLeft
+                size={16}
+                className="transition-all ease-in-out duration-150 text-foreground absolute top-3 -left-0.5 group-hover:text-primary group-hover:-left-1.5"
+              />
+              Home
+            </Button>
+          </div>
+        </MaxWContainer>
       </div>
     </div>
   );

--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -28,7 +28,7 @@ export default function Navbar() {
       initial={{ y: -80, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ ease: "linear", duration: 0.5 }}
-      className=" sticky top-0 w-full z-50 transition-all"
+      className=" sticky top-2 w-full z-50 transition-all"
     >
       <motion.div
         className={cn(
@@ -41,21 +41,19 @@ export default function Navbar() {
         }}
       >
         {inView && (
-          <div className=" fixed top-0 w-full min-h-[6rem] bg-gradient-to-b from-background via-background/80 from-15% via-40% to-100% to-transparent -z-50 left-0 pointer-events-none" />
+          <div className=" fixed top-0 w-full min-h-[6rem] bg-gradient-to-b from-background via-background/80 from-15% via-50% to-100% to-transparent -z-50 left-0 pointer-events-none" />
         )}
-        <Link
-          href="/"
-          onClick={() => {
-            if (window.location.pathname === "/") {
-              window.scrollTo({ top: 0, behavior: "smooth" });
-            }
-          }}
-          className="flex items-center gap-2 group"
-        >
+
+        <div className="flex justify-start items-center gap-20">
           <motion.div
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.95 }}
-            className="relative"
+            className="relative "
+            onClick={() => {
+              if (window.location.pathname === "/") {
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              }
+            }}
           >
             <Image
               src={NotevoLogo}
@@ -66,22 +64,19 @@ export default function Navbar() {
               height={40}
             />
           </motion.div>
-        </Link>
-        {/* 
-        <div className="flex justify-center items-center gap-4">
-          <nav className="hidden lg:flex items-center gap-3">
+          <nav className="hidden lg:flex justify-center items-center gap-3">
             {NavLinks.map((link, i) => (
-              <Button key={i} variant="ghost" className="px-2 h-8">
+              <Button key={i} variant="ghost" className="p-1.5 h-9">
                 <Link
                   href={link.path}
-                  className="relative text-sm font-medium text-foreground transition-colors group"
+                  className="relative text-base font-medium text-foreground transition-colors group"
                 >
                   {link.Name}
                 </Link>
               </Button>
             ))}
           </nav>
-        </div> */}
+        </div>
 
         <Button asChild className="hidden lg:block relative group h-9">
           <Link prefetch={true} href="/signup" className="text-sm font-medium">

--- a/components/landingPage-components/faq.tsx
+++ b/components/landingPage-components/faq.tsx
@@ -11,7 +11,7 @@ export default function FAQ() {
   return (
     <section
       id="faq"
-      className="relative px-4 sm:px-6 md:px-8 py-12 sm:py-16 md:py-20 Desktop:py-24 "
+      className="relative px-4 sm:px-6 md:px-8 pt-12 sm:pt-16 md:pt-20 Desktop:pt-24 "
     >
       <MaxWContainer>
         <SectionHeading
@@ -23,7 +23,7 @@ export default function FAQ() {
           type="single"
           collapsible
           defaultValue="shipping"
-          className="max-w-lg mx-auto min-h-[250px]"
+          className="max-w-lg mx-auto min-h-[238px]"
         >
           {AccordionData.map((item, index) => (
             <AccordionItem key={index} value={item.itmevalue}>


### PR DESCRIPTION
what changed:
- navbar: unhid the nav links (were commented out), logo is now a `div` with scroll-to-top instead of a `Link` wrapper, nav links are slightly larger (`text-base`, `h-9`), navbar offset changed to `top-2`, and the gradient fade adjusted to `via-50%`
- back button on privacy policy and terms of service: changed `router.back()` to `router.push("/")` so it always goes to the homepage instead of relying on browser history (which could be anything). also moved the button inside `MaxWContainer` and nudged the chevron position to `top-3`
- faq section: removed bottom padding (`py-*` → `pt-*`) and tightened the accordion min-height from `250px` to `238px`
- also includes a git warning about CRLF line endings in `faq.tsx`  worth running the file through your editor's line ending normalizer