### PR TITLE
improve error and not found pages

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -28,6 +28,16 @@ export default function Error({
   return (
     <section className="relative flex min-h-svh flex-col items-center justify-center bg-background p-6 overflow-hidden">
       <MaxWContainer className="flex flex-col items-center justify-center gap-3 *:text-center relative px-4 sm:px-6 lg:px-8">
+        <div className=" gap-2 flex justify-center items-center ">
+          <Image
+            src={imgsrc}
+            alt="Notevo Logo"
+            priority
+            width={20}
+            height={20}
+          />
+          <p className="text-sm text-foreground">Notevo.me</p>
+        </div>
         <Card className="overflow-hidden bg-card border-border ">
           <CardContent className="relative pt-4 pb-16">
             <div className="flex flex-col justify-center">
@@ -46,15 +56,17 @@ export default function Error({
           </CardContent>
         </Card>
         <div className=" w-full flex justify-center items-center ">
-          <Image
-            src={imgsrc}
-            alt="Notevo Logo"
-            priority
-            width={16}
-            height={16}
-          />
-          <p className="text-muted-foreground text-xs font-medium px-2 ">
-            {`! Hi this is Notevo team we're sorry | hit the try again button `}
+          <p className="text-muted-foreground text-xs font-medium px-2 max-w-xl ">
+            ! Hi this is Notevo's team we're sorry ,our team is automatically
+            notified whenever a server error like this happens, so we're already
+            on it. If the problem keeps happening, email us at{" "}
+            <Link
+              href="mailto:support@notevo.me"
+              className=" font-bold text-foreground hover:underline"
+            >
+              support@notevo.me
+            </Link>{" "}
+            and we'll help you out. hit the try again button for now
           </p>
         </div>
       </MaxWContainer>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -9,6 +9,16 @@ export default function NotFound() {
   return (
     <section className="relative flex min-h-svh flex-col items-center justify-center bg-background  p-6 md:p-10 overflow-hidden">
       <MaxWContainer className="flex flex-col items-center justify-center gap-4 *:text-center relative px-4 sm:px-6 lg:px-8">
+        <div className=" gap-2 flex justify-center items-center ">
+          <Image
+            src={imgsrc}
+            alt="Notevo Logo"
+            priority
+            width={20}
+            height={20}
+          />
+          <p className="text-sm text-foreground">Notevo.me</p>
+        </div>
         <Card className="overflow-hidden bg-card border-border">
           <CardContent className="relative pt-4 pb-16">
             <div className="flex flex-col items-center justify-center gap-4 text-center">
@@ -25,15 +35,16 @@ export default function NotFound() {
           </CardContent>
         </Card>
         <div className="w-full flex justify-center items-center">
-          <Image
-            src={imgsrc}
-            alt="Notevo Logo"
-            priority
-            width={16}
-            height={16}
-          />
-          <p className="text-muted-foreground text-xs font-medium px-2">
-            {` ! Hi this is Notevo team we're really sorry for this | go back to the home page `}
+          <p className="text-muted-foreground text-xs font-medium px-2 max-w-lg">
+            ! Hi this is Notevo's team we're really sorry but i think we dont
+            have a this page If the problem keeps happening, email us at{" "}
+            <Link
+              href="mailto:support@notevo.me"
+              className=" font-bold text-foreground hover:underline"
+            >
+              support@notevo.me
+            </Link>{" "}
+            and we'll help you out. <br /> but for now Return Home
           </p>
         </div>
       </MaxWContainer>


### PR DESCRIPTION
Updated the error and 404 pages to provide more context and support information.
<img width="712" height="494" alt="image" src="https://github.com/user-attachments/assets/bc007dad-6750-42ba-8dae-1544445450b0" />
<img width="1023" height="442" alt="image" src="https://github.com/user-attachments/assets/ee6bc8b9-8a9d-46c1-b4eb-14db3bda1bc9" />

before : 
<img width="731" height="419" alt="image" src="https://github.com/user-attachments/assets/932cb222-1be5-464b-8f87-46a4bc506bea" />
<img width="770" height="370" alt="image" src="https://github.com/user-attachments/assets/02eeaadd-d019-4872-81f5-d383edc02de3" />


* Added Notevo branding above the cards with the logo and site name
* Replaced the short footer messages with more detailed explanations
* Added a support email link to both pages
* Clarified that server errors are automatically monitored
* Updated the messaging to better guide users on what to do next

The previous pages provided very little information and didn't give users a clear path forward when something went wrong. Adding more context and support options helps reassure users and makes issues easier to resolve.

* Stronger branding on error states
* More helpful and reassuring messaging