### PR TITLE
improve lato font setup and add body font rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,7 @@
   or use the "Copy code" button at https://ui.shadcn.com/themes */
 @layer base {
   :root {
+    --font-lato: var(--font-lato), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     --placeholder: 0 0% 93.7255%;
     --selection-background: #94c4e270;
     --selection-color: #000000;
@@ -361,6 +362,11 @@ div[role="dialog"][data-state="open"]:has([data-sidebar="header"]) {
 
 @layer base {
   body {
+    font-family: var(--font-lato);
+    font-feature-settings: "kern" 1, "liga" 1, "tnum" 1;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     @apply bg-background text-foreground;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,9 +13,12 @@ import {
   generateStructuredData,
 } from "@/lib/seo";
 import Script from "next/script";
+
 const lato = Lato({
-  weight: ["400"],
+  weight: ["400", "700"],
   subsets: ["latin"],
+  display: "swap",
+  variable: "--font-lato",
 });
 
 export const metadata: Metadata = {
@@ -46,7 +49,7 @@ export default function RootLayout({
       <body
         className={cn(
           "bg-background text-foreground flex flex-col min-h-screen",
-          lato.className,
+          lato.variable, // Changed to variable for better control
         )}
       >
         <Script
@@ -62,8 +65,6 @@ export default function RootLayout({
             <ConvexAuthNextjsServerProvider>
               <ConvexClientProvider>
                 <ConvexQueryCacheProvider
-                  // Keep a small number of recently-used query subscriptions alive briefly to reduce
-                  // navigation flicker, but avoid runaway idle subscriptions (bandwidth).
                   expiration={5 * 60_000}
                   maxIdleEntries={50}
                 >


### PR DESCRIPTION
F** fireFox :)
- switched lato from a static class (`lato.className`) to a css variable (`lato.variable`) so the font can be referenced via `var(--font-lato)` in css
- added `700` weight alongside `400` so bold text actually uses lato bold instead of faux bold
- added `display: swap` to avoid invisible text during font load
- defined `--font-lato` in `:root` with a full system font fallback stack
- applied `font-family: var(--font-lato)` to `body` along with `font-feature-settings`, `text-rendering: optimizeLegibility`, and antialiasing (`-webkit-font-smoothing`, `-moz-osx-font-smoothing`) for crisper text rendering
- removed two stale comments