### PR TITLE
tweak default button hover effect and misc ui fixes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -225,6 +225,10 @@
   color-scheme: light;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
 }

--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -369,7 +369,7 @@ function Slider({ children }: { children: React.ReactNode }) {
           <Button
             size="icon"
             variant={canScrollRight ? "default" : "outline"}
-            className="h-8 w-8 sm:h-10 sm:w-10 "
+            className="h-8 w-8 sm:h-10 sm:w-10 !rounded-none"
             onClick={() => scroll("right")}
           >
             <ChevronRight className="h-4 w-4 sm:h-5 sm:w-5" />

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -87,7 +87,7 @@ function SignInWithMagicLink({
             </FormItem>
           )}
         />
-        <Button type="submit" disabled={loading} className="mt-3">
+        <Button type="submit" disabled={loading} className="mt-3 ">
           {loading ? (
             <>
               <LoadingAnimation className="mx-2 w-4 h-4" /> Sending...
@@ -190,7 +190,7 @@ export default function SignInPage() {
                         </span>
                       </div>
 
-                      <div className="grid grid-cols-2 gap-4">
+                      <div className="grid grid-cols-2 gap-2">
                         <SignInWithGitHub />
                         <SignInWithGoogle />
                       </div>
@@ -253,7 +253,7 @@ function SignInWithGitHub() {
   const [loading, setLoading] = useState(false);
   return (
     <Button
-      className="w-full flex-1"
+      className="w-full flex-1 "
       variant="outline"
       type="button"
       onClick={() => {
@@ -282,7 +282,7 @@ function SignInWithGoogle() {
   const [loading, setLoading] = useState(false);
   return (
     <Button
-      className="w-full flex-1"
+      className="w-full flex-1 !rounded-none"
       variant="outline"
       type="button"
       onClick={() => {

--- a/components/PublicNote.tsx
+++ b/components/PublicNote.tsx
@@ -100,143 +100,146 @@ export default function PublicNote({
   };
 
   return (
-      <DropdownMenu
-        open={open}
-        onOpenChange={(next) => {
-          setOpen(next);
-          if (next) tooltip.hide();
-        }}
-      >
-        <Tooltip open={tooltip.open}>
-          <DropdownMenuTrigger asChild>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                className={cn("h-8 px-2 text-sm mt-0.5 gap-1", BtnClassName)}
-                {...tooltip.triggerProps}
-              >
-                {getNote?.published ? (
-                  <>
-                    <EyeClosed size={14} />
-                    {!isMobile && "Unpublish"}
-                  </>
-                ) : (
-                  <>
-                    <Eye size={14} />
-                    {!isMobile && " Publish"}
-                  </>
-                )}
-              </Button>
-            </TooltipTrigger>
-          </DropdownMenuTrigger>
-          <TooltipContent side="bottom" alignOffset={1} align="end">
-            {getNote?.published
-              ? "Take a look at your published note"
-              : "Publish your note to the web"}
-          </TooltipContent>
-        </Tooltip>
+    <DropdownMenu
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) tooltip.hide();
+      }}
+    >
+      <Tooltip open={tooltip.open}>
+        <DropdownMenuTrigger asChild>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              className={cn("h-8 px-2 text-sm mt-0.5 gap-1", BtnClassName)}
+              {...tooltip.triggerProps}
+            >
+              {getNote?.published ? (
+                <>
+                  <EyeClosed size={14} />
+                  {!isMobile && "Unpublish"}
+                </>
+              ) : (
+                <>
+                  <Eye size={14} />
+                  {!isMobile && " Publish"}
+                </>
+              )}
+            </Button>
+          </TooltipTrigger>
+        </DropdownMenuTrigger>
+        <TooltipContent side="bottom" alignOffset={1} align="end">
+          {getNote?.published
+            ? "Take a look at your published note"
+            : "Publish your note to the web"}
+        </TooltipContent>
+      </Tooltip>
 
-        <DropdownMenuContent
-          side="bottom"
-          alignOffset={1}
-          align="end"
-          className=" min-w-[18.5rem] px-3 pb-3 pt-2 space-y-4 text-muted-foreground z-[10000]"
-        >
-          <DropdownMenuGroup className="relative">
-            {getNote?.published ? (
-              <header className="w-full text-start flex flex-col justify-center items-start gap-3">
-                <span className="px-1 space-y-2">
-                  <h1 className="flex justify-start items-center gap-2 text-base text-foreground font-bold">
-                    <CheckSquare
-                      size={16}
-                      className="text-muted-foreground mt-px"
-                    />
-                    Published to the web
-                  </h1>
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Copy the link, share notes with the world
-                  </p>
-                </span>
-                <span className="w-full relative">
-                  <Input
-                    type="text"
-                    value={`https://notevo.me/public/document/${noteId}`}
-                    className="h-9 truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-85% to-transparent to-80% text-transparent bg-clip-text"
-                    disabled
+      <DropdownMenuContent
+        side="bottom"
+        alignOffset={1}
+        align="end"
+        className=" min-w-[18.5rem] px-3 pb-3 pt-2 space-y-4 text-muted-foreground z-[10000]"
+      >
+        <DropdownMenuGroup className="relative">
+          {getNote?.published ? (
+            <header className="w-full text-start flex flex-col justify-center items-start gap-3">
+              <span className="px-1 space-y-2">
+                <h1 className="flex justify-start items-center gap-2 text-base text-foreground font-bold">
+                  <CheckSquare
+                    size={16}
+                    className="text-muted-foreground mt-px"
                   />
-                  <Tooltip open={copyTooltip.open}>
-                    <TooltipTrigger asChild>
-                      <Button
-                        onMouseDown={handleCopy}
-                        onPointerMove={(e) => e.stopPropagation()}
-                        {...copyTooltip.triggerProps}
-                        className={`w-fit h-8 absolute top-1/2 -translate-y-1/2 right-0  text-primary hover:text-primary`}
-                        disabled={isCopied && true}
-                        variant="Trigger"
-                      >
-                        {isCopied ? (
-                          "Copied!"
-                        ) : (
-                          <Copy size={14} className="text-primary" />
-                        )}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent
-                      className=" rounded-tl-sm px-1.5"
-                      side="bottom"
+                  Published to the web
+                </h1>
+                <p className="text-xs font-medium text-muted-foreground">
+                  Copy the link, share notes with the world
+                </p>
+              </span>
+              <span className="w-full relative">
+                <Input
+                  type="text"
+                  value={`https://notevo.me/public/document/${noteId}`}
+                  className="h-9 truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-85% to-transparent to-80% text-transparent bg-clip-text"
+                  disabled
+                />
+                <Tooltip open={copyTooltip.open}>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onMouseDown={handleCopy}
+                      onPointerMove={(e) => e.stopPropagation()}
+                      {...copyTooltip.triggerProps}
+                      className={`w-fit h-8 absolute top-1/2 -translate-y-1/2 right-0  text-primary hover:text-primary`}
+                      disabled={isCopied && true}
+                      variant="Trigger"
                     >
-                      Copy link
-                    </TooltipContent>
-                  </Tooltip>
-                </span>
-                <span className="w-full flex justify-between items-center gap-2">
-                  <Button
-                    onMouseDown={handlePublished}
-                    className="w-full h-8 gap-2 bg-transparent"
-                    variant="outline"
+                      {isCopied ? (
+                        "Copied!"
+                      ) : (
+                        <Copy size={14} className="text-primary" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    className=" rounded-tl-sm px-1.5"
+                    side="bottom"
                   >
-                    <EyeClosed size={14} />
-                    Unpublish
-                  </Button>
-                  <Button className="w-full h-8" variant="secondary">
-                    <Link
-                      target="_blank"
-                      className="flex justify-center items-center gap-2"
-                      href={`https://notevo.me/public/document/${noteId}`}
-                    >
-                      <ExternalLink size={14} />
-                      View site
-                    </Link>
-                  </Button>
-                </span>
-              </header>
-            ) : (
-              <header className="w-full text-start flex flex-col justify-center items-center gap-6">
-                <span className="px-1 space-y-2">
-                  <h1 className="flex justify-start items-center gap-2 text-base text-foreground font-bold">
-                    <Globe2Icon
-                      size={16}
-                      className="text-muted-foreground mt-px"
-                    />
-                    Publish to the web
-                  </h1>
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Publish a static webpage of this document, read only
-                    <br />
-                    and anyone with the link can view or duplicate it.
-                  </p>
-                </span>
+                    Copy link
+                  </TooltipContent>
+                </Tooltip>
+              </span>
+              <span className="w-full flex justify-between items-center gap-2">
                 <Button
                   onMouseDown={handlePublished}
-                  className="w-full h-8 gap-2"
+                  className="w-full h-8 gap-2 bg-transparent"
+                  variant="outline"
                 >
-                  <Eye size={14} />
-                  Publish
+                  <EyeClosed size={14} />
+                  Unpublish
                 </Button>
-              </header>
-            )}
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+                <Button
+                  className="w-full h-8 !rounded-none "
+                  variant="secondary"
+                >
+                  <Link
+                    target="_blank"
+                    className="flex justify-center items-center gap-2 "
+                    href={`https://notevo.me/public/document/${noteId}`}
+                  >
+                    <ExternalLink size={14} />
+                    View site
+                  </Link>
+                </Button>
+              </span>
+            </header>
+          ) : (
+            <header className="w-full text-start flex flex-col justify-center items-center gap-6">
+              <span className="px-1 space-y-2">
+                <h1 className="flex justify-start items-center gap-2 text-base text-foreground font-bold">
+                  <Globe2Icon
+                    size={16}
+                    className="text-muted-foreground mt-px"
+                  />
+                  Publish to the web
+                </h1>
+                <p className="text-xs font-medium text-muted-foreground">
+                  Publish a static webpage of this document, read only
+                  <br />
+                  and anyone with the link can view or duplicate it.
+                </p>
+              </span>
+              <Button
+                onMouseDown={handlePublished}
+                className="w-full h-8 gap-2"
+              >
+                <Eye size={14} />
+                Publish
+              </Button>
+            </header>
+          )}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -146,7 +146,7 @@ export default function NoteSettingsSidbar({
             <Button
               onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
-              className="px-2 h-7 hover:bg-card"
+              className="px-2 h-7 hover:bg-card !rounded-none"
               aria-label="delete-note"
               {...deleteTooltip.triggerProps}
             >

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -95,7 +95,7 @@ export default function PdfSettingsSidebar({
             <Button
               onMouseDown={() => setIsAlertOpen(true)}
               variant="SidebarMenuButton_destructive"
-              className="px-2 h-7 hover:bg-card"
+              className="px-2 h-7 hover:bg-card !rounded-none"
               aria-label="delete-upload"
               {...deleteTooltip.triggerProps}
             >

--- a/components/landingPage-components/HeroSection.tsx
+++ b/components/landingPage-components/HeroSection.tsx
@@ -283,11 +283,11 @@ export default function HeroSection() {
               Active users
             </p>
           </motion.div>
-          <div className="flex gap-4 justify-start items-center">
+          <div className="flex gap-2 justify-start items-center">
             <Button
               asChild
               size="lg"
-              className="relative group overflow-hidden"
+              className="relative group overflow-hidden h-9"
             >
               <Link prefetch={true} href="/signup">
                 Get Started for Free
@@ -297,7 +297,7 @@ export default function HeroSection() {
               variant="outline"
               size="lg"
               asChild
-              className="relative group h-11"
+              className="relative group h-9 !rounded-none"
             >
               <Link prefetch={true} href="#features">
                 Learn More

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground transition-all duration-300 border-r border-b border-transparent hover:border-muted/50 hover:translate-x-[-3px] hover:translate-y-[-3px] hover:rounded-tl-lg hover:shadow-[3px_3px_0px] hover:shadow-primary active:translate-x-[0px] active:translate-y-[0px]",
+          "bg-primary text-primary-foreground transform-gpu backface-hidden will-change-transform transition-all duration-300 border-r border-b border-transparent hover:border-muted/50 hover:translate-x-[-2px] hover:translate-y-[-2px] hover:rounded-tl-lg hover:shadow-[2px_2px_0px] hover:shadow-primary active:translate-x-[0px] active:translate-y-[0px]",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
what changed:
<img width="301" height="86" alt="image" src="https://github.com/user-attachments/assets/74737994-fc0e-45c6-9361-04cbe3f31fc3" />
<img width="211" height="58" alt="image" src="https://github.com/user-attachments/assets/f562bc55-4394-4b57-a688-0addb1c94a2b" />
<img width="378" height="91" alt="image" src="https://github.com/user-attachments/assets/bb91ee2e-d741-4928-b216-89e67e77e75c" />
<img width="375" height="120" alt="image" src="https://github.com/user-attachments/assets/4f53d686-2e0f-4301-bacb-7d87ea25faea" />

**button.tsx:**
- reduced default button hover translate and shadow from `3px` to `2px` for a subtler lift effect
- added `transform-gpu`, `backface-hidden`, and `will-change-transform` to reduce jank during the transform animation

**`!rounded-none` applied to several buttons:**
- "learn more" hero button, google sign in button, slider scroll-right button, "view site" in publish dropdown, and delete buttons in note/pdf settings sidebars  likely part of a design pass squaring off certain button corners

**hero section:** both cta buttons normalized to `h-9`, gap between them reduced from `gap-4` to `gap-2`

**signup page:** oauth button gap reduced from `gap-4` to `gap-2`

**globals.css:** `scroll-behavior: smooth` added back to `html` (was removed in a previous pr)

**PublicNote.tsx:** indentation fixed, no logic changes