### PR TITLE
Cleanup ,editable title for public note, add title to pdf export

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -30,7 +30,7 @@ import NoteDownloadDropdown from "@/components/home-components/NoteDownloadDropd
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import { useNoteWidth } from "@/hooks/useNoteWidth";
 import { useMediaQuery } from "react-responsive";
-
+import { Input } from "@/components/ui/input";
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
@@ -58,10 +58,14 @@ export default function PublicNotePage() {
   });
 
   const [content, setContent] = useState<JSONContent | undefined>(undefined);
+  const [editedTitle, setEditedTitle] = useState(getNote?.title || "");
 
   useEffect(() => {
     if (getNote?.body) {
       setContent(JSON.parse(getNote.body));
+    }
+    if (getNote?.title) {
+      setEditedTitle(getNote.title);
     }
   }, [getNote]);
 
@@ -126,20 +130,20 @@ export default function PublicNotePage() {
       <header className=" sticky top-0 left-0 w-full z-[10000]">
         <div className=" px-2 py-2.5 flex justify-between items-center bg-gradient-to-b from-background from-20% to-transparent w-full">
           <ReadOnlyWarning />
-          <p className=" flex flex-col justify-center items-start text-md text-foreground w-full px-1.5 mt-3 h-8">
+          <p className=" flex flex-col justify-center items-start text-md text-foreground w-full px-1.5 mt-1.5 h-8">
             {PublicNoteTitle}
             <span className="px-0.5 pt-0.5 text-[10px] leading-4 text-nowrap text-muted-foreground ">
               Created {formatNoteTimestamp(getNote.createdAt)} - Last updated{" "}
               {formatNoteTimestamp(getNote.updatedAt)}
             </span>
           </p>
-          <div className="flex justify-end items-center gap-1 w-full">
+          <div className="flex justify-end items-center gap-0 w-full">
             {!isMobile && (
               <>
                 <Tooltip open={noteWidthTooltip.open}>
                   <TooltipTrigger asChild>
                     <Button
-                      variant="ghost"
+                      variant="outline"
                       className="w-8 h-8 pt-0.5"
                       size="icon"
                       onClick={toggleWidth}
@@ -157,11 +161,16 @@ export default function PublicNotePage() {
                       )}
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent align="end" side="bottom">
+                  <TooltipContent
+                    align="end"
+                    side="bottom"
+                    className=" text-xs py-0.5 px-1.5"
+                  >
                     {noteWidth === "false" ? <>Full width</> : <>Max width</>}
                   </TooltipContent>
                 </Tooltip>
                 <NoteDownloadDropdown
+                  className=" !rounded-none"
                   noteBody={JSON.stringify(content)}
                   noteTitle={getNote.title ?? "note"}
                 />
@@ -171,8 +180,8 @@ export default function PublicNotePage() {
             <Tooltip open={themeTooltip.open}>
               <TooltipTrigger asChild>
                 <Button
-                  variant="ghost"
-                  className="w-8 h-8 pt-0.5"
+                  variant="outline"
+                  className="w-8 h-8 pt-0.5 !rounded-none"
                   size="icon"
                   onClick={cycleTheme}
                   {...themeTooltip.triggerProps}
@@ -181,11 +190,18 @@ export default function PublicNotePage() {
                   <span className="sr-only">Toggle theme</span>
                 </Button>
               </TooltipTrigger>
-              <TooltipContent align="end" side="bottom">
+              <TooltipContent
+                align="end"
+                side="bottom"
+                className=" text-xs py-0.5 px-1.5"
+              >
                 Toggle theme
               </TooltipContent>
             </Tooltip>
-            <Button variant="secondary" className="text-sm px-1.5 py-1.5 h-8">
+            <Button
+              variant="outline"
+              className="text-sm px-1.5 py-1.5 h-8 bg-secondary/70 hover:bg-secondary !rounded-none"
+            >
               <Link
                 href="https://notevo.me/"
                 target="_blank"
@@ -204,6 +220,20 @@ export default function PublicNotePage() {
           " pb-28 mx-auto",
         )}
       >
+        <div className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder">
+          <div className="tiptap ProseMirror text-foreground pt-6 prose-stone prose-lg dark:prose-invert prose-headings:font-title font-default focus:outline-none w-full">
+            <Input
+              value={editedTitle}
+              onChange={(e: any) => {
+                setEditedTitle(e.target.value);
+              }}
+              aria-label="note title"
+              placeholder="Untitled Note"
+              autoFocus={true}
+              className="px-0 py-0 my-0 !h-auto text-2xl md:!text-5xl placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          </div>
+        </div>
         <TailwindAdvancedEditor
           editorBubblePlacement={true}
           initialContent={parsedContent}

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -183,10 +183,19 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
               setEditedTitle(e.target.value);
               debouncedUpdateNoteTitle(e.target.value.trim());
             }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                const editor = document.querySelector<HTMLElement>(
+                  ".tiptap.ProseMirror.py-6",
+                );
+                editor?.focus();
+              }
+            }}
             aria-label="note title"
             placeholder="Untitled Note"
             autoFocus={true}
-            className="px-0 py-0 my-0 !h-auto text-2xl md:!text-5xl placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+            className="px-0 py-0 my-0 !h-auto text-2xl md:!text-5xl font-bold placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         </div>
       </div>

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -128,17 +128,14 @@ const TailwindAdvancedEditor = ({
   };
 
   const openPlusMenu = (editor: EditorInstance, buttonEl: HTMLElement) => {
-    // Get the node position from the drag handle's current hovered element
     const dragHandleEl =
       buttonEl.closest("[data-drag-handle]")?.parentElement ??
       buttonEl.closest(".novel-drag-handle")?.parentElement ??
       buttonEl.parentElement?.parentElement;
 
-    // Find which block the drag handle is currently next to by checking DOM position
     const rect = buttonEl.getBoundingClientRect();
     const editorView = (editor as any).view;
 
-    // Use the DOM position to find the ProseMirror node position
     const posAtCoords = editorView.posAtCoords({
       left: rect.right + 30,
       top: rect.top + rect.height / 2,
@@ -147,7 +144,6 @@ const TailwindAdvancedEditor = ({
     let insertAt: number | null = null;
     if (posAtCoords) {
       const $pos = editor.state.doc.resolve(posAtCoords.pos);
-      // Go up to depth 1 to get the top-level block
       const depth = $pos.depth >= 1 ? 1 : $pos.depth;
       const nodeStart = $pos.before(depth);
       const node = editor.state.doc.nodeAt(nodeStart);
@@ -169,7 +165,6 @@ const TailwindAdvancedEditor = ({
     if (plusMenuInsertAt === null) return;
     setPlusMenuOpen(false);
 
-    // Insert an empty paragraph at the target position first, then apply the command
     editor
       .chain()
       .focus()
@@ -177,13 +172,11 @@ const TailwindAdvancedEditor = ({
       .setTextSelection(plusMenuInsertAt + 1)
       .run();
 
-    // Now run the item's command with a fake range pointing to the new empty paragraph
     const from = plusMenuInsertAt + 1;
     const to = plusMenuInsertAt + 1;
     item.command({ editor, range: { from, to } });
   };
 
-  // Create extensions array with ToC configuration
   const extensions = [
     TextStyle,
     Color,

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -67,7 +67,7 @@ export default function NoteDownloadDropdown({
         <DropdownMenuTrigger asChild>
           <TooltipTrigger asChild>
             <Button
-              variant="ghost"
+              variant="outline"
               size="icon"
               className={`w-8 h-8 pt-0.5 ${className ?? ""}`}
               {...tooltip.triggerProps}
@@ -77,7 +77,11 @@ export default function NoteDownloadDropdown({
             </Button>
           </TooltipTrigger>
         </DropdownMenuTrigger>
-        <TooltipContent align="end" side="bottom">
+        <TooltipContent
+          align="end"
+          side="bottom"
+          className=" text-xs py-0.5 px-1.5"
+        >
           Download note
         </TooltipContent>
       </Tooltip>

--- a/components/selectors/link-selector.tsx
+++ b/components/selectors/link-selector.tsx
@@ -45,7 +45,7 @@ export const LinkSelector = ({ open, onOpenChange }: LinkSelectorProps) => {
         <Button
           size="sm"
           variant="SidebarMenuButton"
-          className="gap-2 border-none px-2 h-8"
+          className="gap-1 border-none px-2 h-8 !rounded-none"
         >
           <p className="text-base">↗</p>
           <p

--- a/components/selectors/text-buttons.tsx
+++ b/components/selectors/text-buttons.tsx
@@ -129,45 +129,21 @@ export const TextButtons = () => {
   ];
 
   return (
-      <div className="flex">
-        {items.map((item) => (
-          <EditorBubbleItem
-            key={item.name}
-            onSelect={(editor) => {
-              item.command(editor);
-            }}
-          >
-            <ToolbarTooltipButton
-              label={item.label}
-              shortcut={item.shortcut}
-              size="sm"
-              className="border-none px-2 h-8"
-              variant="SidebarMenuButton"
-              type="button"
-            >
-              <item.icon
-                className={cn("h-4 w-4", {
-                  "text-primary": item.isActive(editor),
-                  "text-foreground": !item.isActive(editor),
-                })}
-              />
-            </ToolbarTooltipButton>
-          </EditorBubbleItem>
-        ))}
-
-        {alignItems.map((item) => (
+    <div className="flex">
+      {items.map((item) => (
+        <EditorBubbleItem
+          key={item.name}
+          onSelect={(editor) => {
+            item.command(editor);
+          }}
+        >
           <ToolbarTooltipButton
-            key={item.name}
             label={item.label}
             shortcut={item.shortcut}
             size="sm"
-            className="border-none px-2 h-8"
+            className="border-none px-2 h-8 !rounded-none"
             variant="SidebarMenuButton"
             type="button"
-            onMouseDown={(e) => {
-              e.preventDefault();
-              (editor.commands as any).setTextAlign(item.align);
-            }}
           >
             <item.icon
               className={cn("h-4 w-4", {
@@ -176,7 +152,31 @@ export const TextButtons = () => {
               })}
             />
           </ToolbarTooltipButton>
-        ))}
-      </div>
+        </EditorBubbleItem>
+      ))}
+
+      {alignItems.map((item) => (
+        <ToolbarTooltipButton
+          key={item.name}
+          label={item.label}
+          shortcut={item.shortcut}
+          size="sm"
+          className="border-none px-2 h-8 !rounded-none"
+          variant="SidebarMenuButton"
+          type="button"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            (editor.commands as any).setTextAlign(item.align);
+          }}
+        >
+          <item.icon
+            className={cn("h-4 w-4", {
+              "text-primary": item.isActive(editor),
+              "text-foreground": !item.isActive(editor),
+            })}
+          />
+        </ToolbarTooltipButton>
+      ))}
+    </div>
   );
 };

--- a/hooks/useNoteDownload.ts
+++ b/hooks/useNoteDownload.ts
@@ -51,6 +51,10 @@ export function useNoteDownload({
       return;
     }
 
+    if (!noteTitle) {
+      alert("No Title available for this note to download.");
+      return;
+    }
     let parsedBody: any;
     try {
       parsedBody = JSON.parse(noteBody);
@@ -101,7 +105,7 @@ export function useNoteDownload({
     let ext!: string;
     const filename = `${noteTitle || "note"}`;
 
-    // ── PDF Helper ──────────────────────────────────────────────
+    //  PDF Helper
     const createReadableExportElement = () => {
       const tempDiv = document.createElement("div");
       tempDiv.style.color = "#000000";
@@ -272,7 +276,15 @@ export function useNoteDownload({
           const maxWidth = pageWidth - 2 * margin;
           const lineHeight = 7;
           let yPosition = margin;
-
+          pdf.setFontSize(24);
+          pdf.setFont("helvetica", "bold");
+          pdf.setTextColor(0, 0, 0);
+          const titleLines = pdf.splitTextToSize(noteTitle, maxWidth);
+          titleLines.forEach((line: string) => {
+            pdf.text(line, margin, yPosition, { baseline: "top" });
+            yPosition += 10;
+          });
+          yPosition += 6; // spacing after title
           const checkAndAddPage = (requiredSpace = lineHeight) => {
             if (yPosition + requiredSpace > pageHeight - margin) {
               pdf.addPage();
@@ -350,7 +362,11 @@ export function useNoteDownload({
                   );
                   lines.forEach((line: string, idx: number) => {
                     checkAndAddPage();
-                    pdf.text(line, idx === 0 ? margin + 5 : margin + 10, yPosition);
+                    pdf.text(
+                      line,
+                      idx === 0 ? margin + 5 : margin + 10,
+                      yPosition,
+                    );
                     yPosition += lineHeight;
                   });
                 });
@@ -374,7 +390,13 @@ export function useNoteDownload({
                     yPosition = margin;
                   }
                   pdf.setFillColor(248, 249, 250);
-                  pdf.rect(margin - 2, yPosition - 3.5, maxWidth + 4, codeLineHeight, "F");
+                  pdf.rect(
+                    margin - 2,
+                    yPosition - 3.5,
+                    maxWidth + 4,
+                    codeLineHeight,
+                    "F",
+                  );
                   pdf.setTextColor(40, 40, 40);
                   let xPos = margin + 1;
                   const charWidth = 1.4;
@@ -407,13 +429,21 @@ export function useNoteDownload({
                 const quoteStartY = yPosition;
                 pdf.setFontSize(10);
                 pdf.setFont("helvetica", "italic");
-                const quoteLines = pdf.splitTextToSize(quoteText, maxWidth - 15);
+                const quoteLines = pdf.splitTextToSize(
+                  quoteText,
+                  maxWidth - 15,
+                );
                 quoteLines.forEach((line: string) => {
                   checkAndAddPage();
                   pdf.text(line, margin + 10, yPosition);
                   yPosition += lineHeight;
                 });
-                pdf.line(margin + 2, quoteStartY - 2, margin + 2, yPosition - lineHeight + 2);
+                pdf.line(
+                  margin + 2,
+                  quoteStartY - 2,
+                  margin + 2,
+                  yPosition - lineHeight + 2,
+                );
                 yPosition += lineHeight * 0.3;
                 break;
               }
@@ -507,7 +537,7 @@ export function useNoteDownload({
 
   return { handleDownload };
 
-  // ── Parse Tiptap JSON → docx children ──────────────────────────
+  // Parse Tiptap JSON → docx children
   function parseTiptapToDocx(nodes: any[]): (Paragraph | any)[] {
     const children: (Paragraph | any)[] = [];
 
@@ -664,9 +694,7 @@ export function useNoteDownload({
         );
 
         if (itemNode.content?.length > 1) {
-          listItemsParsed.push(
-            ...parseTiptapToDocx(itemNode.content.slice(1)),
-          );
+          listItemsParsed.push(...parseTiptapToDocx(itemNode.content.slice(1)));
         }
       }
     });


### PR DESCRIPTION
what changed:
before : 
<img width="1660" height="78" alt="image" src="https://github.com/user-attachments/assets/80ebbd09-56db-4abc-8833-7e8244ee0dc5" />
now : 
<img width="1673" height="183" alt="image" src="https://github.com/user-attachments/assets/94837c51-a654-41b9-a0fb-2d2e21cbb4d5" />

**public note page:**
- added the same inline title input as the private note page, but read-only (no save handler, just local state)
- title syncs from `getNote` when the note loads
- header `mt-3` nudged to `mt-1.5`, action button gap removed (`gap-1` → `gap-0`)
- width toggle and theme toggle switched from `variant=ghost` to `variant=outline`
- theme toggle and "notevo" link button get `!rounded-none`
- download dropdown button also switched to `variant=outline`

**note title input (private note):**
- pressing enter now focuses the editor (queries `.tiptap.ProseMirror.py-6`)
- title input gets `font-bold`

**pdf export:**
- note title is now rendered at the top of the pdf in 24pt bold helvetica before the body content
- added a guard: if no title exists, blocks the download with an alert
- long pdf line calls reformatted for readability (no logic change)
- stale comments removed from `useNoteDownload.ts` and `advanced-editor.tsx`

**editor bubble menu:**
- text formatting and alignment buttons get `!rounded-none`
- link selector button gets `!rounded-none` and `gap-1`
- indentation fix in `text-buttons.tsx` (no logic change)