### PR TITLE
AppSidebar:Adjust input onDoubleClick to avoid layout shift

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -485,7 +485,7 @@ const PinnedNoteItem = memo(
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
                 aria-label="pinned note title"
-                className="flex-1 h-9 pl-7 pr-2 py-0 my-0 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+                className="flex-1 h-3 pl-8 pr-2 py-0 my-0 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <Tooltip open={titleTooltip.open}>
@@ -770,7 +770,7 @@ const PinnedUploadItem = memo(
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
                 aria-label="pinned upload title"
-                className="flex-1 h-9 pl-7 pr-2 py-0 my-0 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+                className="flex-1 h-3 pl-8 pr-2 py-0 my-0 text-sm focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <Tooltip open={titleTooltip.open}>
@@ -1088,7 +1088,7 @@ const WorkspaceItem = memo(
                 onBlur={handleInputBlur}
                 onKeyDown={handleInputKeyPress}
                 aria-label="work space name"
-                className="flex-1 h-9 pl-7 pr-2 py-0 my-0 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
+                className="flex-1 h-3 pl-8 pr-2 py-0 my-0 text-sm focus-visible:outline-none border-0 border-transparent  focus-visible:ring-0 focus-visible:ring-offset-0 app-radius-lg"
               />
             ) : (
               <Tooltip open={titleTooltip.open}>


### PR DESCRIPTION
nothing much just avoiding layout shift when renaming a pinned note or pdf folder or workspace

they were mistakenly changed to h-3 (extremely small and unusable). restored them back to the proper h-9 height.
inputs are now readable and functional again.