### PR TITLE
add inline editable title to the note page

### DIFF
--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -11,8 +11,16 @@ import type { JSONContent } from "@tiptap/react";
 import { useMutation } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
+import { Input } from "@/components/ui/input";
+import z from "zod";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 
 const noteMemoryCache = new Map<string, unknown>();
+
+const noteTitleSchema = z
+  .string()
+  .min(1, "Title cannot be empty")
+  .max(55, "Title must be 55 characters or less");
 
 export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const { noteWidth } = useNoteWidth();
@@ -20,6 +28,10 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const [lastNote, setLastNote] = useState<typeof note>(() => {
     return noteMemoryCache.get(noteId as unknown as string) as typeof note;
   });
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     setLastNote(
@@ -39,8 +51,6 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
     (local, args) => {
       const { _id, body } = args;
-
-      // Update single note query (for the current note being edited)
       const note = local.getQuery(api.notes.getNoteById, { _id });
       if (note) {
         local.setQuery(
@@ -57,6 +67,7 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   );
 
   const [content, setContent] = useState<JSONContent>();
+  const [editedTitle, setEditedTitle] = useState(stableNote?.title || "");
 
   const debouncedUpdateNote = useDebouncedCallback(
     (updatedContent: JSONContent) => {
@@ -66,6 +77,41 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
       });
     },
     500,
+  );
+
+  const debouncedUpdateNoteTitle = useDebouncedCallback(
+    (trimmedTitle: string) => {
+      const currentTitle = stableNote?.title || "";
+      const result = noteTitleSchema.safeParse(trimmedTitle);
+
+      if (!result.success) {
+        setEditedTitle("");
+        return;
+      }
+
+      const slugifiedTitle = trimmedTitle
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-");
+
+      const segments = pathname.split("/");
+      segments[segments.length - 1] = slugifiedTitle;
+      const newPath = segments.join("/");
+
+      router.replace(`${newPath}?${searchParams.toString()}`);
+
+      if (trimmedTitle !== currentTitle) {
+        try {
+          updateNote({ _id: noteId, title: trimmedTitle });
+        } catch (error) {
+          console.error("Error updating note title:", error);
+          setEditedTitle(currentTitle);
+        }
+      }
+    },
+    100,
   );
 
   const serverContent = useMemo(() => {
@@ -85,17 +131,12 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   useEffect(() => {
     if (!stableNote?.title) return;
 
-    // Store original values
     const originalTitle = document.title;
-
-    // Update document title
     document.title = `${stableNote.title} - Notevo`;
 
-    // Update meta description
     let metaDescription = document.querySelector('meta[name="description"]');
     const originalContent = metaDescription?.getAttribute("content");
 
-    // Create better description from note content or title
     const descriptionText = stableNote.body
       ? `${stableNote.title}: ${stableNote.body.substring(0, 150)}...`
       : `View and edit "${stableNote.title}" on Notevo`;
@@ -113,7 +154,6 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
       metaDescription = newMeta;
     }
 
-    // Cleanup function
     return () => {
       document.title = originalTitle;
       if (createdMeta && metaDescription) {
@@ -124,7 +164,6 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
     };
   }, [stableNote?.title, stableNote?.body]);
 
-  // Show loading only when we have no cached value to show.
   if (stableNote === undefined) {
     return <NoteLoadingSkeletonUI />;
   }
@@ -132,10 +171,25 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   return (
     <div
       className={cn(
-        noteWidth === "false" ? " Desktop:w-[900px] w-full px-4" : "px-6",
-        " pb-28 mx-auto",
+        noteWidth === "false" ? "Desktop:w-[900px] w-full px-4" : "px-6",
+        "pb-28 mx-auto",
       )}
     >
+      <div className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder">
+        <div className="tiptap ProseMirror text-foreground pt-6 prose-stone prose-lg dark:prose-invert prose-headings:font-title font-default focus:outline-none w-full">
+          <Input
+            value={editedTitle}
+            onChange={(e: any) => {
+              setEditedTitle(e.target.value);
+              debouncedUpdateNoteTitle(e.target.value.trim());
+            }}
+            aria-label="note title"
+            placeholder="Untitled Note"
+            autoFocus={true}
+            className="px-0 py-0 my-0 !h-auto text-2xl md:!text-5xl placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+          />
+        </div>
+      </div>
       <TailwindAdvancedEditor
         editorBubblePlacement={false}
         initialContent={content ?? serverContent}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full app-radius-lg border border-border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-foreground/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full app-radius-lg border border-border bg-transparent px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-foreground/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:cursor-not-allowed shadow-none disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -30,9 +30,9 @@ const toastVariants = cva(
     variants: {
       variant: {
         default:
-          "border border-border bg-card text-foreground hover:bg-card/90",
+          "border border-border bg-gradient-to-r from-card from-70% to-muted-foreground/50 to-100% text-foreground hover:bg-card/90",
         destructive:
-          "destructive group border-destructive/50 bg-card text-destructive-foreground hover:bg-card/90",
+          "destructive group border-destructive/50 bg-gradient-to-r from-card from-70% to-destructive/50 to-100% text-foreground ",
       },
     },
     defaultVariants: {
@@ -78,7 +78,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-0.5 top-0.5 p-0.5 app-radius-md text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-0.5 top-0.5 p-0.5 app-radius-md text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100",
       className,
     )}
     toast-close=""


### PR DESCRIPTION
the note title used to only be editable from the sidebar. it's now an inline input at the top of the editor, styled to match the prose heading look.
<img width="929" height="496" alt="image" src="https://github.com/user-attachments/assets/a77c2e92-c1d9-4541-8bc6-17e976a91058" />
<img width="442" height="137" alt="image" src="https://github.com/user-attachments/assets/17f75e8e-c705-4040-beeb-47fa158a0b4e" />
<img width="459" height="169" alt="image" src="https://github.com/user-attachments/assets/0e5341ca-dcbc-4880-9720-39b6156434e2" />


what changed:
- added an `Input` above the editor in `NotePageClient` bound to `editedTitle` state
- `debouncedUpdateNoteTitle` (100ms debounce) validates with zod, slugifies the new title, updates the url via `router.replace`, and calls `updateNote` if the title actually changed
- if validation fails (empty or over 55 chars) the title resets to empty and the update is skipped
- input styled as a large heading (`text-2xl` / `md:text-5xl`) with all borders, shadows, and rings stripped
- removed stale comments throughout the file
- minor whitespace fix on the outer container classnames

**input.tsx:** removed `shadow-sm`, set `shadow-none` as default  prevents the base shadow showing through on the title input

**toast.tsx:** default and destructive variants get a gradient background (`from-card to-muted-foreground/50` / `to-destructive/50`), and destructive close button styles simplified to remove unused group-destructive ring overrides