### PR TITLE
improve editor responsiveness on smaller screens

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -72,7 +72,7 @@ const TailwindAdvancedEditor = ({
   const [plusSearchQuery, setPlusSearchQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { resolvedTheme } = useTheme();
-  const isMobile = useMediaQuery({ maxWidth: 640 });
+  const isMobile = useMediaQuery({ maxWidth: 1040 });
 
   useEffect(() => {
     if (resolvedTheme !== "dark") {
@@ -204,7 +204,7 @@ const TailwindAdvancedEditor = ({
               <LinkHoverCard editor={editorInstance} disabled={openLink} />
               <TableControls editor={editorInstance} />
               <DragHandle editor={editorInstance}>
-                <div className="flex items-center justify-center ">
+                <div className="lg:flex items-center justify-center hidden ">
                   <Tooltip delayDuration={150} disableHoverableContent>
                     <TooltipTrigger asChild>
                       <button


### PR DESCRIPTION
before : 
<img width="664" height="481" alt="image" src="https://github.com/user-attachments/assets/b3fcfb29-6b12-4c27-897a-0b1c189d52f5" />

now : 
<img width="732" height="489" alt="image" src="https://github.com/user-attachments/assets/bf2ae9d8-4fa9-4588-a7a6-5da6bc463e53" />


* Updated the mobile breakpoint from `640px` to `1040px`.
* Hid the editor drag handle on screens smaller than the `lg` breakpoint.

The editor layout becomes more constrained on tablet-sized and smaller screens. Treating these viewports as mobile and hiding the drag handle reduces visual clutter and prevents unnecessary controls from taking up space.

* Better editor experience across tablets and smaller laptops.
* More room for the editing area without affecting the desktop experience.
