### PR TITLE
replace scrollbar-thin utility with native scrollbar width

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -108,7 +108,7 @@ export default function PublicNotePage() {
 
   return (
     <div
-      className="relative w-full flex flex-col h-screen overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+      className="relative w-full flex flex-col h-screen overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
       onScroll={(e) => {
         setIsScrolled(e.currentTarget.scrollTop > 0);
       }}

--- a/app/globals.css
+++ b/app/globals.css
@@ -225,10 +225,21 @@
   color-scheme: light;
 }
 
-html {
-  scroll-padding-top: 100px;
-  scroll-behavior: smooth;
-  scrollbar-width: thin;
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: hsl(var(--accent));
+  border-radius: 8px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground));
 }
 
 ::selection {

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -371,9 +371,9 @@ function TableTab({ table }: { table: any }) {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent
-                  className=" px-1.5"
+                  className=" px-1.5 rounded"
                   side="bottom"
-                  sideOffset={5}
+                  sideOffset={10}
                 >
                   Delete table
                 </TooltipContent>

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -229,7 +229,7 @@ function SearchPanel({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-2 transition-all scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+      <div className="flex-1 overflow-y-auto p-2 transition-all scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent">
         {!query.trim() ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
             <FileSearch className="h-8 w-8 text-muted-foreground" />
@@ -301,7 +301,7 @@ function ThumbnailsPanel({ onClose }: { onClose: () => void }) {
       </div>
       <div
         ref={panelRef}
-        className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-3 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+        className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-3 [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
       >
         <div className="flex flex-col items-center gap-2">
           {Array.from({ length: totalPages }, (_, index) => {
@@ -591,7 +591,7 @@ function PdfViewerContent({
         ) : null}
 
         <div className=" absolute inset-y-0 right-0 z-30 flex h-screen w-full items-center justify-center border-b border-border bg-background">
-          <Pages className="h-full min-h-0 w-full transition-all scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+          <Pages className="h-full min-h-0 w-full transition-all scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent">
             <Page>
               <CanvasLayer />
               <TextLayer />

--- a/components/ToC.tsx
+++ b/components/ToC.tsx
@@ -399,7 +399,7 @@ export const ToC = ({ items = [], editor, onActiveIdChange }: ToCProps) => {
     <div
       className={`max-h-[40rem] ${
         isExpanded
-          ? "overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+          ? "overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
           : "overflow-hidden"
       }`}
       onMouseEnter={() => setIsExpanded(true)}

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -321,7 +321,7 @@ const TailwindAdvancedEditor = ({
             }}
             slotAfter={<ImageResizer />}
           >
-            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent">
               <EditorCommandEmpty className="px-2 text-muted-foreground">
                 No results
               </EditorCommandEmpty>
@@ -379,7 +379,7 @@ const TailwindAdvancedEditor = ({
             top: plusMenuPos.y,
             zIndex: 9999,
           }}
-          className=" relative w-64 max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 shadow-lg scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+          className=" relative w-64 max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 shadow-lg scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
         >
           <input
             autoFocus

--- a/components/code-block-component.tsx
+++ b/components/code-block-component.tsx
@@ -71,7 +71,7 @@ export const CodeBlockComponent = ({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="max-h-64 min-w-32 overflow-y-auto scroll-smooth scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+            className="max-h-64 min-w-32 overflow-y-auto scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
             align="start"
           >
             {languages.map((lang) => (

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -1599,7 +1599,7 @@ const AppSidebar = React.memo(function AppSidebar() {
         <SidebarContent
           ref={sidebarContentRef}
           onScroll={handleSidebarScroll}
-          className="scrollbar-gutter-stable pb-16 relative text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-transparent scrollbar-track-transparent group-hover:scrollbar-thumb-border"
+          className="scrollbar-gutter-stable pb-16 relative text-foreground transition-all duration-200 ease-in-out [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-transparent scrollbar-track-transparent group-hover:scrollbar-thumb-border"
         >
           <SidebarNavigation
             pathname={pathname}

--- a/components/home-components/BreadcrumbWithCustomSeparator.tsx
+++ b/components/home-components/BreadcrumbWithCustomSeparator.tsx
@@ -56,7 +56,7 @@ export default function BreadcrumbWithCustomSeparator() {
   return (
     <div className="py-2">
       <Breadcrumb>
-        <BreadcrumbList className="flex flex-nowrap overflow-x-auto whitespace-nowrap text-primary scrollbar-thin">
+        <BreadcrumbList className="flex flex-nowrap overflow-x-auto whitespace-nowrap text-primary [&::-webkit-scrollbar]:w-1.5">
           {pathSegments.map((segment, index) => {
             // Build the path up to this segment
             const pathToSegment =

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -119,7 +119,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         </div>
         <div
           ref={scrollContainerRef}
-          className={`min-h-0 flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent ${
+          className={`min-h-0 flex-1 scrollbar-thumb-border [&::-webkit-scrollbar]:w-1.5 scrollbar-track-transparent ${
             isPdfRoute ? "overflow-hidden pt-0" : "overflow-y-auto py-16"
           }`}
         >

--- a/components/home-components/MoveNoteDialog.tsx
+++ b/components/home-components/MoveNoteDialog.tsx
@@ -254,7 +254,7 @@ export default function MoveNoteDialog({
           </Button>
         </div>
 
-        <div className="min-h-[320px] max-h-[350px] overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
           {moveTargets === undefined ? (
             <div className="space-y-2 p-2">
               {Array.from({ length: 6 }).map((_, index) => (

--- a/components/home-components/MovePdfDialog.tsx
+++ b/components/home-components/MovePdfDialog.tsx
@@ -245,7 +245,7 @@ export default function MovePdfDialog({
           </Button>
         </div>
 
-        <div className="min-h-[320px] max-h-[350px] overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
           {moveTargets === undefined ? (
             <div className="space-y-2 p-2">
               {Array.from({ length: 6 }).map((_, index) => (

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -571,7 +571,7 @@ export default function SearchDialog({
         <div
           ref={resultsScrollRef}
           onScroll={handleResultsScroll}
-          className="min-h-[40vh] max-h-[40vh] overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent p-3"
+          className="min-h-[40vh] max-h-[40vh] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent p-3"
         >
           {canScroll && scrollTop > 8 && (
             <div

--- a/components/selectors/color-selector.tsx
+++ b/components/selectors/color-selector.tsx
@@ -129,7 +129,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
       </PopoverTrigger>
       <PopoverContent
         sideOffset={5}
-        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
+        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
         align="start"
       >
         <div className="flex flex-col">

--- a/components/table-controls.tsx
+++ b/components/table-controls.tsx
@@ -261,7 +261,7 @@ export const TableControls = ({ editor }: TableControlsProps) => {
   const fullMenu = menu.show && (
     <div
       ref={menuRef}
-      className="fixed bg-muted border border-border rounded-tl-lg py-2 px-1 w-[270px] z-[9999] shadow-xl animate-in fade-in-0 zoom-in-95 overflow-y-auto max-h-[80vh] scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+      className="fixed bg-muted border border-border rounded-tl-lg py-2 px-1 w-[270px] z-[9999] shadow-xl animate-in fade-in-0 zoom-in-95 overflow-y-auto max-h-[80vh] [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
       style={{ left: menu.x, top: menu.y }}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}

--- a/components/ui/skeleton-sidebar.tsx
+++ b/components/ui/skeleton-sidebar.tsx
@@ -50,7 +50,7 @@ export default function SkeletonSidebar({
           )}
         </div>
       </SidebarHeader>
-      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent group-hover:scrollbar-thumb-border">
+      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent group-hover:scrollbar-thumb-border">
         <SidebarGroup>
           <SidebarGroupLabel className="text-border">
             <SkeletonTextAnimation className="w-24 h-3" />


### PR DESCRIPTION
before : 
<img width="129" height="118" alt="image" src="https://github.com/user-attachments/assets/8f05ccec-53ca-4cdf-a563-61fa302aee71" />

<img width="57" height="930" alt="image" src="https://github.com/user-attachments/assets/99c173d8-93f2-4f8c-94a5-5eda06967cb9" />

after : 
<img width="144" height="153" alt="image" src="https://github.com/user-attachments/assets/b0a15e38-f7dd-42f4-923b-ec808ef102cb" />

<img width="98" height="977" alt="image" src="https://github.com/user-attachments/assets/58c50b7f-c838-445e-8412-26d3a90d9927" />


swapped `scrollbar-thin` for `[&::-webkit-scrollbar]:w-1.5` across all scrollable containers. this aligns with the global `::-webkit-scrollbar` styles added in globals.css and removes reliance on the tailwind scrollbar plugin for width control.

affected components: public note page, pdf viewer (search panel, thumbnails, pages), toc, editor command menu, plus menu, code block language dropdown, app sidebar, breadcrumb, home content layout, move note/pdf dialogs, search dialog, color selector, table controls, and skeleton sidebar.

also:
- global css now uses `::-webkit-scrollbar` instead of `scrollbar-width: thin` on `html` (same change, different file)
- delete table tooltip gets `rounded` class and `sideOffset` bumped to `10`