### PR TITLE
show specific error messages for empty vs too-long names

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -679,13 +679,22 @@ export default function WorkingSpacePageClient({
       const result = workspaceNameSchema.safeParse(workspaceName);
 
       if (!result.success) {
-        setEditedName("");
-        toast({
-          title: "Naming failed",
-          description:
-            "Name must be 30 characters or less and it can't be empty.",
-          variant: "destructive",
-        });
+        const issue = result.error.issues[0];
+        if (issue.code === "too_small") {
+          setEditedName("");
+          toast({
+            title: "Naming failed",
+            description: "Name must not be empty.",
+            variant: "destructive",
+          });
+        } else if (issue.code === "too_big") {
+          setEditedName(workspace?.name);
+          toast({
+            title: "Naming failed",
+            description: "Name must be 30 characters or less ",
+            variant: "destructive",
+          });
+        }
         return;
       }
 

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -87,13 +87,23 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
       const result = noteTitleSchema.safeParse(trimmedTitle);
 
       if (!result.success) {
-        setEditedTitle("");
-        toast({
-          title: "Naming failed",
-          description:
-            "Title must be 60 characters or less and it can't be empty.",
-          variant: "destructive",
-        });
+        const issue = result.error.issues[0];
+        if (issue.code === "too_small") {
+          setEditedTitle("");
+          toast({
+            title: "Naming failed",
+            description: "Title must not be empty.",
+            variant: "destructive",
+          });
+        } else if (issue.code === "too_big") {
+          setEditedTitle(stableNote?.title || "");
+          toast({
+            title: "Naming failed",
+            description: "Title must be 60 characters or less",
+            variant: "destructive",
+          });
+        }
+
         return;
       }
       const currentUrl = new URL(window.location.href);

--- a/components/selectors/text-buttons.tsx
+++ b/components/selectors/text-buttons.tsx
@@ -44,7 +44,7 @@ function ToolbarTooltipButton({
       </TooltipTrigger>
       <TooltipContent
         side="top"
-        className=" flex justify-center items-center px-1.5 py-0.5"
+        className=" flex justify-center items-center gap-2 px-1 py-0.5"
         sideOffset={6}
       >
         <span>{label}</span>

--- a/components/ui/shortcut-badge.tsx
+++ b/components/ui/shortcut-badge.tsx
@@ -1,5 +1,5 @@
 export const ShortcutBadge = ({ keys }: { keys: string }) => (
-  <span className="ml-2 rounded-tl-sm bg-secondary px-1.5 py-0.5 text-[10px] font-mono font-semibold text-secondary-foreground">
+  <span className="rounded-tl-sm bg-secondary px-1.5 py-px mt-px text-[10px] font-mono font-semibold text-secondary-foreground">
     {keys}
   </span>
 );


### PR DESCRIPTION
what changed:

**note title and workspace name validation:**
- split the single generic error into two specific ones based on the zod issue code
- `too_small` (empty): clears the input and shows "must not be empty"
- `too_big` (over limit): resets to the previous valid value instead of clearing, and shows the character limit message
- this fixes the previous behavior where typing too many characters would wipe your input entirely

**tooltip shortcut badge:**
- removed `ml-2` from `ShortcutBadge`, replaced with `gap-2` on the tooltip content container  spacing is now handled by the parent
- `py-0.5` → `py-px mt-px` for tighter vertical alignment