### PR TITLE
fix editor command menu sticky positioning ux

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -414,7 +414,7 @@ const TailwindAdvancedEditor = ({
                   executePlusMenuItem(editorInstance, filtered[selectedIndex]);
               }
             }}
-            className=" sticky top-0 left-0 w-full px-2 py-1 m-0 text-xs bg-muted/50 backdrop-blur-md border-b border-border rounded text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-0"
+            className=" sticky -top-1.5 left-0 w-full px-2 py-1 m-0 text-xs bg-muted border-b border-border rounded-tl text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-0"
           />
           {(() => {
             const filtered = suggestionItems.filter(


### PR DESCRIPTION
small ui tweak to the slash command menu input:
before : 
<img width="320" height="105" alt="image" src="https://github.com/user-attachments/assets/f427c741-0ebf-43fd-923b-c2ca25aeb796" />

a bit better just for my ocd brain : 
<img width="295" height="377" alt="image" src="https://github.com/user-attachments/assets/94f468b7-1dfb-45a2-8e5e-7ade79632d05" />

- adjusted sticky positioning from `top-0` to `-top-1.5`
- simplified background styling (removed backdrop blur)
- updated rounding to `rounded-tl` for better visual fit

the command menu now aligns more cleanly with the editor.