### PR TITLE
improve title input behavior, fix url slug update

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -30,7 +30,7 @@ import NoteDownloadDropdown from "@/components/home-components/NoteDownloadDropd
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import { useNoteWidth } from "@/hooks/useNoteWidth";
 import { useMediaQuery } from "react-responsive";
-import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
@@ -222,15 +222,26 @@ export default function PublicNotePage() {
       >
         <div className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder">
           <div className="tiptap ProseMirror text-foreground pt-6 prose-stone prose-lg dark:prose-invert prose-headings:font-title font-default focus:outline-none w-full">
-            <Input
+            <Textarea
               value={editedTitle}
               onChange={(e: any) => {
                 setEditedTitle(e.target.value);
               }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const editor = document.querySelector<HTMLElement>(
+                    ".tiptap.ProseMirror.py-6",
+                  );
+                  editor?.focus();
+                }
+              }}
               aria-label="note title"
               placeholder="Untitled Note"
               autoFocus={true}
-              className="px-0 py-0 my-0 !h-auto text-2xl md:!text-5xl placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+              rows={1}
+              style={{ resize: "none", overflow: "hidden" }}
+              className="px-0.5 py-6 my-0 field-sizing-content min-h-0 min-w-0 w-full max-w-full max-h-fit whitespace-pre-wrap [overflow-wrap:anywhere] text-2xl md:!text-5xl font-bold placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
         </div>

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -28,6 +28,7 @@ import TablesNotFound from "@/components/home-components/TablesNotFound";
 import SkeletonTextAnimation from "@/components/ui/SkeletonTextAnimation";
 import LoadingAnimation from "@/components/ui/LoadingAnimation";
 import IntentPrefetchLink from "@/components/IntentPrefetchLink";
+import { useToast } from "@/hooks/use-toast";
 import {
   Card,
   CardContent,
@@ -66,6 +67,7 @@ import {
 } from "@/lib/parse-tiptap-content";
 import { generateSlug } from "@/lib/generateSlug";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import { useDebouncedCallback } from "use-debounce";
 const getContentPreviewFromBody = (body: any) => {
   if (!body) return "No content yet. Click to start writing...";
   try {
@@ -85,7 +87,7 @@ const workspaceNameSchema = z
 const noteTitleSchema = z
   .string()
   .min(1, "Title cannot be empty")
-  .max(55, "Title must be 55 characters or less");
+  .max(60, "Title must be 60 characters or less");
 
 const tableNameSchema = z
   .string()
@@ -429,7 +431,7 @@ function TableTab({ table }: { table: any }) {
             >
               Delete
             </AlertDialogAction>
-          </AlertDialogFooter>
+          </AlertDialogFooter>{" "}
         </AlertDialogContent>
       </AlertDialog>
     </>
@@ -603,7 +605,7 @@ export default function WorkingSpacePageClient({
     workspace && (workspace.slug as string);
 
   const tables = tablesQuery !== undefined ? tablesQuery : cached?.tables;
-
+  const { toast } = useToast();
   useEffect(() => {
     const key = workingSpaceId as unknown as string;
     const prev = workspacePageMemoryCache.get(key) ?? {};
@@ -656,24 +658,6 @@ export default function WorkingSpacePageClient({
     });
   }, [workspace]);
 
-  const handleNameBlur = useCallback(async () => {
-    const result = workspaceNameSchema.safeParse(editedName.trim());
-    if (!result.success) {
-      setIsEditingName(false);
-      setEditedName(workspace?.name || "Untitled");
-      return;
-    }
-    const trimmed = result.data;
-    if (trimmed !== (workspace?.name || "Untitled")) {
-      try {
-        await updateWorkingSpace({ _id: workingSpaceId, name: trimmed });
-      } catch (error) {
-        console.error("Error updating workspace name:", error);
-      }
-    }
-    setIsEditingName(false);
-  }, [editedName, workspace?.name, workingSpaceId, updateWorkingSpace]);
-
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
@@ -684,6 +668,35 @@ export default function WorkingSpacePageClient({
       }
     },
     [workspace?.name],
+  );
+  const debouncedUpdateWorkSpaceName = useDebouncedCallback(
+    (workspaceName: string) => {
+      const currentTitle = workspace?.name || "";
+      const result = workspaceNameSchema.safeParse(workspaceName);
+
+      if (!result.success) {
+        setEditedName(workspace?.name || "Untitled");
+        toast({
+          title: "Naming failed",
+          description:
+            "Name must be 30 characters or less and it can't be empty.",
+          variant: "destructive",
+        });
+        setIsEditingName(false);
+        return;
+      }
+
+      if (workspaceName !== currentTitle) {
+        try {
+          updateWorkingSpace({ _id: workingSpaceId, name: workspaceName });
+          nameInputRef.current?.blur();
+          setIsEditingName(false);
+        } catch (error) {
+          console.error("Error updating workspace name:", error);
+        }
+      }
+    },
+    100,
   );
 
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -777,8 +790,10 @@ export default function WorkingSpacePageClient({
                 <Input
                   ref={nameInputRef as any}
                   value={editedName}
-                  onChange={(e) => setEditedName(e.target.value)}
-                  onBlur={handleNameBlur}
+                  onChange={(e: any) => {
+                    setEditedName(e.target.value);
+                    debouncedUpdateWorkSpaceName(e.target.value.trim());
+                  }}
                   onKeyDown={handleNameKeyDown}
                   className="min-w-fit max-w-2xl border-transparent bg-transparent px-2 h-[3.3rem] text-3xl md:text-5xl focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
                 />

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -11,16 +11,17 @@ import type { JSONContent } from "@tiptap/react";
 import { useMutation } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
-import { Input } from "@/components/ui/input";
 import z from "zod";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-
+import { generateSlug } from "@/lib/generateSlug";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
 const noteMemoryCache = new Map<string, unknown>();
 
 const noteTitleSchema = z
   .string()
   .min(1, "Title cannot be empty")
-  .max(55, "Title must be 55 characters or less");
+  .max(60, "Title must be 60 characters or less");
 
 export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const { noteWidth } = useNoteWidth();
@@ -32,6 +33,7 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { toast } = useToast();
 
   useEffect(() => {
     setLastNote(
@@ -86,21 +88,23 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
 
       if (!result.success) {
         setEditedTitle("");
+        toast({
+          title: "Naming failed",
+          description:
+            "Title must be 60 characters or less and it can't be empty.",
+          variant: "destructive",
+        });
         return;
       }
+      const currentUrl = new URL(window.location.href);
 
-      const slugifiedTitle = trimmedTitle
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9\s-]/g, "")
-        .replace(/\s+/g, "-")
-        .replace(/-+/g, "-");
+      const segments = currentUrl.pathname.split("/");
 
-      const segments = pathname.split("/");
-      segments[segments.length - 1] = slugifiedTitle;
-      const newPath = segments.join("/");
+      segments[3] = generateSlug(trimmedTitle);
 
-      router.replace(`${newPath}?${searchParams.toString()}`);
+      currentUrl.pathname = segments.join("/");
+
+      window.history.replaceState({}, "", currentUrl.href);
 
       if (trimmedTitle !== currentTitle) {
         try {
@@ -177,7 +181,7 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
     >
       <div className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder">
         <div className="tiptap ProseMirror text-foreground pt-6 prose-stone prose-lg dark:prose-invert prose-headings:font-title font-default focus:outline-none w-full">
-          <Input
+          <Textarea
             value={editedTitle}
             onChange={(e: any) => {
               setEditedTitle(e.target.value);
@@ -195,7 +199,9 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
             aria-label="note title"
             placeholder="Untitled Note"
             autoFocus={true}
-            className="px-0 py-0 my-0 !h-auto text-2xl md:!text-5xl font-bold placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+            rows={1}
+            style={{ resize: "none", overflow: "hidden" }}
+            className="px-0.5 py-6 my-0 field-sizing-content min-h-0 min-w-0 w-full max-w-full max-h-fit whitespace-pre-wrap [overflow-wrap:anywhere] text-2xl md:!text-5xl font-bold placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         </div>
       </div>

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -276,7 +276,6 @@ const TailwindAdvancedEditor = ({
           )}
           <EditorContent
             initialContent={initialContent}
-            autofocus={true}
             extensions={extensions}
             className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder"
             editorProps={{

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -101,7 +101,7 @@ const workspaceNameSchema = z
 const noteTitleSchema = z
   .string()
   .min(1, "Title cannot be empty")
-  .max(55, "Title must be 55 characters or less");
+  .max(60, "Title must be 60 characters or less");
 
 const CREATE_NOTE_WORKSPACE_STORAGE_KEY = "notevo_create_note_workspace_id";
 const PINNED_NOTES_EXPANDED_STORAGE_KEY =

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -30,9 +30,9 @@ const toastVariants = cva(
     variants: {
       variant: {
         default:
-          "border border-border bg-gradient-to-r from-card from-70% to-muted-foreground/50 to-100% text-foreground hover:bg-card/90",
+          "border border-border bg-gradient-to-r from-card from-60% to-muted-foreground/50 to-100% text-foreground hover:bg-card/90",
         destructive:
-          "destructive group border-destructive/50 bg-gradient-to-r from-card from-70% to-destructive/50 to-100% text-foreground ",
+          "destructive group border border-border  bg-gradient-to-r from-card from-60% to-destructive/50 to-100% text-foreground ",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
improve title input behavior and fix url slug update

what changed:

**title input:**
- switched from `Input` to `Textarea` with `field-sizing-content` so it auto-expands for long titles instead of scrolling
- `rows=1`, `resize=none`, `overflow=hidden` keep it compact by default
- applied to both the private note page and the public note page
- public note page now also gets enter-to-focus-editor behavior (same as private)

**slug / url update:**
- replaced the manual slugify logic with a shared `generateSlug` utility from `lib/generateSlug`
- switched from `router.replace` to `window.history.replaceState` so the url updates without triggering a next.js navigation or re-render
- url is now built from `window.location.href` and segment `[3]` is replaced, which is more explicit than slicing from the end

**validation:**
- max title length bumped from 55 to 60 chars in all three places it's defined (`NotePageClient`, `AppSidebar`, `WorkingSpacePageClient`)
- validation failure now shows a destructive toast instead of silently clearing the input

**editor:**
- removed `autofocus` from `EditorContent` since the title textarea now takes focus on load

**toast styles:**
- gradient `from-*` stop moved from `70%` to `60%` on both default and destructive variants
- destructive variant gets a proper `border border-border` instead of relying on `border-destructive/50`
<img width="440" height="114" alt="image" src="https://github.com/user-attachments/assets/6f94357c-18f8-4f5c-b3ef-5e176bcdcb9a" />
<img width="468" height="128" alt="image" src="https://github.com/user-attachments/assets/86a7af3e-aeec-4210-b2da-ca8fe1b2c988" />

switch workspace name update from onblur to debounced onChange

same pattern as the note title instead of waiting for the input to lose focus, the workspace name now saves as you type with a 100ms debounce.

what changed:
- removed `handleNameBlur` and replaced it with `debouncedUpdateWorkSpaceName`
- validation failure now shows a destructive toast (same copy as note title: "naming failed") and resets the input to the current workspace name
- on success, blurs the input and sets `isEditingName` to false
- `handleNameKeyDown` kept as-is for enter/escape behavior
- added `useToast` and `useDebouncedCallback` imports
- minor: trailing `{" "}` added after `</AlertDialogFooter>` (probably accidental, worth removing)
