### PR TITLE
normalize tooltip styles, tighten sidebar button padding

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -357,11 +357,11 @@ function Slider({ children }: { children: React.ReactNode }) {
       )}
 
       {(canScrollRight || canScrollLeft) && (
-        <div className="z-10 absolute -bottom-10 right-0 flex justify-center items-center gap-2">
+        <div className="z-10 absolute -bottom-8 right-0 flex justify-center items-center gap-2">
           <Button
             size="icon"
             variant={canScrollLeft ? "default" : "outline"}
-            className=" h-8 w-8 sm:h-10 sm:w-10 "
+            className="h-9 w-8"
             onClick={() => scroll("left")}
           >
             <ChevronLeft className="h-4 w-4 sm:h-5 sm:w-5" />
@@ -369,7 +369,7 @@ function Slider({ children }: { children: React.ReactNode }) {
           <Button
             size="icon"
             variant={canScrollRight ? "default" : "outline"}
-            className="h-8 w-8 sm:h-10 sm:w-10 !rounded-none"
+            className="h-9 w-8 !rounded-none"
             onClick={() => scroll("right")}
           >
             <ChevronRight className="h-4 w-4 sm:h-5 sm:w-5" />

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -363,7 +363,7 @@ function TableTab({ table }: { table: any }) {
                       e.stopPropagation();
                       setIsDeleteAlertOpen(true);
                     }}
-                    className=" px-1 h-6 text-foreground hover:text-destructive"
+                    className=" px-1.5 h-7 text-foreground hover:text-destructive"
                     aria-label="delete-table"
                     {...deleteTooltip.triggerProps}
                   >
@@ -371,9 +371,9 @@ function TableTab({ table }: { table: any }) {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent
-                  className=" px-1.5 rounded"
-                  side="bottom"
-                  sideOffset={10}
+                  className=" !rounded-none"
+                  side="right"
+                  sideOffset={5}
                 >
                   Delete table
                 </TooltipContent>

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -1196,12 +1196,17 @@ const WorkspacesList = memo(function WorkspacesList({
           <SidebarGroupAction
             onClick={handleCreateWorkingSpace}
             {...addWorkspaceTooltip.triggerProps}
+            className=" !rounded-none"
           >
             <Plus size={16} className=" text-muted-foreground" />{" "}
             <span className="sr-only">Add Workspace</span>
           </SidebarGroupAction>
         </TooltipTrigger>
-        <TooltipContent side="right" sideOffset={5} className=" !rounded">
+        <TooltipContent
+          side="right"
+          sideOffset={5}
+          className=" text-xs py-0.5 px-1.5 !rounded-none"
+        >
           Add Workspace
         </TooltipContent>
       </Tooltip>

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -125,7 +125,7 @@ export default function NoteSettingsSidbar({
             <Button
               onClick={handleFavoritePin}
               variant="SidebarMenuButton"
-              className="px-2 h-7 hover:bg-card"
+              className="px-1.5 h-7 hover:bg-card"
               aria-label="pin-note"
               {...pinTooltip.triggerProps}
             >
@@ -136,7 +136,7 @@ export default function NoteSettingsSidbar({
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5} className="!rounded">
+          <TooltipContent side="right" sideOffset={5} className="!rounded-none">
             {getNote?.favorite ? "Unpin note" : "Pin note"}
           </TooltipContent>
         </Tooltip>
@@ -146,14 +146,18 @@ export default function NoteSettingsSidbar({
             <Button
               onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
-              className="px-2 h-7 hover:bg-card !rounded-none"
+              className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="delete-note"
               {...deleteTooltip.triggerProps}
             >
               <X size={16} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5} className="!rounded">
+          <TooltipContent
+            side="right"
+            sideOffset={5}
+            className=" !rounded-none"
+          >
             Delete note
           </TooltipContent>
         </Tooltip>

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -74,7 +74,7 @@ export default function PdfSettingsSidebar({
             <Button
               onClick={handleFavoritePin}
               variant="SidebarMenuButton"
-              className="px-2 h-7 hover:bg-card"
+              className="px-1.5 h-7 hover:bg-card"
               aria-label="pin-upload"
               {...pinTooltip.triggerProps}
             >
@@ -85,7 +85,11 @@ export default function PdfSettingsSidebar({
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5} className="!rounded">
+          <TooltipContent
+            side="right"
+            sideOffset={5}
+            className=" !rounded-none"
+          >
             {pdf?.favorite ? "Unpin upload" : "Pin upload"}
           </TooltipContent>
         </Tooltip>
@@ -95,14 +99,14 @@ export default function PdfSettingsSidebar({
             <Button
               onMouseDown={() => setIsAlertOpen(true)}
               variant="SidebarMenuButton_destructive"
-              className="px-2 h-7 hover:bg-card !rounded-none"
+              className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="delete-upload"
               {...deleteTooltip.triggerProps}
             >
               <X size={16} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5} className="!rounded">
+          <TooltipContent side="right" sideOffset={5} className="!rounded-none">
             Delete upload
           </TooltipContent>
         </Tooltip>

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -111,14 +111,14 @@ export default function WorkingSpaceSettingsSidbar({
             <Button
               onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
-              className="px-2 h-7 hover:bg-card"
+              className="px-1.5 h-7 hover:bg-card"
               aria-label="delete-workspace"
               {...deleteTooltip.triggerProps}
             >
               <X size={16} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={5} className="!rounded">
+          <TooltipContent side="right" sideOffset={5} className="!rounded-none">
             Delete workspace
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
finishes the `!rounded-none` rollout started in the previous pr, this time applied consistently across all tooltips and a few remaining buttons.

what changed:

- all sidebar tooltips (`!rounded` to `!rounded-none`): note settings, pdf settings, workspace settings, add workspace action, and delete table
- add workspace action button gets `!rounded-none`
- delete table tooltip repositioned from `side=bottom` to `side=right` with `sideOffset=5`
- button padding in note, pdf, and workspace settings sidebars tightened from `px-2` to `px-1.5`
- delete table button size bumped from `h-6 px-1` to `h-7 px-1.5`
- home page slider nav buttons normalized to `h-9 w-8` (no more responsive size variants), nav container moved up from `-bottom-10` to `-bottom-8`
- add workspace tooltip gets smaller text with `text-xs py-0.5 px-1.5`