### PR TITLE
clarify insert block tooltip

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -236,7 +236,7 @@ const TailwindAdvancedEditor = ({
                       align="center"
                       className=" text-xs font-bold py-0.5 px-1.5 rounded "
                     >
-                      <p>Insert block</p>
+                      <p> Click to insert block below </p>
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip delayDuration={150} disableHoverableContent>


### PR DESCRIPTION
The previous tooltip was short but didn't clearly explain where the new block would be inserted. The updated text provides more context about the action's result.
<img width="251" height="100" alt="image" src="https://github.com/user-attachments/assets/dab14268-e959-4e73-98fe-3702ecd768e0" />

* Clearer guidance for users
