### PR TITLE
refine landing page cta and signup flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,6 @@ export default async function HomePage() {
           <MoreAboutMe />
           <FAQ />
           {/* <PricingSection /> */}
-          <SignUpToday />
         </div>
         <Footer />
       </div>

--- a/components/landingPage-components/Footer.tsx
+++ b/components/landingPage-components/Footer.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
+import SignUpToday from "./SignUpToday";
 export default function Footer() {
   return (
     <div className="relative w-full overflow-hidden bg-transparent">
@@ -34,6 +35,7 @@ export default function Footer() {
         </svg>
       </div>
       <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 pb-10 bg-[#EFEFEF]">
+        <SignUpToday />
         <div className="max-w-6xl mx-auto py-5 px-6 md:px-12 lg:px-16">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
             <div>

--- a/components/landingPage-components/HowToStartSection.tsx
+++ b/components/landingPage-components/HowToStartSection.tsx
@@ -148,20 +148,29 @@ function SignUpPreview() {
 
   return (
     <div className="flex flex-col gap-2.5 p-5 w-full">
-      <div className="bg-background app-radius-lg px-3.5 py-2.5 border border-border">
-        <p className="text-[10px] text-muted-foreground uppercase tracking-widest mb-1">
+      <div>
+        <p className="text-[10px] mx-1 text-muted-foreground uppercase tracking-widest mb-1">
           Email
         </p>
-        <p className="text-xs text-foreground min-h-[16px] flex items-center gap-0.5">
-          {displayed.length > 0 ? (
-            displayed
-          ) : (
-            <span className="text-muted-foreground">name@email.com</span>
-          )}
-          {!done && (
-            <span className="inline-block w-0.5 h-3 bg-primary app-radius-sm cursor-blink" />
-          )}
-        </p>
+        <div className="bg-background app-radius-lg px-3.5 py-2.5 border border-border">
+          <p className="text-xs text-foreground min-h-[16px] flex items-center gap-0.5">
+            {displayed.length > 0 ? (
+              <>
+                {displayed}
+                {!done && (
+                  <span className="inline-block w-0.5 h-3 bg-primary app-radius-sm cursor-blink" />
+                )}
+              </>
+            ) : (
+              <>
+                {!done && (
+                  <span className="inline-block w-0.5 h-3 bg-primary app-radius-sm cursor-blink" />
+                )}
+                <span className="text-muted-foreground">name@email.com</span>
+              </>
+            )}
+          </p>
+        </div>
       </div>
       <motion.div
         className={`bg-primary text-primary-foreground text-center text-sm app-radius-lg px-4 py-2 text-[11px] mt-1 transition-all duration-300 border-r border-b border-muted/50 translate-x-[0px] translate-y-[0px]${done ? " border-muted/50 translate-x-[-3px] translate-y-[-3px] app-radius-lg shadow-[3px_3px_0px] shadow-primary " : ""}`}
@@ -177,10 +186,10 @@ function SignUpPreview() {
         <div className="flex-1 h-px bg-border" />
       </div>
       <div className="flex gap-2">
-        {["GitHub", "Google"].map((label) => (
+        {["GitHub", "Google"].map((label, i) => (
           <div
             key={label}
-            className="flex-1 bg-background border border-border app-radius-lg py-2 text-center text-[11px] text-foreground font-medium"
+            className={`flex-1 bg-background border border-border ${i === 0 ? "app-radius-lg" : "rounded-none"} py-2 text-center text-[11px] text-foreground font-medium`}
           >
             {label}
           </div>
@@ -424,8 +433,6 @@ function WritingPreview() {
 
 const stepPreviews = [SignUpPreview, WorkspacePreview, WritingPreview];
 
-/*  Main Section  */
-
 export default function HowToStartSection() {
   const containerRef = useRef<HTMLDivElement>(null);
   const nodeRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -447,7 +454,6 @@ export default function HowToStartSection() {
         />
 
         <div ref={containerRef} className="relative max-w-7xl mx-auto">
-          {/* Step connector dots row */}
           <div className="flex items-center max-w-3xl mx-auto mb-8 px-6 md:px-12">
             {HowToStartSteps.map((_: Step, i: number) => (
               <div key={i} className="flex items-center flex-1 last:flex-none">
@@ -463,7 +469,6 @@ export default function HowToStartSection() {
             ))}
           </div>
 
-          {/* Cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 Desktop:grid-cols-3 gap-6">
             {HowToStartSteps.map((step: Step, index: number) => {
               const Icon = stepIcons[index];
@@ -477,12 +482,10 @@ export default function HowToStartSection() {
                   transition={{ duration: 0.5, delay: index * 0.1 }}
                   className="group relative bg-card app-radius-xl border border-border overflow-hidden flex flex-col"
                 >
-                  {/* Preview area */}
                   <div className="bg-muted border-b border-border h-72 overflow-hidden flex items-center justify-center">
                     <Preview />
                   </div>
 
-                  {/* Card content */}
                   <div className="p-5 flex flex-col flex-1">
                     <span className="absolute top-2 left-2 inline-flex items-center bg-secondary text-secondary-foreground app-radius-lg border border-primary/20 p-1.5 text-[11px] font-bold mb-3">
                       <Icon className="w-4 h-4 text-primary" />
@@ -503,7 +506,6 @@ export default function HowToStartSection() {
             })}
           </div>
 
-          {/* Animated beams — rendered after mount so refs are populated */}
           {isMounted &&
             HowToStartSteps.map((_: Step, index: number) => {
               if (index < HowToStartSteps.length - 1) {
@@ -525,18 +527,6 @@ export default function HowToStartSection() {
               }
               return null;
             })}
-        </div>
-
-        {/* CTA */}
-        <div className="mt-5 flex flex-col items-center gap-3">
-          <Button className="px-10 text-base">
-            <Link prefetch={true} href="/signup">
-              Get Started Free
-            </Link>
-          </Button>
-          <p className="text-xs text-muted-foreground">
-            No credit card required
-          </p>
         </div>
       </div>
     </section>

--- a/components/landingPage-components/SignUpToday.tsx
+++ b/components/landingPage-components/SignUpToday.tsx
@@ -6,14 +6,14 @@ export default function SignUpToday() {
   return (
     <section
       className={cn(
-        "px-4 sm:px-6 md:px-8",
+        "px-1",
         "py-12 sm:py-16 md:py-20 Desktop:py-24",
         "relative overflow-hidden",
       )}
     >
       <div className="relative flex flex-col items-center justify-center gap-8 ">
         <div className="text-center space-y-4 ">
-          <h2 className="text-5xl md:text-7xl Desktop:text-[94px] font-bold tracking-tight bg-gradient-to-r from-primary/90 via-primary to-primary/90 bg-clip-text text-transparent">
+          <h2 className="text-6xl md:text-7xl Desktop:text-[100px] font-bold tracking-tight text-primary">
             It Doesn't Have To Be Complicated
           </h2>
           <p className="text-lg md:text-xl font-semibold text-muted-foreground">
@@ -29,7 +29,7 @@ export default function SignUpToday() {
               href="/signup"
               className="text-base font-medium"
             >
-              Start Free
+              Get Started for Free
             </Link>
           </Button>
           {/* <Button size="lg" variant="outline" asChild className="w-full sm:w-auto">

--- a/components/landingPage-components/faq.tsx
+++ b/components/landingPage-components/faq.tsx
@@ -15,7 +15,7 @@ export default function FAQ() {
     >
       <MaxWContainer>
         <SectionHeading
-          SectionTitle="FAQ"
+          SectionTitle="Frequently Asked Questions"
           SectionSubTitle="if your interested"
         />
 
@@ -23,7 +23,7 @@ export default function FAQ() {
           type="single"
           collapsible
           defaultValue="shipping"
-          className="max-w-lg mx-auto min-h-[238px]"
+          className="max-w-lg mx-auto min-h-[300px]"
         >
           {AccordionData.map((item, index) => (
             <AccordionItem key={index} value={item.itmevalue}>


### PR DESCRIPTION
## what changed
before : 
<img width="1683" height="715" alt="image" src="https://github.com/user-attachments/assets/0a10274a-5c91-4f84-98eb-fdbb3154358c" />

after : 
<img width="1732" height="838" alt="image" src="https://github.com/user-attachments/assets/8c41f88e-fdaf-4a12-8f8f-9d8817dc9800" />
<img width="1659" height="671" alt="image" src="https://github.com/user-attachments/assets/8564ac70-6af1-4ec6-b967-e4b54f81cfd9" />
<img width="456" height="453" alt="image" src="https://github.com/user-attachments/assets/5f63c29b-2c2d-4845-b16c-77c6e3190b1f" />




Updated several landing page sections to improve the signup experience and clean up the layout.

* Moved the signup CTA into the footer instead of rendering it on the homepage directly
* Refined the signup preview card with better input and button styling
* Updated the main CTA section typography and changed the button text to "Get Started for Free"
* Expanded the FAQ title and increased its minimum height
* Removed duplicate CTA content from the how-to section
* Cleaned up unused comments and simplified some styling

There were multiple calls to action spread across the page, which made the flow feel repetitive. Consolidating the signup section and refining the preview components creates a cleaner journey and improves visual consistency.


* More focused and less repetitive landing page flow
* Stronger footer CTA placement at the end of the page
* Improved signup preview visuals and interactions
* Clearer FAQ section with better spacing
* Cleaner component structure with less unnecessary code
* More consistent messaging around getting started
