### PR TITLE
improve mobile warning visibility

### DIFF
--- a/components/ui/mobile-warning.tsx
+++ b/components/ui/mobile-warning.tsx
@@ -24,12 +24,12 @@ export function MobileWarning() {
   if (!showWarning) return null;
 
   return (
-    <div className="fixed top-4 left-4 right-4 z-50 bg-background/60 backdrop-blur-md p-4 rounded-lg border border-border shadow-lg">
+    <div className="fixed top-4 left-4 right-4 z-[100001] bg-background/80 backdrop-blur-md pr-2 pl-4 py-2 rounded-tl-lg border border-border shadow-lg">
       <div className="flex items-start gap-3">
         <AlertTriangle className="h-5 w-5 text-yellow-500 mt-0.5" />
         <div className="flex-1">
-          <h3 className="font-semibold text-primary">Mobile View Warning</h3>
-          <p className="text-sm text-primary/70 mt-1">
+          <h3 className="font-semibold text-foreground">Mobile View Warning</h3>
+          <p className="text-base text-muted-foreground mt-1">
             We do NOT support mobile yet. Use with caution.
           </p>
         </div>


### PR DESCRIPTION
## what changed
before : 
<img width="1899" height="377" alt="image" src="https://github.com/user-attachments/assets/36e8f7c7-7ffe-411c-9835-7c1b1a21ce31" />

after : 
<img width="1624" height="278" alt="image" src="https://github.com/user-attachments/assets/f656fc85-a619-4027-a52f-8d94d3312f80" />


Updated the styling of the mobile warning banner.

* Increased the z-index to ensure the warning stays above other UI elements
* Increased background opacity for better readability
* Adjusted padding and border radius styling
* Updated heading color from primary to foreground
* Increased warning text size and switched to muted foreground styling
* 
The warning could be easy to miss or become obscured by other interface elements. The styling updates make it more noticeable and easier to read while keeping it visually consistent with the rest of the UI.
