### PR TITLE
refine search dialog responsive sizing

### DIFF
--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -545,7 +545,7 @@ export default function SearchDialog({
         </DialogTrigger>
       )}
 
-      <DialogContent className="p-0 overflow-hidden bg-card border-border sm:h-fit h-dvh w-full max-w-full sm:w-[90vw] sm:max-w-3xl md:max-w-4xl gap-0 shadow-2xl z-[900001]">
+      <DialogContent className="p-0 overflow-hidden bg-card border-border md:h-fit h-dvh w-full max-w-full sm:w-[90vw] sm:max-w-3xl md:max-w-4xl gap-0 shadow-2xl z-[900001]">
         <DialogTitle className="sr-only">Search Notes</DialogTitle>
         <DialogDescription className="sr-only">
           Search across workspaces, tables, and notes, then open the selected
@@ -571,7 +571,7 @@ export default function SearchDialog({
         <div
           ref={resultsScrollRef}
           onScroll={handleResultsScroll}
-          className=" md:min-h-[50vh] min-h-[85dvh]  overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
+          className=" md:min-h-[50vh] md:max-h-[50vh] min-h-[85dvh]  overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
         >
           {canScroll && scrollTop > 8 && (
             <div


### PR DESCRIPTION
## what changed
sorry mb that was stupid lol 

before :
<img width="960" height="1015" alt="image" src="https://github.com/user-attachments/assets/a8fc4ce9-630f-4f30-8602-bdda27072584" />

after fixing my stupid mistake lol :  
<img width="953" height="645" alt="image" src="https://github.com/user-attachments/assets/381d1d52-6a4d-4684-95f1-b8cf1c3acf7d" />

* Updated the search dialog to switch back to its fit-content height starting at the `md` breakpoint instead of `sm`.
* Added a maximum height to the search results container on desktop while keeping the full-height layout on mobile.

These adjustments improve the dialog layout across tablet and desktop screens while maintaining the full-screen experience on mobile. Adding a max height also keeps the results area contained and scrollable.

