### PR TITLE
overhaul scrollbar styling across the app

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function PublicNotePage() {
 
   return (
     <div
-      className="relative w-full flex flex-col h-screen overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
+      className="relative w-full flex flex-col h-screen overflow-y-auto [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
       onScroll={(e) => {
         setIsScrolled(e.currentTarget.scrollTop > 0);
       }}

--- a/app/globals.css
+++ b/app/globals.css
@@ -229,27 +229,21 @@ html {
   scroll-behavior: smooth;
 }
 
-/* Firefox scrollbar */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: hsl(var(--muted-foreground) / 0.5) transparent;
-}
-
 ::-webkit-scrollbar {
   width: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: transparent;
+  background: hsl(0 0% 97.6471%);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--muted-foreground)/0.5);
+  background: hsla(17, 22%, 32%, 0.854);
   border-radius: 8px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground));
+  background: hsl(16.6667 21.9512% 32.1569%);
 }
 
 ::selection {

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -229,7 +229,7 @@ function SearchPanel({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-2 transition-all scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent">
+      <div className="scrollbar-gutter-stable flex-1 overflow-y-auto p-2 transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
         {!query.trim() ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
             <FileSearch className="h-8 w-8 text-muted-foreground" />
@@ -301,7 +301,7 @@ function ThumbnailsPanel({ onClose }: { onClose: () => void }) {
       </div>
       <div
         ref={panelRef}
-        className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-3 [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
+        className="scrollbar-gutter-stable flex-1 overflow-y-auto overflow-x-hidden px-3 py-3 [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
       >
         <div className="flex flex-col items-center gap-2">
           {Array.from({ length: totalPages }, (_, index) => {
@@ -591,7 +591,7 @@ function PdfViewerContent({
         ) : null}
 
         <div className=" absolute inset-y-0 right-0 z-30 flex h-screen w-full items-center justify-center border-b border-border bg-background">
-          <Pages className="h-full min-h-0 w-full transition-all scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent">
+          <Pages className="scrollbar-gutter-stable [&::-webkit-scrollbar-track]:bg-transparent h-full min-h-0 w-full transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border">
             <Page>
               <CanvasLayer />
               <TextLayer />

--- a/components/ToC.tsx
+++ b/components/ToC.tsx
@@ -399,7 +399,7 @@ export const ToC = ({ items = [], editor, onActiveIdChange }: ToCProps) => {
     <div
       className={`max-h-[40rem] ${
         isExpanded
-          ? "overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
+          ? "overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
           : "overflow-hidden"
       }`}
       onMouseEnter={() => setIsExpanded(true)}

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -314,7 +314,7 @@ const TailwindAdvancedEditor = ({
             }}
             slotAfter={<ImageResizer />}
           >
-            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent">
+            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
               <EditorCommandEmpty className="px-2 text-muted-foreground">
                 No results
               </EditorCommandEmpty>
@@ -372,7 +372,7 @@ const TailwindAdvancedEditor = ({
             top: plusMenuPos.y,
             zIndex: 9999,
           }}
-          className=" relative w-64 max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 shadow-lg scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
+          className="relative w-64 max-h-[330px] overflow-y-auto rounded-tl-lg border border-border bg-muted px-1 py-1 shadow-lg scroll-smooth scrollbar-gutter-stable [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
         >
           <input
             autoFocus

--- a/components/code-block-component.tsx
+++ b/components/code-block-component.tsx
@@ -71,7 +71,7 @@ export const CodeBlockComponent = ({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="max-h-64 min-w-32 overflow-y-auto scroll-smooth [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
+            className="max-h-64 min-w-32 overflow-y-auto scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
             align="start"
           >
             {languages.map((lang) => (

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -1604,7 +1604,7 @@ const AppSidebar = React.memo(function AppSidebar() {
         <SidebarContent
           ref={sidebarContentRef}
           onScroll={handleSidebarScroll}
-          className="scrollbar-gutter-stable pb-16 relative text-foreground transition-all duration-200 ease-in-out [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-transparent scrollbar-track-transparent group-hover:scrollbar-thumb-border"
+          className="scrollbar-gutter-stable pb-16 relative text-foreground transition-all duration-200 ease-in-out [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent group-hover:[&::-webkit-scrollbar-thumb]:bg-border"
         >
           <SidebarNavigation
             pathname={pathname}

--- a/components/home-components/BreadcrumbWithCustomSeparator.tsx
+++ b/components/home-components/BreadcrumbWithCustomSeparator.tsx
@@ -55,7 +55,7 @@ export default function BreadcrumbWithCustomSeparator() {
   return (
     <div className="py-2">
       <Breadcrumb>
-        <BreadcrumbList className="flex flex-nowrap overflow-x-auto whitespace-nowrap text-primary !gap-0.5 [&::-webkit-scrollbar]:w-1.5">
+        <BreadcrumbList className="flex flex-nowrap overflow-x-auto whitespace-nowrap text-primary !gap-0.5 [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable">
           {pathSegments.map((segment, index) => {
             // Build the path up to this segment
             const pathToSegment =

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -119,7 +119,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         </div>
         <div
           ref={scrollContainerRef}
-          className={`min-h-0 flex-1 scrollbar-thumb-border [&::-webkit-scrollbar]:w-1.5 scrollbar-track-transparent ${
+          className={`scrollbar-gutter-stable min-h-0 flex-1 [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-track]:bg-transparent ${
             isPdfRoute ? "overflow-hidden pt-0" : "overflow-y-auto py-16"
           }`}
         >

--- a/components/home-components/MoveNoteDialog.tsx
+++ b/components/home-components/MoveNoteDialog.tsx
@@ -254,7 +254,7 @@ export default function MoveNoteDialog({
           </Button>
         </div>
 
-        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3 bg-card">
           {moveTargets === undefined ? (
             <div className="space-y-2 p-2">
               {Array.from({ length: 6 }).map((_, index) => (

--- a/components/home-components/MovePdfDialog.tsx
+++ b/components/home-components/MovePdfDialog.tsx
@@ -245,7 +245,7 @@ export default function MovePdfDialog({
           </Button>
         </div>
 
-        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent p-3 bg-card">
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3 bg-card">
           {moveTargets === undefined ? (
             <div className="space-y-2 p-2">
               {Array.from({ length: 6 }).map((_, index) => (

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -571,7 +571,7 @@ export default function SearchDialog({
         <div
           ref={resultsScrollRef}
           onScroll={handleResultsScroll}
-          className="min-h-[40vh] max-h-[40vh] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent p-3"
+          className="min-h-[40vh] max-h-[40vh] overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
         >
           {canScroll && scrollTop > 8 && (
             <div

--- a/components/selectors/color-selector.tsx
+++ b/components/selectors/color-selector.tsx
@@ -129,7 +129,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
       </PopoverTrigger>
       <PopoverContent
         sideOffset={5}
-        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
+        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
         align="start"
       >
         <div className="flex flex-col">

--- a/components/table-controls.tsx
+++ b/components/table-controls.tsx
@@ -261,7 +261,7 @@ export const TableControls = ({ editor }: TableControlsProps) => {
   const fullMenu = menu.show && (
     <div
       ref={menuRef}
-      className="fixed bg-muted border border-border rounded-tl-lg py-2 px-1 w-[270px] z-[9999] shadow-xl animate-in fade-in-0 zoom-in-95 overflow-y-auto max-h-[80vh] [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent"
+      className="fixed bg-muted border border-border rounded-tl-lg py-2 px-1 w-[270px] z-[9999] shadow-xl animate-in fade-in-0 zoom-in-95 overflow-y-auto max-h-[80vh] [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent scrollbar-gutter-stable"
       style={{ left: menu.x, top: menu.y }}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}

--- a/components/ui/skeleton-sidebar.tsx
+++ b/components/ui/skeleton-sidebar.tsx
@@ -50,7 +50,7 @@ export default function SkeletonSidebar({
           )}
         </div>
       </SidebarHeader>
-      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out [&::-webkit-scrollbar]:w-1.5 scrollbar-thumb-border scrollbar-track-transparent group-hover:scrollbar-thumb-border">
+      <SidebarContent className="text-foreground transition-all duration-200 ease-in-out [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent group-hover:[&::-webkit-scrollbar-thumb]:bg-border">
         <SidebarGroup>
           <SidebarGroupLabel className="text-border">
             <SkeletonTextAnimation className="w-24 h-3" />


### PR DESCRIPTION
two things changed: the global scrollbar colors are now hardcoded hsl values instead of css variables, and all per-component scrollbar classes were migrated from the tailwind-scrollbar plugin utilities to native webkit arbitrary variants.

**globals.css:**
- removed the firefox `scrollbar-width: thin` / `scrollbar-color` rule on `*` (firefox now falls back to default)
- `::-webkit-scrollbar-track` background changed from `transparent` to a hardcoded light value (`hsl(0 0% 97.6%)`)
- scrollbar thumb colors hardcoded to specific hsl values instead of `hsl(var(--muted-foreground)/0.5)` and `hsl(var(--muted-foreground))`  note: these are now fixed and won't adapt to dark mode

**per-component scrollbar classes:**
- `[&::-webkit-scrollbar]:w-1.5` to `[&::-webkit-scrollbar]:w-[0.4rem]` (slightly narrower)
- `scrollbar-thumb-border` to `[&::-webkit-scrollbar-thumb]:bg-border`
- `scrollbar-track-transparent` to `[&::-webkit-scrollbar-track]:bg-transparent`
- `scrollbar-gutter-stable` added to most scrollable containers to prevent layout shift when the scrollbar appears/disappears

affected: public note page, pdf viewer (search, thumbnails, pages), toc, editor command menu, plus menu, code block language dropdown, app sidebar, breadcrumb, home content layout, move note/pdf dialogs, search dialog, color selector, table controls, skeleton sidebar.