### PR TITLE
refine ui: softer scrollbar + thinner sidebar resize handle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -234,7 +234,7 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--accent));
+  background: hsl(var(--muted-foreground)/0.5);
   border-radius: 8px;
 }
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -365,7 +365,7 @@ const Sidebar = React.memo(
       const resizeHandle =
         state === "expanded" && !isMobile ? (
           <div
-            className="group/resize absolute right-0 top-0 h-full w-2.5 cursor-col-resize "
+            className="group/resize absolute right-0 top-0 h-full w-1 cursor-col-resize "
             onMouseDown={handleMouseDown}
           >
             <div className="absolute -right-[1px] top-0 h-full w-px cursor-col-resize bg-gradient-to-t from-transparent from-5% to-95% to-transparent via-50% group-hover/resize:via-primary" />


### PR DESCRIPTION
small visual tweaks just for dark and light mode cuz in light mode its not really visible:
before 
<img width="98" height="977" alt="image" src="https://github.com/user-attachments/assets/0022d38b-f7c0-4bfa-8d92-b134a5ab09f5" />

now : 
<img width="75" height="924" alt="image" src="https://github.com/user-attachments/assets/84d1a54f-9a81-4820-9b81-f61134cc3577" />

- changed the scrollbar thumb color to a more subtle `muted-foreground/0.5`
- made the sidebar resize handle thinner (`w-1` instead of `w-2.5`)

these changes make the ui feel cleaner and less heavy while still keeping good usability.
