### PR TITLE
add animated highlight to faq questions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -265,6 +265,46 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
+.animated-highlight {
+  position: relative;
+  display: inline-block;
+  z-index: 1;
+  padding: 0 0.3rem;
+}
+
+.animated-highlight::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 100%;
+  background-color: hsl(var(--secondary));
+  border-radius: 0.5rem;
+  z-index: -1;
+
+}
+
+@keyframes sweep-highlight {
+  0% {
+    width: 0;
+  }
+
+  100% {
+    width: 100%;
+  }
+}
+
+.animated-highlight-container:hover>.animated-highlight::after {
+  color: hsl(var(--secondary-foreground));
+  animation: sweep-highlight 0.5s ease-out forwards;
+}
+
+.animated-highlight-container:hover>span.animated-highlight {
+  color: hsl(var(--secondary-foreground));
+}
+
+
 /* For Firefox */
 input[type=number] {
   -moz-appearance: textfield;

--- a/components/landingPage-components/faq.tsx
+++ b/components/landingPage-components/faq.tsx
@@ -27,7 +27,10 @@ export default function FAQ() {
         >
           {AccordionData.map((item, index) => (
             <AccordionItem key={index} value={item.itmevalue}>
-              <AccordionTrigger>{item.trigger}</AccordionTrigger>
+              <AccordionTrigger className="animated-highlight-container">
+                {" "}
+                <span className="animated-highlight">{item.trigger}</span>{" "}
+              </AccordionTrigger>
               <AccordionContent>{item.content}</AccordionContent>
             </AccordionItem>
           ))}

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -31,7 +31,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center cursor-default justify-between py-4 text-lg font-medium transition-all hover:underline text-left  [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center cursor-default justify-between py-4 text-lg font-medium transition-all text-left  [&[data-state=open]>svg]:rotate-180",
         className,
       )}
       {...props}


### PR DESCRIPTION
added a smooth sweep highlight animation on hover for FAQ accordion triggers.
a little bit better than the underline thing

before : 
<img width="823" height="370" alt="image" src="https://github.com/user-attachments/assets/35a76cb5-b0eb-404b-91f9-7759570578f3" />

after : 
<img width="867" height="404" alt="image" src="https://github.com/user-attachments/assets/f1c82bc8-971b-463c-8a41-2062f0112269" />


- new `.animated-highlight` utility in globals.css
- updated accordion trigger to remove default underline
- applied the effect to all FAQ items
