### PR TITLE
update navbar: add about, live editor demo

### DIFF
--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -66,10 +66,11 @@ export default function Navbar() {
           </motion.div>
           <nav className="hidden lg:flex justify-center items-center gap-3">
             {NavLinks.map((link, i) => (
-              <Button key={i} variant="ghost" className="p-1.5 h-9">
+              <Button key={i} variant="link" className="p-2 h-9">
                 <Link
                   href={link.path}
-                  className="relative text-base font-medium text-foreground transition-colors group "
+                  target={link.target || "_self"}
+                  className="relative text-sm font-medium text-foreground group "
                 >
                   {link.Name}
                 </Link>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -21,16 +21,26 @@ export const NavLinks = [
     Name: "Features",
     path: "/#features",
     clicked: false,
-  },
-  {
-    Name: "FAQ",
-    path: "/#faq",
-    clicked: false,
+    target: "_self",
   },
   {
     Name: "About",
     path: "/#about",
     clicked: false,
+    target: "_self",
+  },
+  {
+    Name: "FAQ",
+    path: "/#faq",
+    clicked: false,
+    target: "_self",
+  },
+
+  {
+    Name: "Give our text editor a try.",
+    path: "https://notevo.me/public/document/k57etpnqzy45zav3vf8v38mbcn8856qn",
+    clicked: false,
+    target: "_blank",
   },
   // {
   //     Name:"Pricing",


### PR DESCRIPTION
improved the landing navbar:

it feels like they're not on the same level but trust me they are lol

<img width="1689" height="140" alt="image" src="https://github.com/user-attachments/assets/b71561a7-c200-49bb-9034-8f265e92aaf0" />

- added a clear "About" link
- replaced the old last item with a direct link to a live text editor demo (opens in new tab)
- switched to `variant="link"` for a lighter, more elegant nav style
