### PR TITLE
clean up unused comments and imports

### DIFF
--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -71,7 +71,6 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
   const [content, setContent] = useState<JSONContent>();
   const [editedTitle, setEditedTitle] = useState(stableNote?.title || "");
 
-  // stableNote loads async — if editedTitle is still empty when data arrives, sync it
   useEffect(() => {
     if (stableNote?.title && !editedTitle) {
       setEditedTitle(stableNote.title);

--- a/app/home/[id]/loading.tsx
+++ b/app/home/[id]/loading.tsx
@@ -55,7 +55,6 @@ function NotesGridSkeleton({ count }: { count: number }) {
 export default function Loading() {
   return (
     <MaxWContainer className="my-5">
-      {/* Header (match WorkingSpacePageClient layout) */}
       <header className="pb-5">
         <div className="relative overflow-hidden app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8">
           <div className="relative flex flex-col gap-4">
@@ -74,12 +73,10 @@ export default function Loading() {
         </div>
       </header>
 
-      {/* Tabs */}
       <div className="mt-6 mb-6">
         <TabsSkeleton count={5} />
       </div>
 
-      {/* Control Bar */}
       <div className="space-y-6">
         <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
           <div className="flex items-center gap-3 flex-1 w-full sm:w-auto">
@@ -98,10 +95,8 @@ export default function Loading() {
           </div>
         </div>
 
-        {/* Notes grid */}
         <NotesGridSkeleton count={6} />
 
-        {/* Show more */}
         <div className="flex justify-center pt-2">
           <Skeleton className="h-10 w-28 app-radius-lg" />
         </div>

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -18,7 +18,6 @@ import {
 import { GlobalWorkerOptions } from "pdfjs-dist/legacy/build/pdf.mjs";
 import "pdfjs-dist/web/pdf_viewer.css";
 import {
-  ArrowUpRight,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -26,13 +25,10 @@ import {
   FileText,
   Search,
   X,
-  Plus,
-  Minus,
 } from "lucide-react";
 import { useQuery } from "@/cache/useQuery";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import MaxWContainer from "@/components/ui/MaxWContainer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -42,7 +38,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import SkeletonTextAnimation from "@/components/ui/SkeletonTextAnimation";
 import { cn } from "@/lib/utils";
 import {
   Tooltip,
@@ -51,8 +46,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import PdfSettings from "@/components/home-components/PdfSettings";
-import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
-import BreadcrumbWithCustomSeparator from "@/components/home-components/BreadcrumbWithCustomSeparator";
+import { useSidebar } from "@/components/ui/sidebar";
 
 GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/legacy/build/pdf.worker.mjs",

--- a/app/home/[id]/pdf/[pdfId]/loading.tsx
+++ b/app/home/[id]/pdf/[pdfId]/loading.tsx
@@ -1,9 +1,5 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
 
-function Skeleton({ className = "" }: { className?: string }) {
-  return <div className={`bg-border rounded-md animate-pulse ${className}`} />;
-}
-
 export default function Loading() {
   return (
     <MaxWContainer className="flex h-full w-[900px] flex-col px-0 py-0 mx-0">

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -7,17 +7,14 @@ function Skeleton({ className = "" }: { className?: string }) {
 function WorkspaceCardSkeleton() {
   return (
     <div className="flex-shrink-0 w-[330px] min-h-[230px] rounded-lg border border-border bg-card overflow-hidden flex flex-col">
-      {/* CardHeader */}
       <div className="p-6 pb-3">
         <Skeleton className="h-5 w-3/4" />
       </div>
-      {/* CardContent — folder icon area */}
       <div className="px-6 flex-1">
         <div className="h-full flex items-center justify-center">
           <Skeleton className="h-8 w-8 rounded-md" />
         </div>
       </div>
-      {/* CardFooter */}
       <div className="px-6 py-4 flex justify-between items-center border-t border-border">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-9 w-12" />
@@ -29,7 +26,6 @@ function WorkspaceCardSkeleton() {
 function NoteCardSkeleton() {
   return (
     <div className="flex-shrink-0 w-[330px] h-[230px] rounded-lg border border-border bg-card overflow-hidden flex flex-col">
-      {/* CardHeader */}
       <div className="p-6 pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 space-y-2">
@@ -38,13 +34,11 @@ function NoteCardSkeleton() {
           </div>
         </div>
       </div>
-      {/* CardContent */}
       <div className="px-6 pb-3 flex-1 space-y-2">
         <Skeleton className="h-3 w-full" />
         <Skeleton className="h-3 w-5/6" />
         <Skeleton className="h-3 w-4/6" />
       </div>
-      {/* CardFooter */}
       <div className="px-6 py-4 flex justify-between items-center border-t border-border mt-auto">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-9 w-12" />
@@ -60,7 +54,6 @@ function SliderRow({ children }: { children: React.ReactNode }) {
 export default function Loading() {
   return (
     <MaxWContainer className="relative my-5">
-      {/* Hero Section */}
       <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <div className="max-w-3xl mx-auto text-center">
           <Skeleton className="h-10 w-56 mx-auto mb-4" />
@@ -69,7 +62,6 @@ export default function Loading() {
         </div>
       </div>
 
-      {/* Workspaces Slider */}
       <div className="mb-12">
         <div className="mb-6 flex justify-between items-center">
           <Skeleton className="h-7 w-44" />
@@ -82,7 +74,6 @@ export default function Loading() {
         </SliderRow>
       </div>
 
-      {/* Pinned Notes Slider */}
       <div className="mb-12">
         <div className="mb-6">
           <Skeleton className="h-7 w-36" />
@@ -94,7 +85,6 @@ export default function Loading() {
         </SliderRow>
       </div>
 
-      {/* Recent Notes Slider */}
       <div className="mb-12">
         <div className="mb-6">
           <Skeleton className="h-7 w-36" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,6 @@ export default async function HomePage() {
   }
 
   return (
-    // Force light mode for the entire landing page regardless of user theme
     <div className="force-light">
       <div className="relative flex flex-col min-h-screen bg-background text-foreground">
         <div className="absolute inset-0">

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -36,7 +36,6 @@ function SignInWithMagicLink({
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
 
-  // Zod schema for email
   const emailSchema = z.object({
     email: z.string().email({ message: "Please enter a valid email address." }),
   });
@@ -105,7 +104,6 @@ export default function SignInPage() {
   const [step, setStep] = useState<"signIn" | "linkSent">("signIn");
   return (
     <div className=" force-light relative flex min-h-svh flex-col items-center justify-center p-6 md:p-10 overflow-hidden">
-      {/* Real PNG grain noise overlay — always light mode, fixed values */}
       <div
         aria-hidden="true"
         className="pointer-events-none select-none absolute inset-0"

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -19,9 +19,7 @@ import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 interface NoteDownloadDropdownProps {
   noteBody: string | undefined | null;
   noteTitle: string;
-  /** Alignment of the dropdown menu relative to its trigger. Defaults to "end". */
   align?: "end" | "start" | "center";
-  /** Extra class names for the trigger button. */
   className?: string;
 }
 

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -90,8 +90,6 @@ export const reducer = (state: State, action: Action): State => {
     case "DISMISS_TOAST": {
       const { toastId } = action;
 
-      // ! Side effects ! - This could be extracted into a dismissToast() action,
-      // but I'll keep it here for simplicity
       if (toastId) {
         addToRemoveQueue(toastId);
       } else {


### PR DESCRIPTION
Performed a general cleanup across multiple pages and components.

* Removed outdated and redundant comments throughout loading screens and page components
* Removed unused imports from the PDF viewer and other files
* Deleted an unused skeleton helper in the PDF loading page
* Removed unnecessary inline documentation from component props
* Simplified comments in the toast reducer and note page client

Many comments and imports were no longer adding value and some had become outdated. Removing them helps reduce noise and makes the code easier to navigate and maintain.
