### PR TITLE
simplify theme toggle labels

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -18,20 +18,17 @@ export function ThemeToggle() {
 
   const isDarkMode = resolvedTheme === "dark";
   const nextTheme = isDarkMode ? "light" : "dark";
-  const Icon = isDarkMode ? Sun : Moon;
 
   return (
     <Toggle
       pressed={isDarkMode}
       onPressedChange={() => setTheme(nextTheme)}
-      aria-label={`Switch to ${nextTheme} mode`}
+      aria-label="Switch Themes"
       className="group flex h-8 w-full min-w-0 items-center justify-between gap-2 px-2 text-sm font-normal text-foreground hover:bg-border data-[state=on]:border-transparent data-[state=on]:bg-transparent data-[state=on]:text-foreground"
     >
       <span className="flex min-w-0 items-center">
-        <Icon className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
-        <span className="truncate capitalize text-foreground">
-          {nextTheme} mode
-        </span>
+        <Moon className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="truncate capitalize text-foreground">Dark mode</span>
       </span>
       <span
         className="relative h-5 w-9 shrink-0 rounded-full bg-border/70 transition-colors group-data-[state=on]:bg-primary"


### PR DESCRIPTION
## what changed
it just cuz it didn't make any sense before lol

before : 
<img width="256" height="71" alt="image" src="https://github.com/user-attachments/assets/d2df3fdf-cbcd-4f74-96d2-8c9117741223" />
<img width="287" height="82" alt="image" src="https://github.com/user-attachments/assets/64ba594a-54a7-4608-8ad2-a1c224b3b482" />

after : 
<img width="256" height="51" alt="image" src="https://github.com/user-attachments/assets/4b6f1265-17b5-4b5a-ae74-dfa83b765e9c" />
<img width="262" height="79" alt="image" src="https://github.com/user-attachments/assets/0f85585a-22be-4ddb-8f76-95ee51ef74ef" />


Updated the theme toggle to use consistent labeling and iconography.

* Replaced the dynamic sun/moon icon with a static moon icon
* Changed the toggle label to always display "Dark mode"
* Simplified the aria label from a dynamic theme description to "Switch Themes"
* Removed logic that switched the displayed icon and text based on the current theme

The previous implementation displayed the next theme state rather than the setting being controlled, which could be slightly confusing. A fixed label makes it clearer that the toggle controls dark mode.