### PR TITLE
ui polish: tooltips, skeletons, sticky tabs,fotr links

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -811,7 +811,7 @@ export default function WorkingSpacePageClient({
             onValueChange={handleTabChange}
             className="mt-6"
           >
-            <div className="mb-6">
+            <div className=" sticky top-0 left-0 mb-6 z-[900000]">
               <SliderTabsList
                 tables={tables}
                 activeTableId={defaultTableId ?? ""}

--- a/app/home/[id]/[slug]/loading.tsx
+++ b/app/home/[id]/[slug]/loading.tsx
@@ -1,7 +1,7 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
+  return <div className={`bg-border rounded-md animate-pulse ${className}`} />;
 }
 
 function ParagraphSkeleton() {
@@ -23,7 +23,7 @@ export default function Loading() {
         <Skeleton className="h-4 w-48" />
       </div>
       <ParagraphSkeleton />
-      <div className="h-40 app-radius-lg bg-border animate-pulse" />
+      <div className="h-40 rounded-lg bg-border animate-pulse" />
       <ParagraphSkeleton />
     </MaxWContainer>
   );

--- a/app/home/[id]/loading.tsx
+++ b/app/home/[id]/loading.tsx
@@ -1,7 +1,9 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return <div className={`bg-border app-radius-md animate-pulse ${className}`} />;
+  return (
+    <div className={`bg-border app-radius-md animate-pulse ${className}`} />
+  );
 }
 
 function TabsSkeleton({ count }: { count: number }) {
@@ -9,10 +11,7 @@ function TabsSkeleton({ count }: { count: number }) {
     <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
       <div className="inline-flex items-center gap-3 p-1 bg-card/90 backdrop-blur-sm app-radius-lg border border-border">
         {Array.from({ length: count }).map((_, i) => (
-          <div
-            key={i}
-            className="px-6 py-2.5 app-radius-lg bg-muted/30"
-          >
+          <div key={i} className="px-6 py-2.5 app-radius-lg bg-muted/30">
             <Skeleton className="h-5 w-24" />
           </div>
         ))}

--- a/app/home/[id]/pdf/[pdfId]/loading.tsx
+++ b/app/home/[id]/pdf/[pdfId]/loading.tsx
@@ -1,15 +1,13 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-border app-radius-md animate-pulse ${className}`} />
-  );
+  return <div className={`bg-border rounded-md animate-pulse ${className}`} />;
 }
 
 export default function Loading() {
   return (
     <MaxWContainer className="flex h-full w-[900px] flex-col px-0 py-0 mx-0">
-      <div className="flex-1 rounded-none border border-border bg-card animate-pulse" />
+      <div className="flex-1 rounded-none border border-border bg-transparent animate-pulse" />
     </MaxWContainer>
   );
 }

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -1,14 +1,12 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
 function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-border app-radius-md animate-pulse ${className}`} />
-  );
+  return <div className={`bg-border rounded-md animate-pulse ${className}`} />;
 }
 
 function WorkspaceCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[330px] min-h-[230px] app-radius-xl border border-border bg-card overflow-hidden flex flex-col">
+    <div className="flex-shrink-0 w-[330px] min-h-[230px] rounded-lg border border-border bg-card overflow-hidden flex flex-col">
       {/* CardHeader */}
       <div className="p-6 pb-3">
         <Skeleton className="h-5 w-3/4" />
@@ -16,7 +14,7 @@ function WorkspaceCardSkeleton() {
       {/* CardContent — folder icon area */}
       <div className="px-6 flex-1">
         <div className="h-full flex items-center justify-center">
-          <Skeleton className="h-8 w-8 app-radius-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
         </div>
       </div>
       {/* CardFooter */}
@@ -30,7 +28,7 @@ function WorkspaceCardSkeleton() {
 
 function NoteCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[330px] h-[230px] app-radius-xl border border-border bg-card overflow-hidden flex flex-col">
+    <div className="flex-shrink-0 w-[330px] h-[230px] rounded-lg border border-border bg-card overflow-hidden flex flex-col">
       {/* CardHeader */}
       <div className="p-6 pb-3">
         <div className="flex items-start justify-between gap-2">
@@ -63,7 +61,7 @@ export default function Loading() {
   return (
     <MaxWContainer className="relative my-5">
       {/* Hero Section */}
-      <div className="overflow-hidden app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
+      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <div className="max-w-3xl mx-auto text-center">
           <Skeleton className="h-10 w-56 mx-auto mb-4" />
           <Skeleton className="h-4 w-full max-w-xl mx-auto mb-2" />

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -14,6 +14,8 @@ import {
   FolderOpen,
   Globe,
   Pickaxe,
+  Scale,
+  Gavel,
 } from "lucide-react";
 import { TbSelector } from "react-icons/tb";
 import {
@@ -520,7 +522,11 @@ const PinnedNoteItem = memo(
                     </IntentPrefetchLink>
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={5}>
+                <TooltipContent
+                  side="right"
+                  sideOffset={5}
+                  className="!rounded"
+                >
                   {note.title || "Untitled"}
                 </TooltipContent>
               </Tooltip>
@@ -805,7 +811,11 @@ const PinnedUploadItem = memo(
                     </IntentPrefetchLink>
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={5}>
+                <TooltipContent
+                  side="right"
+                  sideOffset={5}
+                  className="!rounded"
+                >
                   {pdf.title || "Untitled"}
                 </TooltipContent>
               </Tooltip>
@@ -1123,7 +1133,11 @@ const WorkspaceItem = memo(
                     </IntentPrefetchLink>
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={5}>
+                <TooltipContent
+                  side="right"
+                  sideOffset={5}
+                  className="!rounded"
+                >
                   {workingSpace.name || "Untitled"}
                 </TooltipContent>
               </Tooltip>
@@ -1182,7 +1196,7 @@ const WorkspacesList = memo(function WorkspacesList({
             <span className="sr-only">Add Workspace</span>
           </SidebarGroupAction>
         </TooltipTrigger>
-        <TooltipContent side="right" sideOffset={5}>
+        <TooltipContent side="right" sideOffset={5} className=" !rounded">
           Add Workspace
         </TooltipContent>
       </Tooltip>
@@ -1310,23 +1324,40 @@ const UserAccountSection = memo(function UserAccountSection({
                 Sign out
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <div className="px-1.5 pt-0.5 *:text-[10px] leading-4 text-nowrap space-y-1 *:text-muted-foreground/80">
-                <Link
-                  href="https://github.com/notevome"
-                  target="_blank"
-                  className=" flex justify-start items-center gap-1 hover:underline"
-                >
-                  <FaGithub size={12} className="inline mt-px" />
-                  Version {process.env.NEXT_PUBLIC_APP_VERSION}
-                </Link>
-                <Link
-                  href="https://www.mohammedh.dev/"
-                  target="_blank"
-                  className=" flex justify-start items-center gap-1 hover:underline"
-                >
-                  <Pickaxe size={12} className="inline mt-px" />
-                  @Mohammed H.
-                </Link>
+              <div className=" flex flex-col gap-px justify-center items-start px-1.5 pt-0.5 *:text-[10px] leading-4 text-nowrap *:text-muted-foreground/80">
+                <span className=" w-full flex justify-between items-center">
+                  <Link
+                    href="https://github.com/notevome"
+                    target="_blank"
+                    className="hover:underline"
+                  >
+                    Version {process.env.NEXT_PUBLIC_APP_VERSION}
+                  </Link>
+                  <Link
+                    href="https://www.mohammedh.dev/"
+                    target="_blank"
+                    className="hover:underline"
+                  >
+                    @Mohammed H.
+                  </Link>
+                </span>
+
+                <span className=" w-full flex justify-between items-center">
+                  <Link
+                    href="/terms-of-service"
+                    target="_blank"
+                    className=" hover:underline"
+                  >
+                    Terms of Service
+                  </Link>
+                  <Link
+                    href="mailto:support@notevo.me"
+                    target="_blank"
+                    className=" hover:underline"
+                  >
+                    Help & Support
+                  </Link>
+                </span>
               </div>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -136,7 +136,7 @@ export default function NoteSettingsSidbar({
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5}>
+          <TooltipContent side="right" sideOffset={5} className="!rounded">
             {getNote?.favorite ? "Unpin note" : "Pin note"}
           </TooltipContent>
         </Tooltip>
@@ -153,7 +153,7 @@ export default function NoteSettingsSidbar({
               <X size={16} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5}>
+          <TooltipContent side="right" sideOffset={5} className="!rounded">
             Delete note
           </TooltipContent>
         </Tooltip>

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -85,7 +85,7 @@ export default function PdfSettingsSidebar({
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5}>
+          <TooltipContent side="right" sideOffset={5} className="!rounded">
             {pdf?.favorite ? "Unpin upload" : "Pin upload"}
           </TooltipContent>
         </Tooltip>
@@ -102,7 +102,7 @@ export default function PdfSettingsSidebar({
               <X size={16} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5}>
+          <TooltipContent side="right" sideOffset={5} className="!rounded">
             Delete upload
           </TooltipContent>
         </Tooltip>

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -118,7 +118,7 @@ export default function WorkingSpaceSettingsSidbar({
               <X size={16} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5}>
+          <TooltipContent side="right" sideOffset={5} className="!rounded">
             Delete workspace
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
what changed:
before : 
<img width="1416" height="375" alt="image" src="https://github.com/user-attachments/assets/d919d957-a03e-4b12-aa6e-59c2573eab0f" />
<img width="250" height="249" alt="image" src="https://github.com/user-attachments/assets/36c9a75f-84e7-4d88-ab87-48aee026dfa9" />

Now : 
<img width="225" height="253" alt="image" src="https://github.com/user-attachments/assets/8fa7229d-6787-49b0-b40d-258651c1c42f" />
<img width="1638" height="419" alt="image" src="https://github.com/user-attachments/assets/6ab29e1d-270c-44ac-97fe-4d806aaee496" />

just waaaaayyyy better 

**tooltips:**
- added `!rounded` to all sidebar tooltips (pinned notes, uploads, workspaces, settings panels) for a sharper look consistent with the rest of the ui

**loading skeletons:**
- replaced `app-radius-*` custom classes with standard tailwind `rounded-*` in all loading skeleton files (`/home`, `/home/[id]`, `/home/[id]/[slug]`, `/home/[id]/pdf/[pdfId]`)
- pdf loading skeleton background changed from `bg-card` to `bg-transparent` to avoid a flash of card color

**workspace page:**
- tabs list is now `sticky top-0` with `z-[900000]` so it stays visible when scrolling through notes

**user account dropdown:**
- footer links restructured into two rows: version + author on the left/right of one row, terms of service + help & support on the second
- removed icons from the version and author links, laid out with flexbox instead
- added `Scale` and `Gavel` icon imports (unused visually but imported alongside the restructure)