### PR TITLE
clean up search tree and filter out empty stuff

### DIFF
--- a/components/home-components/GlobalFolderDropUpload.tsx
+++ b/components/home-components/GlobalFolderDropUpload.tsx
@@ -354,7 +354,7 @@ export default function GlobalFolderDropUpload() {
     <>
       {isDragActive ? (
         <div className="pointer-events-none fixed inset-0 z-[100000] flex items-center justify-center p-4 bg-background/60 backdrop-blur-sm">
-          <div className=" w-full h-full app-radius-lg border-4 border-dashed border-border bg-card px-4 pb-3 pt-3.5 text-center shadow-2xl">
+          <div className=" w-full h-full rounded-lg border-4 border-dashed border-border bg-card px-4 pb-3 pt-3.5 text-center shadow-2xl">
             <div className=" mb-3 w-full h-full flex flex-col items-center justify-center gap-2 ">
               <FolderOpen size={32} className=" text-muted-foreground mt-0.5" />
               <h3 className="text-xl  font-semibold text-foreground">

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -243,44 +243,36 @@ function TableSection({
       {isExpanded && (
         <div className=" relative ">
           <div className=" ml-5 absolute top-0 left-0 h-full w-px bg-muted-foreground/30" />
-          {items.length === 0 ? (
-            <p className="text-[11px] text-muted-foreground/40 text-center py-2 ml-6">
-              {query
-                ? `No notes or uploads match "${query}" here.`
-                : "No notes or uploads here."}
-            </p>
-          ) : (
-            items.map((item: any) =>
-              item.kind === "pdf" ? (
-                <PdfItem
-                  key={item._id}
-                  pdf={{
-                    ...item,
-                    workingSpaceName: workspace.name,
-                    tableName: table.name,
-                  }}
-                  onClick={() => onNoteClick(item)}
-                  isSelected={selectedNoteId === String(item._id)}
-                  query={query}
-                  onIntentPrefetch={onIntentPrefetch}
-                  indented
-                />
-              ) : (
-                <NoteItem
-                  key={item._id}
-                  note={{
-                    ...item,
-                    workingSpaceName: workspace.name,
-                    tableName: table.name,
-                  }}
-                  onClick={() => onNoteClick(item)}
-                  isSelected={selectedNoteId === String(item._id)}
-                  query={query}
-                  onIntentPrefetch={onIntentPrefetch}
-                  indented
-                />
-              ),
-            )
+          {items.map((item: any) =>
+            item.kind === "pdf" ? (
+              <PdfItem
+                key={item._id}
+                pdf={{
+                  ...item,
+                  workingSpaceName: workspace.name,
+                  tableName: table.name,
+                }}
+                onClick={() => onNoteClick(item)}
+                isSelected={selectedNoteId === String(item._id)}
+                query={query}
+                onIntentPrefetch={onIntentPrefetch}
+                indented
+              />
+            ) : (
+              <NoteItem
+                key={item._id}
+                note={{
+                  ...item,
+                  workingSpaceName: workspace.name,
+                  tableName: table.name,
+                }}
+                onClick={() => onNoteClick(item)}
+                isSelected={selectedNoteId === String(item._id)}
+                query={query}
+                onIntentPrefetch={onIntentPrefetch}
+                indented
+              />
+            ),
           )}
         </div>
       )}
@@ -311,17 +303,14 @@ function WorkspaceTree({
         const workspaceId = String(workspace._id);
         const isExpanded = expandedWorkspaceIds.includes(workspaceId);
         const tables: any[] = workspace.tables ?? [];
-        const totalNotes = tables.reduce(
-          (acc: number, t: any) => acc + (t.notes?.length ?? 0),
-          0,
-        );
+        if (tables.length === 0) return null;
 
         return (
           <div key={workspace._id} className="overflow-hidden app-radius-lg">
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-border/50 hover:border-2 hover:bg-transparent"
+              className="h-8 w-full flex-1 justify-start gap-2 px-2 text-sm font-medium border-0 border-transparent hover:border-2 hover:bg-transparent"
               onClick={() => toggleWorkspace(workspaceId)}
             >
               <ChevronRight
@@ -345,23 +334,17 @@ function WorkspaceTree({
 
             {isExpanded && (
               <div className="space-y-0.5 px-1 py-1">
-                {tables.length === 0 ? (
-                  <p className="text-xs text-muted-foreground/50 text-center py-3">
-                    No tables in this workspace yet.
-                  </p>
-                ) : (
-                  tables.map((table: any) => (
-                    <TableSection
-                      key={table._id}
-                      table={table}
-                      workspace={workspace}
-                      selectedNoteId={selectedNoteId}
-                      query={query}
-                      onNoteClick={onNoteClick}
-                      onIntentPrefetch={onIntentPrefetch}
-                    />
-                  ))
-                )}
+                {tables.map((table: any) => (
+                  <TableSection
+                    key={table._id}
+                    table={table}
+                    workspace={workspace}
+                    selectedNoteId={selectedNoteId}
+                    query={query}
+                    onNoteClick={onNoteClick}
+                    onIntentPrefetch={onIntentPrefetch}
+                  />
+                ))}
               </div>
             )}
           </div>
@@ -434,7 +417,7 @@ export default function SearchDialog({
     );
   }, [searchTargets]);
 
-  const hasResults = (searchTargets?.length ?? 0) > 0;
+  const hasResults = allNotes.length > 0;
 
   const handleResultsScroll = useCallback(() => {
     const el = resultsScrollRef.current;
@@ -511,7 +494,9 @@ export default function SearchDialog({
   const handleNoteClick = (note: any) => {
     setOpen(false);
     if (note.kind === "pdf") {
-      router.push(`/home/${note.workingSpaceId}/pdf/${note.slug}?pdfId=${note._id}`);
+      router.push(
+        `/home/${note.workingSpaceId}/pdf/${note.slug}?pdfId=${note._id}`,
+      );
       return;
     }
     router.push(`/home/${note.workingSpaceId}/${note.slug}?id=${note._id}`);

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -443,7 +443,6 @@ export const getWorkspaceTree = query({
           (a, b) => b.updatedAt - a.updatedAt,
         );
 
-        // On initial load, limit tables
         const tablesToProcess = isSearching
           ? sortedTables
           : sortedTables.slice(0, TREE_TABLES_PER_WORKSPACE);
@@ -465,6 +464,7 @@ export const getWorkspaceTree = query({
                 )
                 .order("desc")
                 .collect();
+
               return {
                 ...table,
                 notes: allNotes.map(({ body, ...rest }) => rest),
@@ -472,7 +472,6 @@ export const getWorkspaceTree = query({
               };
             }
 
-            // Initial load — .take() stops at DB level
             const firstNotes = await ctx.db
               .query("notes")
               .withIndex("by_notesTableId", (q) =>
@@ -496,16 +495,24 @@ export const getWorkspaceTree = query({
           }),
         );
 
+        // Only keep tables that have at least one note or pdf
+        const nonEmptyTables = tablesWithNotes.filter(
+          (table) => table.notes.length > 0 || table.pdfs.length > 0,
+        );
+
+        // Drop workspace entirely if it has no non-empty tables
+        if (nonEmptyTables.length === 0) return null;
+
         if (!isSearching) {
-          return { ...workspace, tables: tablesWithNotes };
+          return { ...workspace, tables: nonEmptyTables };
         }
 
-        // Filter by query
+        // Search path
         const workspaceMatches = normalizeSearchText(workspace.name).includes(
           normalizedQuery,
         );
 
-        const filteredTables = tablesWithNotes
+        const filteredTables = nonEmptyTables
           .map((table) => {
             const tableMatches = normalizeSearchText(table.name).includes(
               normalizedQuery,
@@ -513,24 +520,20 @@ export const getWorkspaceTree = query({
             const matchingNotes = table.notes.filter((note: any) =>
               normalizeSearchText(note.title).includes(normalizedQuery),
             );
-            const matchingPdfs = (table.pdfs ?? []).filter((pdf: any) =>
+            const matchingPdfs = table.pdfs.filter((pdf: any) =>
               normalizeSearchText(pdf.title).includes(normalizedQuery),
             );
 
             if (tableMatches) return table;
             if (matchingNotes.length > 0 || matchingPdfs.length > 0)
-              return {
-                ...table,
-                notes: matchingNotes,
-                pdfs: matchingPdfs,
-              };
+              return { ...table, notes: matchingNotes, pdfs: matchingPdfs };
+
             return null;
           })
           .filter(Boolean);
 
-        if (workspaceMatches && filteredTables.length === 0)
-          return { ...workspace, tables: [] };
-        if (!workspaceMatches && filteredTables.length === 0) return null;
+        // Drop workspace if no tables matched and workspace name didn't match
+        if (filteredTables.length === 0) return null;
 
         return { ...workspace, tables: filteredTables };
       }),


### PR DESCRIPTION
what changed:
<img width="798" height="199" alt="image" src="https://github.com/user-attachments/assets/6b24c516-379c-4112-aa19-b63733189190" />

i just dont want to see this anymore there is more then one way to do it but there you go 

**convex/notes.ts:**
- tables with no notes or pdfs are now filtered out before returning from `getWorkspaceTree`
- workspaces with no non-empty tables are dropped entirely (return `null`)
- simplified the search path: if no tables matched and the workspace name didn't match, drop it  removed the edge case that returned a workspace with an empty tables array
- removed a couple stale comments

**SearchDialog.tsx:**
- removed the empty state messages inside `TableSection` and `WorkspaceTree` since empty tables/workspaces no longer reach the client
- workspaces with no tables now return `null` early instead of rendering an empty shell
- `hasResults` now checks `allNotes.length` instead of `searchTargets.length` which was counting workspaces not actual results
- fixed hover border class: `border-border/50` → `border-transparent` so there's no layout shift on hover
- formatted a long `router.push` line

**GlobalFolderDropUpload.tsx:**
- swapped `app-radius-lg` for `rounded-lg` on the drag overlay border