### PR TITLE
fix title textarea auto-height for firefox and improve sync reliability

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -283,8 +283,6 @@ input[type=number] {
   }
 
   textarea.field-sizing-content {
-    height: auto !important;
-    overflow: hidden !important;
     white-space: pre-wrap !important;
     overflow-wrap: anywhere !important;
   }
@@ -375,9 +373,7 @@ div[role="dialog"][data-state="open"]:has([data-sidebar="header"]) {
 
 @layer utilities {
   .field-sizing-content {
-    /* field-sizing is Chrome-only; Firefox fallback via JS resize observer or overflow: hidden on textarea */
     field-sizing: content;
-    /* Firefox: textareas need explicit min-height and overflow:hidden + JS to auto-grow */
     min-height: 0;
   }
 

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -9,7 +9,7 @@ import { useNoteWidth } from "@/hooks/useNoteWidth";
 import { cn } from "@/lib/utils";
 import type { JSONContent } from "@tiptap/react";
 import { useMutation } from "convex/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import z from "zod";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
@@ -70,18 +70,31 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
 
   const [content, setContent] = useState<JSONContent>();
   const [editedTitle, setEditedTitle] = useState(stableNote?.title || "");
-  const titleRef = useRef<HTMLTextAreaElement>(null);
 
-  // Firefox doesn't support field-sizing:content, so we manually sync height.
-  const syncTitleHeight = (el: HTMLTextAreaElement) => {
-    el.style.height = "auto";
+  // stableNote loads async — if editedTitle is still empty when data arrives, sync it
+  useEffect(() => {
+    if (stableNote?.title && !editedTitle) {
+      setEditedTitle(stableNote.title);
+    }
+  }, [stableNote?.title]);
+
+  useEffect(() => {
+    if (titleElRef.current) syncHeight(titleElRef.current);
+  }, [noteId, editedTitle]);
+
+  const syncHeight = (el: HTMLTextAreaElement) => {
+    el.style.minHeight = "0";
+    el.style.height = "0";
     el.style.height = `${el.scrollHeight}px`;
   };
 
-  // Sync on mount (for existing content) and whenever noteId changes
-  useEffect(() => {
-    if (titleRef.current) syncTitleHeight(titleRef.current);
-  }, [noteId, stableNote?.title]);
+  const titleElRef = useRef<HTMLTextAreaElement | null>(null);
+  const setTitleRef = useCallback((el: HTMLTextAreaElement | null) => {
+    titleElRef.current = el;
+    if (!el) return;
+    syncHeight(el);
+    el.addEventListener("input", () => syncHeight(el));
+  }, []);
 
   const debouncedUpdateNote = useDebouncedCallback(
     (updatedContent: JSONContent) => {
@@ -201,13 +214,12 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
         "pb-28 mx-auto",
       )}
     >
-      <div className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder">
+      <div className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder overflow-hidden">
         <div className="tiptap ProseMirror text-foreground pt-6 prose-stone prose-lg dark:prose-invert prose-headings:font-title font-default focus:outline-none w-full">
           <Textarea
-            ref={titleRef}
+            ref={setTitleRef}
             value={editedTitle}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-              syncTitleHeight(e.target);
               setEditedTitle(e.target.value);
               debouncedUpdateNoteTitle(e.target.value.trim());
             }}
@@ -223,8 +235,8 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
             aria-label="note title"
             placeholder="Untitled Note"
             rows={1}
-            style={{ resize: "none", overflow: "hidden" }}
-            className="px-0 py-2 my-0 mx-0 field-sizing-content min-h-0 min-w-0 w-full max-w-full max-h-fit whitespace-pre-wrap [overflow-wrap:anywhere] text-2xl md:!text-5xl font-bold placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+            style={{ resize: "none", overflow: "hidden", width: "100%" }}
+            className="px-0 py-2 my-0 mx-0 field-sizing-content !min-h-0 min-w-0 w-full max-w-full [white-space:pre-wrap] [overflow-wrap:break-word] [word-break:break-word] text-2xl md:!text-5xl font-bold placeholder:text-muted-foreground/50 !rounded-none focus:shadow-none shadow-none focus-visible:outline-none border-0 border-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         </div>
       </div>


### PR DESCRIPTION
**the problem:**
<img width="891" height="143" alt="image" src="https://github.com/user-attachments/assets/24ca174f-2e4f-45aa-bec7-c6b1fe9e0838" />

`field-sizing: content` is chrome-only. on firefox, the title textarea wouldn't grow as you typed  it stayed at one line. the previous attempt at a firefox fallback used `height: auto !important` + `overflow: hidden !important` in css, which caused layout jank and didn't reliably sync on mount or when switching notes.

**what changed:**

**ref strategy:**
replaced the plain `useRef<HTMLTextAreaElement>` (`titleRef`) with a callback ref (`setTitleRef`) using `useCallback`. this lets us:
- call `syncHeight` immediately when the element mounts (before any react render cycle)
- attach a native `input` event listener directly on the element for real-time height sync as the user types, bypassing react's synthetic event batching

**`syncHeight` function:**
the height sync logic was updated from:
```
el.style.height = "auto";
el.style.height = `${el.scrollHeight}px`;
```
to:
```
el.style.minHeight = "0";
el.style.height = "0";
el.style.height = `${el.scrollHeight}px`;
```
resetting to `0` instead of `auto` gives a more reliable scroll height read on firefox, where `auto` can return a stale value before the browser recalculates layout.

**manual sync on noteId/editedTitle change:**
kept the `useEffect` that calls `syncHeight` when `noteId` or `editedTitle` changes, so switching notes correctly resizes the textarea to match the incoming title.

**stableNote async sync:**
added a `useEffect` to set `editedTitle` from `stableNote.title` if the title is still empty when data arrives. this handles the case where the note loads after initial render and the textarea would otherwise stay blank.

**`onChange` handler:**
removed the manual `syncHeight(e.target)` call from `onChange` since the native `input` listener on the ref now handles this. this avoids double-calling sync.

**css cleanup:**
- removed `height: auto !important` and `overflow: hidden !important` from `textarea.field-sizing-content` — these were the source of the jank
- removed explanatory comments from `.field-sizing-content` utility class that are no longer needed

**textarea classnames:**
- replaced `whitespace-pre-wrap [overflow-wrap:anywhere]` with `[white-space:pre-wrap] [overflow-wrap:break-word] [word-break:break-word]` for more explicit control and better cross-browser wrapping
- added `overflow: hidden` and `width: 100%` to inline styles to prevent any scrollbar flash during height recalc
- added `overflow-hidden` to the wrapper div to clip any overflow during transitions
- `field-sizing-content` kept for chrome; js height sync handles firefox