### PR TITLE
improve sidebar action buttons

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -16,6 +16,8 @@ import {
   Pickaxe,
   Scale,
   Gavel,
+  FolderPlus,
+  SquarePen,
 } from "lucide-react";
 import { TbSelector } from "react-icons/tb";
 import {
@@ -248,10 +250,10 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
       {getWorkingSpaces?.length === 0 && (
         <Button
           variant="outline"
-          className="font-medium w-full h-9 flex justify-start items-center gap-2 bg-primary text-primary-foreground hover:bg-primary/80"
+          className="font-medium w-full h-9 flex justify-start items-center gap-1.5 bg-primary text-primary-foreground hover:bg-primary/80"
           onClick={handleCreateWorkingSpace}
         >
-          <Plus size={16} /> Create Workspace
+          <FolderPlus size={16} /> Create Workspace
         </Button>
       )}
       {getWorkingSpaces?.length === 1 || getWorkingSpaces?.length === 0
@@ -259,22 +261,34 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
             <Button
               key={workingSpace._id}
               variant="outline"
-              className="font-medium w-full h-9 flex justify-start items-center gap-2 bg-primary text-primary-foreground hover:bg-primary/80"
+              className="font-medium w-full h-9 flex justify-start items-center gap-1.5 bg-primary text-primary-foreground hover:bg-primary/80"
               disabled={loading}
               onMouseDown={() => void createNoteInWorkspace(workingSpace)}
             >
-              {loading ? <>redirecting...</> : <> Create Note</>}
+              {loading ? (
+                <>redirecting...</>
+              ) : (
+                <>
+                  <SquarePen size={16} /> Create Note
+                </>
+              )}
             </Button>
           ))
         : createNoteWorkspace && (
             <div className="flex h-9 w-full items-center overflow-hidden app-radius-lg">
               <Button
                 variant="outline"
-                className="font-medium h-9 flex-1 justify-start gap-2 !rounded-r-none bg-primary text-primary-foreground hover:bg-primary/90"
+                className="font-medium h-9 flex-1 justify-start gap-1.5 !rounded-r-none bg-primary text-primary-foreground hover:bg-primary/90"
                 disabled={loading}
                 onClick={() => void createNoteInWorkspace(createNoteWorkspace)}
               >
-                {loading ? <>redirecting...</> : <>Create Note</>}
+                {loading ? (
+                  <>redirecting...</>
+                ) : (
+                  <>
+                    <SquarePen size={16} /> Create Note
+                  </>
+                )}
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>


### PR DESCRIPTION
 the primary action buttons in the sidebar to improve clarity and make them easier to scan.
<img width="297" height="194" alt="image" src="https://github.com/user-attachments/assets/9ee9ef5b-f51c-4e83-ab25-66f881b93b61" />
<img width="300" height="235" alt="image" src="https://github.com/user-attachments/assets/f9f3eafa-68ec-46ed-b917-167e8db279fa" />


### What changed

* Replaced the generic **Plus** icon with a **FolderPlus** icon for the **Create Workspace** button.
* Added a **SquarePen** icon to the **Create Note** button across both the single-workspace and multi-workspace flows.
* Adjusted the button spacing (`gap`) to better align the new icons with their labels.
* Kept the existing loading behavior while preserving the updated button layout.

The previous buttons relied on generic or missing icons, making the primary actions less distinguishable at a glance. Using action-specific icons gives each button a clearer purpose and creates a more consistent experience throughout the sidebar.


* Primary actions are easier to identify visually.
* Icons better communicate the action being performed (creating a workspace vs. creating a note).
