### PR TITLE
improve landing page spacing and faq readability

### DIFF
--- a/components/landingPage-components/MoreAboutMe.tsx
+++ b/components/landingPage-components/MoreAboutMe.tsx
@@ -3,13 +3,7 @@ import { NOISE_PNG } from "@/lib/data";
 import { cn } from "@/lib/utils";
 export default function MoreAboutMe() {
   return (
-    <section
-      id="about"
-      className={cn(
-        "px-4 sm:px-6 md:px-8",
-        "py-12 sm:py-16 md:py-20 Desktop:py-24",
-      )}
-    >
+    <section id="about" className="py-12 sm:py-16 md:py-20 Desktop:py-24">
       <MaxWContainer>
         <div className="relative pt-10">
           <div className="absolute inset-x-0 bottom-0 top-4 rounded-sm bg-primary" />
@@ -40,13 +34,13 @@ export default function MoreAboutMe() {
                 zIndex: 5,
               }}
             />
-            <div className="absolute top-0 bottom-0 left-16 w-px bg-[#f5a0a07d]" />
+            <div className="absolute top-0 bottom-0 left-10 md:left-16 w-px bg-[#f5a0a07d]" />
 
             <div
               className="w-full border border-border flex flex-col sm:flex-row items-center gap-6 sm:gap-10 px-6 sm:px-10"
               style={{ paddingTop: "9px", paddingBottom: "9px" }}
             >
-              <div className="flex flex-col justify-between py-6 pl-12 gap-3 w-full sm:w-2/3">
+              <div className="flex flex-col justify-between py-6 pl-6 md:pl-12 gap-3 w-full sm:w-2/3">
                 <div className="space-y-0">
                   <p
                     className="text-lg sm:text-xl leading-relaxed text-foreground"

--- a/components/landingPage-components/faq.tsx
+++ b/components/landingPage-components/faq.tsx
@@ -11,7 +11,7 @@ export default function FAQ() {
   return (
     <section
       id="faq"
-      className="relative px-4 sm:px-6 md:px-8 pt-12 sm:pt-16 md:pt-20 Desktop:pt-24 "
+      className="relative pt-12 sm:pt-16 md:pt-20 Desktop:pt-24 "
     >
       <MaxWContainer>
         <SectionHeading
@@ -23,15 +23,17 @@ export default function FAQ() {
           type="single"
           collapsible
           defaultValue="shipping"
-          className="max-w-lg mx-auto min-h-[300px]"
+          className="max-w-2xl mx-auto min-h-[400px]"
         >
           {AccordionData.map((item, index) => (
             <AccordionItem key={index} value={item.itmevalue}>
-              <AccordionTrigger className="animated-highlight-container">
+              <AccordionTrigger className="animated-highlight-container text-2xl font-medium">
                 {" "}
                 <span className="animated-highlight">{item.trigger}</span>{" "}
               </AccordionTrigger>
-              <AccordionContent>{item.content}</AccordionContent>
+              <AccordionContent className=" px-2 text-lg">
+                {item.content}
+              </AccordionContent>
             </AccordionItem>
           ))}
         </Accordion>

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -37,7 +37,7 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      <ChevronDown className="h-5 w-5 shrink-0 text-primary bg-secondary rounded-md p-0.5 transition-transform duration-200" />
+      <ChevronDown className="h-8 w-8 shrink-0 text-primary bg-secondary rounded-md p-0.5 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));


### PR DESCRIPTION
## what changed
before : 
<img width="852" height="483" alt="image" src="https://github.com/user-attachments/assets/a6f2d1af-48fd-4e3f-b555-6507eeae9331" />
<img width="445" height="604" alt="image" src="https://github.com/user-attachments/assets/18a19c4d-0dd7-48ba-82e7-4787b0715265" />

after the changes : 
<img width="1012" height="593" alt="image" src="https://github.com/user-attachments/assets/ef32d980-bc50-49a0-a707-0dfde1bbd854" />
<img width="447" height="494" alt="image" src="https://github.com/user-attachments/assets/00bca5fe-4740-4a3e-84f4-7b89a41d476c" />


* Removed extra horizontal padding from the About Me and FAQ sections.
* Adjusted the timeline line and content padding in the About Me section to improve alignment on smaller screens.
* Increased the FAQ accordion width and minimum height.
* Increased the FAQ question, answer, and chevron icon sizes for better readability.

These updates improve the layout consistency across the landing page and make the FAQ section easier to read and interact with, especially on different screen sizes.

