### PR TITLE
add scrollbar-gutter to public note page

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function PublicNotePage() {
 
   return (
     <div
-      className="relative w-full flex flex-col h-screen overflow-y-auto [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
+      className="relative w-full flex flex-col h-screen overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent"
       onScroll={(e) => {
         setIsScrolled(e.currentTarget.scrollTop > 0);
       }}


### PR DESCRIPTION
added `scrollbar-gutter-stable` to the public note viewer.

this prevents layout shift when the scrollbar appears/disappears while scrolling, making the reading experience smoother and more stable.
