### PR TITLE
fix workspace tabs z-index + increase title length

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -811,7 +811,7 @@ export default function WorkingSpacePageClient({
             onValueChange={handleTabChange}
             className="mt-6"
           >
-            <div className=" sticky top-0 left-0 mb-6 z-[900000]">
+            <div className=" sticky top-0 left-0 mb-6 z-40">
               <SliderTabsList
                 tables={tables}
                 activeTableId={defaultTableId ?? ""}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,7 +4,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 const getMaxTitleLength = () => {
-  if (typeof window === "undefined") return 12; // SSR safety
+  if (typeof window === "undefined") return 14; // SSR safety
 
   const width = window.innerWidth;
 


### PR DESCRIPTION
small cleanup in the workspace page:
before : 
<img width="673" height="233" alt="image" src="https://github.com/user-attachments/assets/14a24b1b-2815-4208-bdb9-7176adebd6d0" />

after fixing this funny mistake : 
<img width="642" height="183" alt="image" src="https://github.com/user-attachments/assets/350958d3-cb00-4b01-b322-86e358deee0e" />

- lowered the overly aggressive z-index on the sticky tabs container (`z-[900000]` → `z-40`)
- increased the default max title length from 12 to 14 characters for better readability on wider screens

tabs now layer correctly and titles have a bit more room.