### PR TITLE
improve editor drop cursor visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -858,6 +858,12 @@ hr {
 
 }
 
+.prosemirror-dropcursor-block {
+  background-color: hsl(var(--border)) !important;
+  height: 3px !important;
+  border-radius: 2px !important;
+}
+
 .ProseMirror ul:not([data-type="taskList"]) li,
 .ProseMirror ol li {
   padding-left: 0.375rem;


### PR DESCRIPTION
Added custom styling for the ProseMirror block drop cursor.
before : 
<img width="741" height="84" alt="image" src="https://github.com/user-attachments/assets/bb2da245-9ab6-440d-acb8-ac15206e80d8" />

after : 
<img width="779" height="187" alt="image" src="https://github.com/user-attachments/assets/9f305df0-da8f-4310-9d3d-a5b8406a86fb" />


* Set the drop cursor color to use the theme border color
* Increased the cursor height to 3px
* Added rounded corners for a smoother appearance

The default drop cursor was harder to notice while dragging blocks, making it less clear where content would be inserted. The new styling provides a more visible insertion indicator.

* Better visual consistency with the editor theme

