### PR TITLE
add account settings and profile updates

### DIFF
--- a/components/home-components/AccountSettingsDialog.tsx
+++ b/components/home-components/AccountSettingsDialog.tsx
@@ -1,0 +1,802 @@
+"use client";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  Camera,
+  CreditCard,
+  RotateCcw,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useMutation } from "convex/react";
+import { toast } from "sonner";
+import { api } from "@/convex/_generated/api";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import { formatUserEmail } from "@/lib/utils";
+interface AccountSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  user: Doc<"users"> | undefined;
+}
+
+type PhotoSize = {
+  width: number;
+  height: number;
+};
+
+type CropBox = {
+  x: number;
+  y: number;
+  size: number;
+};
+
+type CropCorner = "nw" | "ne" | "sw" | "se";
+
+function splitName(name: string | undefined) {
+  const parts = (name ?? "").trim().split(/\s+/).filter(Boolean);
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+function loadImage(src: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = src;
+  });
+}
+
+async function createEditedAvatarBlob(src: string, crop: CropBox) {
+  const image = await loadImage(src);
+  const canvas = document.createElement("canvas");
+  const size = 512;
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error("Could not edit avatar image");
+  }
+
+  context.fillStyle = "#111827";
+  context.fillRect(0, 0, size, size);
+  context.translate(size / 2, size / 2);
+  context.drawImage(
+    image,
+    crop.x,
+    crop.y,
+    crop.size,
+    crop.size,
+    -size / 2,
+    -size / 2,
+    size,
+    size,
+  );
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+          return;
+        }
+        reject(new Error("Could not export avatar image"));
+      },
+      "image/jpeg",
+      0.92,
+    );
+  });
+}
+
+function createCenteredCrop(photoSize: PhotoSize): CropBox {
+  const size = Math.min(photoSize.width, photoSize.height) * 0.8;
+
+  return {
+    x: (photoSize.width - size) / 2,
+    y: (photoSize.height - size) / 2,
+    size,
+  };
+}
+
+function clampCrop(crop: CropBox, photoSize: PhotoSize): CropBox {
+  const maxSize = Math.min(photoSize.width, photoSize.height);
+  const size = Math.min(Math.max(crop.size, maxSize * 0.2), maxSize);
+  const x = Math.min(Math.max(crop.x, 0), photoSize.width - size);
+  const y = Math.min(Math.max(crop.y, 0), photoSize.height - size);
+
+  return { x, y, size };
+}
+
+export default function AccountSettingsDialog({
+  open,
+  onOpenChange,
+  user,
+}: AccountSettingsDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const photoPreviewRef = useRef<HTMLDivElement>(null);
+  const cropInteractionRef = useRef<{
+    mode: "move" | "resize";
+    corner?: CropCorner;
+    startClientX: number;
+    startClientY: number;
+    startCrop: CropBox;
+  } | null>(null);
+  const generateAvatarUploadUrl = useMutation(
+    api.users.generateAvatarUploadUrl,
+  );
+  const updateProfile = useMutation(api.users.updateProfile);
+  const nameParts = useMemo(() => splitName(user?.name), [user?.name]);
+  const [firstName, setFirstName] = useState(nameParts.firstName);
+  const [lastName, setLastName] = useState(nameParts.lastName);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [selectedPhotoUrl, setSelectedPhotoUrl] = useState<string | null>(null);
+  const [selectedPhotoSize, setSelectedPhotoSize] = useState<PhotoSize | null>(
+    null,
+  );
+  const [photoPreviewSize, setPhotoPreviewSize] = useState(385);
+  const [crop, setCrop] = useState<CropBox | null>(null);
+  const [isPhotoEditorOpen, setIsPhotoEditorOpen] = useState(false);
+  const [isSavingName, setIsSavingName] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [isDeletingAvatar, setIsDeletingAvatar] = useState(false);
+  const removeAvatarTooltip = useHoverTooltip(150);
+
+  useEffect(() => {
+    if (!open) return;
+    setFirstName(nameParts.firstName);
+    setLastName(nameParts.lastName);
+  }, [nameParts.firstName, nameParts.lastName, open]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (selectedPhotoUrl) URL.revokeObjectURL(selectedPhotoUrl);
+    };
+  }, [selectedPhotoUrl]);
+
+  useEffect(() => {
+    if (!selectedPhotoUrl) {
+      setSelectedPhotoSize(null);
+      setCrop(null);
+      return;
+    }
+
+    let isCurrent = true;
+
+    void loadImage(selectedPhotoUrl).then((image) => {
+      if (!isCurrent) return;
+
+      const photoSize = {
+        width: image.naturalWidth || image.width,
+        height: image.naturalHeight || image.height,
+      };
+
+      setSelectedPhotoSize(photoSize);
+      setCrop(createCenteredCrop(photoSize));
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [selectedPhotoUrl]);
+
+  useEffect(() => {
+    if (!isPhotoEditorOpen || !photoPreviewRef.current) return;
+
+    const updatePreviewSize = () => {
+      if (!photoPreviewRef.current) return;
+      setPhotoPreviewSize(photoPreviewRef.current.clientWidth);
+    };
+
+    updatePreviewSize();
+    const resizeObserver = new ResizeObserver(updatePreviewSize);
+    resizeObserver.observe(photoPreviewRef.current);
+
+    return () => resizeObserver.disconnect();
+  }, [isPhotoEditorOpen]);
+
+  const fullName = `${firstName.trim()} ${lastName.trim()}`.trim();
+  const currentName = (user?.name ?? "").trim();
+  const hasNameChanges = fullName.length > 0 && fullName !== currentName;
+  const displayName = fullName || currentName || "Your profile";
+  const avatarSrc = previewUrl ?? user?.image;
+  const hasAvatarImage = Boolean(avatarSrc);
+  const displayedPhotoRect = selectedPhotoSize
+    ? (() => {
+        const scale = Math.min(
+          photoPreviewSize / selectedPhotoSize.width,
+          photoPreviewSize / selectedPhotoSize.height,
+        );
+        const width = selectedPhotoSize.width * scale;
+        const height = selectedPhotoSize.height * scale;
+
+        return {
+          left: (photoPreviewSize - width) / 2,
+          top: (photoPreviewSize - height) / 2,
+          width,
+          height,
+          scale,
+        };
+      })()
+    : null;
+  const cropStyle =
+    crop && displayedPhotoRect
+      ? {
+          left: displayedPhotoRect.left + crop.x * displayedPhotoRect.scale,
+          top: displayedPhotoRect.top + crop.y * displayedPhotoRect.scale,
+          width: crop.size * displayedPhotoRect.scale,
+          height: crop.size * displayedPhotoRect.scale,
+        }
+      : null;
+
+  const handleAvatarUpload = useCallback(
+    async (file: File) => {
+      if (!file.type.startsWith("image/")) {
+        toast.error("Please choose a JPG or PNG image.");
+        return;
+      }
+
+      if (file.size / 1024 / 1024 > 5) {
+        toast.error("Avatar must be 5MB or smaller.");
+        return;
+      }
+
+      setIsUploadingAvatar(true);
+      const objectUrl = URL.createObjectURL(file);
+      setPreviewUrl((currentUrl) => {
+        if (currentUrl) URL.revokeObjectURL(currentUrl);
+        return objectUrl;
+      });
+
+      try {
+        const uploadUrl = await generateAvatarUploadUrl({});
+        const response = await fetch(uploadUrl, {
+          method: "POST",
+          headers: { "Content-Type": file.type },
+          body: file,
+        });
+
+        if (!response.ok) {
+          throw new Error("Avatar upload failed");
+        }
+
+        const { storageId } = (await response.json()) as {
+          storageId: Id<"_storage">;
+        };
+
+        await updateProfile({ avatarStorageId: storageId });
+        toast.success("Avatar updated.");
+      } catch (error) {
+        console.error("Error updating avatar:", error);
+        toast.error("Could not update avatar. Please try again.");
+        setPreviewUrl(null);
+      } finally {
+        setIsUploadingAvatar(false);
+      }
+    },
+    [generateAvatarUploadUrl, updateProfile],
+  );
+
+  const closePhotoEditor = useCallback(() => {
+    setIsPhotoEditorOpen(false);
+    setCrop(null);
+    setSelectedPhotoSize(null);
+    setSelectedPhotoUrl((currentUrl) => {
+      if (currentUrl) URL.revokeObjectURL(currentUrl);
+      return null;
+    });
+  }, []);
+
+  const openPhotoEditorFromFile = useCallback((file: File) => {
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please choose an image file.");
+      return;
+    }
+
+    if (file.size / 1024 / 1024 > 5) {
+      toast.error("Avatar must be 5MB or smaller.");
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setSelectedPhotoUrl((currentUrl) => {
+      if (currentUrl) URL.revokeObjectURL(currentUrl);
+      return objectUrl;
+    });
+    setIsPhotoEditorOpen(true);
+  }, []);
+
+  const handleFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (file) openPhotoEditorFromFile(file);
+    },
+    [openPhotoEditorFromFile],
+  );
+  const startCropInteraction = useCallback(
+    (
+      event: React.PointerEvent<HTMLDivElement | HTMLButtonElement>,
+      mode: "move" | "resize",
+      corner?: CropCorner,
+    ) => {
+      if (!crop) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      cropInteractionRef.current = {
+        mode,
+        corner,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        startCrop: crop,
+      };
+    },
+    [crop],
+  );
+
+  const handleCropPointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const interaction = cropInteractionRef.current;
+      if (!interaction || !displayedPhotoRect || !selectedPhotoSize) return;
+
+      event.preventDefault();
+      const deltaX =
+        (event.clientX - interaction.startClientX) / displayedPhotoRect.scale;
+      const deltaY =
+        (event.clientY - interaction.startClientY) / displayedPhotoRect.scale;
+
+      if (interaction.mode === "move") {
+        setCrop(
+          clampCrop(
+            {
+              ...interaction.startCrop,
+              x: interaction.startCrop.x + deltaX,
+              y: interaction.startCrop.y + deltaY,
+            },
+            selectedPhotoSize,
+          ),
+        );
+        return;
+      }
+
+      const start = interaction.startCrop;
+      const corner = interaction.corner ?? "se";
+      const signedDeltaX = corner.includes("w") ? -deltaX : deltaX;
+      const signedDeltaY = corner.includes("n") ? -deltaY : deltaY;
+      const nextSize = start.size + Math.max(signedDeltaX, signedDeltaY);
+      const normalizedSize = Math.min(
+        Math.max(
+          nextSize,
+          Math.min(selectedPhotoSize.width, selectedPhotoSize.height) * 0.2,
+        ),
+        Math.min(selectedPhotoSize.width, selectedPhotoSize.height),
+      );
+      const nextCrop = {
+        x: corner.includes("w")
+          ? start.x + start.size - normalizedSize
+          : start.x,
+        y: corner.includes("n")
+          ? start.y + start.size - normalizedSize
+          : start.y,
+        size: normalizedSize,
+      };
+
+      setCrop(clampCrop(nextCrop, selectedPhotoSize));
+    },
+    [displayedPhotoRect, selectedPhotoSize],
+  );
+
+  const endCropInteraction = useCallback(() => {
+    cropInteractionRef.current = null;
+  }, []);
+
+  const handleConfirmPhotoEdit = useCallback(async () => {
+    if (!selectedPhotoUrl || !crop) return;
+
+    try {
+      const blob = await createEditedAvatarBlob(selectedPhotoUrl, crop);
+      const file = new File([blob], "avatar.jpg", { type: "image/jpeg" });
+      closePhotoEditor();
+      await handleAvatarUpload(file);
+    } catch (error) {
+      console.error("Error editing avatar:", error);
+      toast.error("Could not edit this photo. Please try another image.");
+    }
+  }, [closePhotoEditor, crop, handleAvatarUpload, selectedPhotoUrl]);
+
+  const handleDeleteAvatar = useCallback(async () => {
+    if (!hasAvatarImage || isDeletingAvatar) return;
+
+    setIsDeletingAvatar(true);
+    removeAvatarTooltip.hide();
+    try {
+      await updateProfile({ clearAvatar: true });
+      setPreviewUrl((currentUrl) => {
+        if (currentUrl) URL.revokeObjectURL(currentUrl);
+        return null;
+      });
+      toast.success("Avatar removed.");
+    } catch (error) {
+      console.error("Error removing avatar:", error);
+      toast.error("Could not remove avatar. Please try again.");
+    } finally {
+      setIsDeletingAvatar(false);
+    }
+  }, [hasAvatarImage, isDeletingAvatar, removeAvatarTooltip, updateProfile]);
+
+  const handleSaveName = useCallback(async () => {
+    if (!hasNameChanges) return;
+
+    setIsSavingName(true);
+    try {
+      await updateProfile({ name: fullName });
+      toast.success("Profile updated.");
+    } catch (error) {
+      console.error("Error updating profile:", error);
+      toast.error("Could not save your name. Please try again.");
+    } finally {
+      setIsSavingName(false);
+    }
+  }, [fullName, hasNameChanges, updateProfile]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className=" md:min-w-[850px] max-w-3xl overflow-hidden p-0 text-foreground z-[900001] ">
+        <DialogHeader className=" px-4 pb-2 pt-4 border-b border-border ">
+          <DialogTitle>Account settings</DialogTitle>
+          <DialogDescription>
+            Manage your profile, billing preferences, and account safety.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-8 px-4 py-4 max-h-[78vh] overflow-y-auto crollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
+          <section className="space-y-5">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold">My Profile</h2>
+                <p className="text-sm text-muted-foreground">
+                  Update the name and avatar shown across Notevo.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                disabled={!hasNameChanges || isSavingName}
+                onClick={() => void handleSaveName()}
+              >
+                {isSavingName ? "Saving..." : "Save changes"}
+              </Button>
+            </div>
+
+            <div className="grid gap-5 sm:grid-cols-[auto_1fr] sm:items-end">
+              <div className="space-y-2">
+                <div className="relative h-20 w-20">
+                  <button
+                    type="button"
+                    className="group relative block h-20 w-20 overflow-hidden app-radius-lg border border-border bg-muted"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isUploadingAvatar || isDeletingAvatar}
+                    aria-label={
+                      hasAvatarImage
+                        ? "Edit profile photo"
+                        : "Upload a new avatar"
+                    }
+                  >
+                    <Avatar className="h-full w-full app-radius-lg">
+                      {avatarSrc ? (
+                        <AvatarImage src={avatarSrc} alt={displayName} />
+                      ) : null}
+                      <AvatarFallback className="bg-border text-lg text-foreground">
+                        {displayName.charAt(0).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="absolute inset-0 flex items-center justify-center bg-background/70 opacity-0 transition-opacity group-hover:opacity-100">
+                      <Camera className="h-5 w-5" />
+                    </span>
+                  </button>
+                  {hasAvatarImage ? (
+                    <Tooltip open={removeAvatarTooltip.open}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground shadow-sm transition-colors hover:bg-destructive hover:text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                          aria-label="Remove profile photo"
+                          disabled={isUploadingAvatar || isDeletingAvatar}
+                          onClick={() => void handleDeleteAvatar()}
+                          {...removeAvatarTooltip.triggerProps}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="right"
+                        sideOffset={6}
+                        className=" text-xs px-1.5 py-0.5 z-[900001]"
+                      >
+                        Remove profile photo
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : null}
+                </div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  onChange={handleFileChange}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {isUploadingAvatar
+                    ? "Uploading..."
+                    : isDeletingAvatar
+                      ? "Removing..."
+                      : "Click to change"}
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="account-first-name">First name</Label>
+                  <Input
+                    id="account-first-name"
+                    value={firstName}
+                    onChange={(event) => setFirstName(event.target.value)}
+                    className="h-9"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="account-last-name">Last name</Label>
+                  <Input
+                    id="account-last-name"
+                    value={lastName}
+                    onChange={(event) => setLastName(event.target.value)}
+                    className="h-9"
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+          <Separator />
+          <section className="space-y-4">
+            <div className="flex items-center gap-2">
+              <CreditCard className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-base font-semibold">Billing</h2>
+            </div>
+            <div className="border border-border bg-muted/20 p-4 app-radius-lg">
+              <p className="font-medium">Billing options are coming soon</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Subscription plans and invoices will live here when Notevo adds
+                paid plans.
+              </p>
+            </div>
+          </section>
+
+          <Separator />
+
+          <section className="space-y-4">
+            <div className="flex items-center gap-2 text-destructive">
+              <Trash2 className="h-5 w-5" />
+              <h2 className="text-base font-semibold">Danger zone</h2>
+            </div>
+            <div className="border border-destructive/40 bg-destructive/5 p-4 app-radius-lg">
+              <p className="font-medium text-destructive">Delete account</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Permanently deleting your user will remove access to your
+                workspaces, notes, uploads, and account data.
+              </p>
+              <p className="mt-3 text-sm text-muted-foreground">
+                Signed in as {formatUserEmail(user?.email)}
+              </p>
+              <Button
+                variant="outline"
+                className="mt-4 border-destructive/40 text-destructive hover:bg-destructive/10"
+                disabled
+              >
+                Delete your account
+              </Button>
+            </div>
+          </section>
+        </div>
+
+        {isPhotoEditorOpen && selectedPhotoUrl ? (
+          <div
+            data-avatar-photo-editor
+            className="fixed inset-0 z-[900002] flex items-center justify-center bg-background/30 px-4 backdrop-blur-sm"
+          >
+            <div className="w-full max-w-[550px] overflow-hidden app-radius-lg border border-border bg-card text-card-foreground shadow-2xl">
+              <div className="flex items-center justify-between border-b border-border px-2 py-2">
+                <div className="flex items-center gap-3">
+                  <Button
+                    variant="ghost"
+                    onClick={closePhotoEditor}
+                    aria-label="Back to account settings"
+                    className=" h-8 flex justify-center items-center gap-2"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                    <h3 className="text-sm font-semibold">Profile photo</h3>
+                  </Button>
+                </div>
+                <Button
+                  variant="ghost"
+                  className="flex h-8 w-8 items-center justify-center rounded-full"
+                  onClick={closePhotoEditor}
+                  size="icon"
+                  aria-label="Close photo editor"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="space-y-6 px-2.5 pt-5 pb-2.5">
+                <div
+                  ref={photoPreviewRef}
+                  className="relative mx-auto aspect-square w-full max-w-[385px] overflow-hidden bg-muted"
+                  onPointerMove={handleCropPointerMove}
+                  onPointerUp={endCropInteraction}
+                  onPointerCancel={endCropInteraction}
+                >
+                  <div
+                    role="img"
+                    aria-label="Selected profile photo preview"
+                    className="absolute bg-contain bg-center bg-no-repeat"
+                    style={{
+                      backgroundImage: `url(${selectedPhotoUrl})`,
+                      left: displayedPhotoRect?.left ?? 0,
+                      top: displayedPhotoRect?.top ?? 0,
+                      width: displayedPhotoRect?.width ?? "100%",
+                      height: displayedPhotoRect?.height ?? "100%",
+                    }}
+                  />
+
+                  {cropStyle ? (
+                    <>
+                      <div
+                        className="absolute bg-background/55"
+                        style={{
+                          left: displayedPhotoRect?.left ?? 0,
+                          top: displayedPhotoRect?.top ?? 0,
+                          width: displayedPhotoRect?.width ?? 0,
+                          height:
+                            cropStyle.top - (displayedPhotoRect?.top ?? 0),
+                        }}
+                      />
+                      <div
+                        className="absolute bg-background/55"
+                        style={{
+                          left: displayedPhotoRect?.left ?? 0,
+                          top: cropStyle.top + cropStyle.height,
+                          width: displayedPhotoRect?.width ?? 0,
+                          height:
+                            (displayedPhotoRect?.top ?? 0) +
+                            (displayedPhotoRect?.height ?? 0) -
+                            (cropStyle.top + cropStyle.height),
+                        }}
+                      />
+                      <div
+                        className="absolute bg-background/55"
+                        style={{
+                          left: displayedPhotoRect?.left ?? 0,
+                          top: cropStyle.top,
+                          width:
+                            cropStyle.left - (displayedPhotoRect?.left ?? 0),
+                          height: cropStyle.height,
+                        }}
+                      />
+                      <div
+                        className="absolute bg-background/55"
+                        style={{
+                          left: cropStyle.left + cropStyle.width,
+                          top: cropStyle.top,
+                          width:
+                            (displayedPhotoRect?.left ?? 0) +
+                            (displayedPhotoRect?.width ?? 0) -
+                            (cropStyle.left + cropStyle.width),
+                          height: cropStyle.height,
+                        }}
+                      />
+
+                      <div
+                        className="absolute cursor-move touch-none border border-dashed border-foreground/80"
+                        style={cropStyle}
+                        onPointerDown={(event) =>
+                          startCropInteraction(event, "move")
+                        }
+                      >
+                        {[
+                          {
+                            corner: "nw" as const,
+                            position: "left-[-5px] top-[-5px]",
+                          },
+                          {
+                            corner: "ne" as const,
+                            position: "right-[-5px] top-[-5px]",
+                          },
+                          {
+                            corner: "sw" as const,
+                            position: "bottom-[-5px] left-[-5px]",
+                          },
+                          {
+                            corner: "se" as const,
+                            position: "bottom-[-5px] right-[-5px]",
+                          },
+                        ].map(({ corner, position }) => (
+                          <button
+                            key={corner}
+                            type="button"
+                            className={`absolute h-3 w-3 touch-none border border-foreground bg-card ${position}`}
+                            aria-label="Resize crop area"
+                            onPointerDown={(event) =>
+                              startCropInteraction(event, "resize", corner)
+                            }
+                          />
+                        ))}
+                      </div>
+                    </>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="h-8"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      Change photo
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className=" h-8 !rounded-none"
+                      onClick={() => {
+                        closePhotoEditor();
+                        if (hasAvatarImage) void handleDeleteAvatar();
+                      }}
+                    >
+                      Delete photo
+                    </Button>
+                  </div>
+                  <Button
+                    type="button"
+                    onClick={() => void handleConfirmPhotoEdit()}
+                    disabled={isUploadingAvatar}
+                    className=" !rounded-none h-8"
+                  >
+                    {isUploadingAvatar ? "Uploading..." : "Confirm"}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -73,6 +73,7 @@ import React from "react";
 import { ThemeToggle } from "../ThemeToggle";
 import { UserIcon } from "lucide-react";
 import Feedback from "./Feedback";
+import AccountSettingsDialog from "./AccountSettingsDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import { usePaginatedQuery } from "@/cache/usePaginatedQuery";
@@ -1237,9 +1238,15 @@ const UserAccountSection = memo(function UserAccountSection({
 }: UserAccountSectionProps) {
   const settingsHref = "/home/settings/profile";
   const isSettingsActive = pathname === settingsHref;
+  const [isAccountSettingsOpen, setIsAccountSettingsOpen] = useState(false);
 
   return (
     <SidebarFooter className=" z-50 text-foreground">
+      <AccountSettingsDialog
+        open={isAccountSettingsOpen}
+        onOpenChange={setIsAccountSettingsOpen}
+        user={User}
+      />
       <SidebarMenu>
         <SidebarMenuItem>
           <DropdownMenu>
@@ -1291,8 +1298,10 @@ const UserAccountSection = memo(function UserAccountSection({
               className="app-radius-lg m-2 p-1.5 bg-background backdrop-blur w-[--radix-popper-anchor-width] z-[90000]"
             >
               <DropdownMenuItem
-                className=" cursor-default hover:bg-transparent"
-                onClick={(e) => e.preventDefault()}
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setIsAccountSettingsOpen(true);
+                }}
               >
                 <Avatar className="h-8 w-8">
                   <AvatarImage

--- a/components/home-components/GlobalFolderDropUpload.tsx
+++ b/components/home-components/GlobalFolderDropUpload.tsx
@@ -296,7 +296,12 @@ export default function GlobalFolderDropUpload() {
     const hasFiles = (event: DragEvent) =>
       Array.from(event.dataTransfer?.types ?? []).includes("Files");
 
+    const isAvatarPhotoEditorEvent = (event: DragEvent) =>
+      event.target instanceof Element &&
+      Boolean(event.target.closest("[data-avatar-photo-editor]"));
+
     const handleDragEnter = (event: DragEvent) => {
+      if (isAvatarPhotoEditorEvent(event)) return;
       if (!hasFiles(event)) return;
       event.preventDefault();
       dragDepthRef.current += 1;
@@ -304,6 +309,7 @@ export default function GlobalFolderDropUpload() {
     };
 
     const handleDragOver = (event: DragEvent) => {
+      if (isAvatarPhotoEditorEvent(event)) return;
       if (!hasFiles(event)) return;
       event.preventDefault();
       if (event.dataTransfer) {
@@ -313,6 +319,7 @@ export default function GlobalFolderDropUpload() {
     };
 
     const handleDragLeave = (event: DragEvent) => {
+      if (isAvatarPhotoEditorEvent(event)) return;
       if (!hasFiles(event)) return;
       event.preventDefault();
       dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
@@ -322,6 +329,7 @@ export default function GlobalFolderDropUpload() {
     };
 
     const handleDrop = async (event: DragEvent) => {
+      if (isAvatarPhotoEditorEvent(event)) return;
       if (!hasFiles(event)) return;
       event.preventDefault();
       dragDepthRef.current = 0;

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -86,7 +86,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           backgroundSize: "128px 128px",
           opacity: isDark ? 0.03 : 0.02,
           mixBlendMode: "multiply",
-          zIndex: 90000,
+          zIndex: 900002,
         }}
       />
       <main

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -39,7 +39,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      "flex h-full w-full items-center justify-center rounded-lg bg-muted",
+      "flex h-full w-full items-center justify-center app-radius-lg bg-muted",
       className,
     )}
     {...props}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -18,7 +18,7 @@ const Separator = React.forwardRef<
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-primary/20 text-primary/20 self-center",
+        "shrink-0 bg-border text-border self-center",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-5 mx-1 w-[1px]",
         className,
       )}

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,8 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
-import { query } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+
 export const viewer = query({
   args: {},
   handler: async (ctx) => {
@@ -15,6 +17,70 @@ export const viewer = query({
     return user;
   },
 });
+
+export const generateAvatarUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
+      throw new Error("Not signed in");
+    }
+
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+export const updateProfile = mutation({
+  args: {
+    name: v.optional(v.string()),
+    avatarStorageId: v.optional(v.id("_storage")),
+    clearAvatar: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
+      throw new Error("Not signed in");
+    }
+
+    const user = await ctx.db.get(userId);
+    if (user === null) {
+      throw new Error("User was deleted");
+    }
+
+    const patch: {
+      name?: string;
+      image?: string | undefined;
+    } = {};
+
+    if (args.name !== undefined) {
+      const name = args.name.trim();
+      if (name.length < 1 || name.length > 80) {
+        throw new Error("Name must be between 1 and 80 characters");
+      }
+      patch.name = name;
+    }
+
+    if (args.avatarStorageId !== undefined) {
+      const imageUrl = await ctx.storage.getUrl(args.avatarStorageId);
+      if (!imageUrl) {
+        throw new Error("Avatar upload was not found");
+      }
+      patch.image = imageUrl;
+    }
+
+    if (args.clearAvatar) {
+      patch.image = undefined;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return user;
+    }
+
+    await ctx.db.patch(userId, patch);
+    return await ctx.db.get(userId);
+  },
+});
+
 export const users = query({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, { paginationOpts }) => {


### PR DESCRIPTION
## what changed
<img width="892" height="758" alt="image" src="https://github.com/user-attachments/assets/4e2c72a5-5ffd-40ce-86af-09b1f293a9b0" />

 account settings flow that allows users to manage their profile .

### account settings integration

* Added the `AccountSettingsDialog` to the sidebar user account section
* Replaced the non-interactive account menu item with an action that opens the settings dialog
* Added local state management to control the dialog's open and close behavior

### profile update backend support

Added new Convex mutations to support profile management:

* `generateAvatarUploadUrl` for securely uploading avatar images to storage
* `updateProfile` for updating a user's display name and profile photo
* Added validation for profile names to ensure they remain within acceptable limits
* Added support for replacing or removing existing profile photos
* Added storage URL resolution so uploaded avatar files can be saved as user profile images

### upload handling improvements

* Updated the global drag-and-drop upload system to detect avatar editor interactions
* Prevented global upload handlers from triggering when users drag files into the avatar photo editor
* Added checks across drag enter, drag over, drag leave, and drop events to avoid upload conflicts

### ui consistency updates

* Updated avatar fallback styling to use the shared application radius system
* Updated separators to use border colors instead of primary colors for a more neutral appearance
* Increased overlay z-index values to ensure dialogs and account settings UI appear above background effects

Adding profile editing required both frontend and backend support. The account settings dialog provides an accessible entry point from the sidebar, while the new Convex mutations handle profile updates and avatar uploads securely.

The drag-and-drop changes were necessary because the existing global upload system could interfere with avatar uploads, creating a poor user experience when editing profile photos.

Several styling updates were included to keep the new settings experience visually consistent with the rest of the application.


* Users can update their profile information without leaving the workspace
* Avatar uploads are fully supported through dedicated backend mutations
* Profile photos can be uploaded, replaced, or removed
* Avatar editing no longer conflicts with global drag-and-drop uploads
* Account settings are easier to discover through the sidebar menu
* More consistent UI styling across avatars, separators, and overlays
* Stronger foundation for future account management features
