### PR TITLE
finish rounde drollout on remaining tooltips and editor button

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -217,7 +217,7 @@ const TailwindAdvancedEditor = ({
                       <button
                         type="button"
                         aria-label="Insert block below"
-                        className="flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-md opacity-50 transition-colors hover:bg-border"
+                        className="flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
                         onMouseDown={(event) => {
                           event.preventDefault();
                           event.stopPropagation();
@@ -234,7 +234,7 @@ const TailwindAdvancedEditor = ({
                     <TooltipContent
                       side="left"
                       align="center"
-                      className=" text-xs font-bold py-0.5 px-1.5 rounded "
+                      className=" text-xs font-bold py-0.5 px-1.5 !rounded-none "
                     >
                       <p> Click to insert block below </p>
                     </TooltipContent>
@@ -272,7 +272,7 @@ const TailwindAdvancedEditor = ({
                     <TooltipContent
                       side="left"
                       align="center"
-                      className=" text-xs font-bold py-0.5 px-1.5 rounded "
+                      className=" text-xs font-bold py-0.5 px-1.5 !rounded-none "
                     >
                       <p>Drag</p>
                     </TooltipContent>

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -530,7 +530,7 @@ const PinnedNoteItem = memo(
                 <TooltipContent
                   side="right"
                   sideOffset={5}
-                  className="!rounded"
+                  className="!rounded-none"
                 >
                   {note.title || "Untitled"}
                 </TooltipContent>
@@ -819,7 +819,7 @@ const PinnedUploadItem = memo(
                 <TooltipContent
                   side="right"
                   sideOffset={5}
-                  className="!rounded"
+                  className=" !rounded-none"
                 >
                   {pdf.title || "Untitled"}
                 </TooltipContent>
@@ -1141,7 +1141,7 @@ const WorkspaceItem = memo(
                 <TooltipContent
                   side="right"
                   sideOffset={5}
-                  className="!rounded"
+                  className="!rounded-none"
                 >
                   {workingSpace.name || "Untitled"}
                 </TooltipContent>

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -530,7 +530,7 @@ const PinnedNoteItem = memo(
                 <TooltipContent
                   side="right"
                   sideOffset={5}
-                  className="!rounded-none"
+                  className="!rounded-none py-[5px]"
                 >
                   {note.title || "Untitled"}
                 </TooltipContent>
@@ -819,7 +819,7 @@ const PinnedUploadItem = memo(
                 <TooltipContent
                   side="right"
                   sideOffset={5}
-                  className=" !rounded-none"
+                  className=" !rounded-none py-[5px]"
                 >
                   {pdf.title || "Untitled"}
                 </TooltipContent>
@@ -1141,7 +1141,7 @@ const WorkspaceItem = memo(
                 <TooltipContent
                   side="right"
                   sideOffset={5}
-                  className="!rounded-none"
+                  className="!rounded-none py-[5px]"
                 >
                   {workingSpace.name || "Untitled"}
                 </TooltipContent>


### PR DESCRIPTION
finish `!rounded-none` rollout on remaining tooltips and editor button
<img width="405" height="80" alt="image" src="https://github.com/user-attachments/assets/677b9754-3f92-4280-8b09-30646e7b4960" />
<img width="420" height="56" alt="image" src="https://github.com/user-attachments/assets/3eb0db3a-bc8d-484a-851b-4e8606714417" />


- updated the three remaining sidebar item tooltips (pinned notes, pinned uploads, workspaces) from `!rounded` to `!rounded-none`
- applied `!rounded-none` to the insert block and drag handle tooltips in the editor
- changed the insert block button itself from `rounded-md` to `rounded-none` to match