### PR TITLE
improve search dialog responsiveness

### DIFF
--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -545,7 +545,7 @@ export default function SearchDialog({
         </DialogTrigger>
       )}
 
-      <DialogContent className="p-0 overflow-hidden bg-card border-border md:min-w-[850px] gap-0 shadow-2xl">
+      <DialogContent className="p-0 overflow-hidden bg-card border-border sm:h-fit h-dvh w-full max-w-full sm:w-[90vw] sm:max-w-3xl md:max-w-4xl gap-0 shadow-2xl z-[900001]">
         <DialogTitle className="sr-only">Search Notes</DialogTitle>
         <DialogDescription className="sr-only">
           Search across workspaces, tables, and notes, then open the selected
@@ -571,7 +571,7 @@ export default function SearchDialog({
         <div
           ref={resultsScrollRef}
           onScroll={handleResultsScroll}
-          className="min-h-[40vh] max-h-[40vh] overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
+          className=" md:min-h-[50vh] min-h-[85dvh]  overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
         >
           {canScroll && scrollTop > 8 && (
             <div


### PR DESCRIPTION
## what changed

* Updated the search dialog to use a responsive layout across different screen sizes.
* Made the dialog full-screen on mobile while keeping a constrained width on larger screens.
* Increased the results area height on mobile and adjusted it for desktop.
* Added a higher z-index to ensure the dialog stays above other UI elements.

The previous dialog layout wasn't optimized for smaller screens, making it harder to use. These changes improve the search experience by giving the dialog more space and ensuring it displays correctly across devices.

so now : 

* Better mobile experience with a full-screen search dialog.
* More room to browse search results without excessive scrolling.

