### PR TITLE
improve delete workflow and shortcuts

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -361,9 +361,12 @@ function TableTab({ table }: { table: any }) {
                     type="button"
                     variant="ghost"
                     onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setIsDeleteAlertOpen(true);
+                      if (e.button === 0 && e.shiftKey) {
+                        e.preventDefault();
+                        handleDelete();
+                      } else {
+                        setIsDeleteAlertOpen(true);
+                      }
                     }}
                     className=" px-1.5 h-7 text-foreground hover:text-destructive"
                     aria-label="delete-table"
@@ -421,6 +424,13 @@ function TableTab({ table }: { table: any }) {
               undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -178,9 +178,14 @@ export default function NoteSettings({
     setInputValue(trimmedValue);
   };
 
-  const initiateDelete = () => {
-    setOpen(false);
-    setIsAlertOpen(true);
+  const initiateDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (e.button === 0 && e.shiftKey) {
+      e.preventDefault();
+      handleDelete(e as React.MouseEvent<HTMLButtonElement>);
+    } else {
+      setOpen(false);
+      setIsAlertOpen(true);
+    }
   };
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -213,7 +218,6 @@ export default function NoteSettings({
     setOpen(false);
     setIsMoveDialogOpen(true);
   };
-
   return (
     <>
       <DropdownMenu
@@ -388,6 +392,14 @@ export default function NoteSettings({
               undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
+
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -81,8 +81,13 @@ export default function NoteSettingsSidbar({
   );
   const getNote = useQuery(api.notes.getNoteById, { _id: noteId });
 
-  const initiateDelete = () => {
-    setIsAlertOpen(true);
+  const initiateDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.button === 0 && event.shiftKey) {
+      event.preventDefault();
+      void handleDelete(event);
+    } else {
+      setIsAlertOpen(true);
+    }
   };
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -144,11 +149,11 @@ export default function NoteSettingsSidbar({
         <Tooltip open={deleteTooltip.open}>
           <TooltipTrigger asChild>
             <Button
-              onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
               className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="delete-note"
               {...deleteTooltip.triggerProps}
+              onMouseDown={initiateDelete}
             >
               <X size={16} />
             </Button>
@@ -172,6 +177,13 @@ export default function NoteSettingsSidbar({
               undone.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -141,6 +141,19 @@ export default function PdfSettings({
     }
   }, [deletePdf, onDelete, pdfId]);
 
+  const initiateDelete = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (event.button === 0 && event.shiftKey) {
+        event.preventDefault();
+        void handleDelete();
+      } else {
+        setOpen(false);
+        setIsAlertOpen(true);
+      }
+    },
+    [handleDelete],
+  );
+
   const handleFavoritePin = useCallback(async () => {
     if (!pdf) return;
     await updatePdf({
@@ -293,10 +306,7 @@ export default function PdfSettings({
             <Button
               variant="SidebarMenuButton_destructive"
               className="w-full h-8 px-2 text-sm"
-              onClick={() => {
-                setOpen(false);
-                setIsAlertOpen(true);
-              }}
+              onClick={initiateDelete}
               aria-label="delete-upload"
             >
               <FaRegTrashCan size={14} className="text-muted-foreground" />
@@ -321,6 +331,13 @@ export default function PdfSettings({
               undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -61,6 +61,15 @@ export default function PdfSettingsSidebar({
     }
   };
 
+  const initiateDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.button === 0 && event.shiftKey) {
+      event.preventDefault();
+      void handleDelete(event);
+    } else {
+      setIsAlertOpen(true);
+    }
+  };
+
   return (
     <>
       <div
@@ -97,11 +106,11 @@ export default function PdfSettingsSidebar({
         <Tooltip open={deleteTooltip.open}>
           <TooltipTrigger asChild>
             <Button
-              onMouseDown={() => setIsAlertOpen(true)}
               variant="SidebarMenuButton_destructive"
               className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="delete-upload"
               {...deleteTooltip.triggerProps}
+              onMouseDown={initiateDelete}
             >
               <X size={16} />
             </Button>
@@ -121,6 +130,13 @@ export default function PdfSettingsSidebar({
               undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -167,9 +167,14 @@ export default function TableSettings({
     setOpen(false);
   };
 
-  const initiateDelete = () => {
-    setOpen(false); // Close the dropdown
-    setIsAlertOpen(true); // Open the alert dialog
+  const initiateDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.button === 0 && event.shiftKey) {
+      event.preventDefault();
+      void handleDelete(event);
+    } else {
+      setOpen(false);
+      setIsAlertOpen(true);
+    }
   };
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -254,6 +259,13 @@ export default function TableSettings({
               undone."
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -186,9 +186,14 @@ export default function WorkingSpaceSettings({
     setOpen(false);
   };
 
-  const initiateDelete = () => {
-    setOpen(false);
-    setIsAlertOpen(true);
+  const initiateDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.button === 0 && event.shiftKey) {
+      event.preventDefault();
+      void handleDelete(event);
+    } else {
+      setOpen(false);
+      setIsAlertOpen(true);
+    }
   };
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -308,6 +313,13 @@ export default function WorkingSpaceSettings({
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -71,8 +71,13 @@ export default function WorkingSpaceSettingsSidbar({
     if (workspace) return;
   });
 
-  const initiateDelete = () => {
-    setIsAlertOpen(true);
+  const initiateDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (event.button === 0 && event.shiftKey) {
+      event.preventDefault();
+      void handleDelete(event);
+    } else {
+      setIsAlertOpen(true);
+    }
   };
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -109,11 +114,11 @@ export default function WorkingSpaceSettingsSidbar({
         <Tooltip open={deleteTooltip.open}>
           <TooltipTrigger asChild>
             <Button
-              onMouseDown={initiateDelete}
               variant="SidebarMenuButton_destructive"
               className="px-1.5 h-7 hover:bg-card"
               aria-label="delete-workspace"
               {...deleteTooltip.triggerProps}
+              onMouseDown={initiateDelete}
             >
               <X size={16} />
             </Button>
@@ -152,6 +157,13 @@ export default function WorkingSpaceSettingsSidbar({
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <p>
+            if you don't wanna see again hold
+            <span className=" mx-1 text-xs pointer-events-none border border-border inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              Shift
+            </span>
+            when you delete and it will be deleted without confirmation.
+          </p>
           <AlertDialogFooter>
             <AlertDialogCancel className="bg-transparent border border-border hover:bg-accent">
               Cancel

--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -204,6 +204,23 @@ export default function WorkingspaceNewDropdownBtn({
     fileInputRef.current?.click();
   }, [persistPreferredAction]);
 
+  useEffect(() => {
+    const handlerCreateNoteShortcut = (e: KeyboardEvent) => {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        (e.metaKey || e.shiftKey) &&
+        e.key.toLowerCase() === "o"
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleCreateNote();
+      }
+    };
+    window.addEventListener("keydown", handlerCreateNoteShortcut);
+    return () =>
+      window.removeEventListener("keydown", handlerCreateNoteShortcut);
+  }, []);
+
   return (
     <>
       <input
@@ -242,10 +259,18 @@ export default function WorkingspaceNewDropdownBtn({
               <ChevronDown className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuContent align="end" className="w-fit">
             <DropdownMenuItem onClick={() => void handleSelectNote()}>
               <FileText className="h-4 w-4 text-muted-foreground" />
               New note
+              <span className="inline-flex gap-0.5">
+                <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                  <span className="text-xs">Ctrl + Shift</span>
+                </kbd>
+                <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                  <span className="text-xs">O</span>
+                </kbd>
+              </span>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleSelectUpload}>
               <FileUp className="h-4 w-4 text-muted-foreground" />

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-      "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-none sm:rounded-tl-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] text-foreground gap-4 border bg-background px-4 pt-4 pb-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-none sm:rounded-tl-lg",
         className,
       )}
       {...props}
@@ -51,7 +51,7 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      "flex flex-col space-y-0.5 text-center sm:text-left",
       className,
     )}
     {...props}
@@ -104,7 +104,7 @@ const AlertDialogAction = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={cn(buttonVariants(), className)}
+    className={cn(buttonVariants(), `h-8   !rounded-none`, className)}
     {...props}
   />
 ));
@@ -118,7 +118,7 @@ const AlertDialogCancel = React.forwardRef<
     ref={ref}
     className={cn(
       buttonVariants({ variant: "outline" }),
-      "mt-2 sm:mt-0",
+      "mt-2 sm:mt-0 h-8",
       className,
     )}
     {...props}


### PR DESCRIPTION
## what changed
before : 
<img width="226" height="148" alt="image" src="https://github.com/user-attachments/assets/9c34e0a9-8742-4bf5-b82f-f0aabc41b12e" />
<img width="539" height="198" alt="image" src="https://github.com/user-attachments/assets/54367630-5537-4dee-a338-e52862d80b4b" />
but now :
<img width="323" height="152" alt="image" src="https://github.com/user-attachments/assets/62d54c31-9ff3-40c5-a835-505ceda1dc9b" />
<img width="563" height="239" alt="image" src="https://github.com/user-attachments/assets/574e011e-a712-4245-84f8-a0ce0e6e0b86" />


* Added a `Shift + Click` shortcut to bypass the delete confirmation dialog for notes, tables, PDFs, and workspaces.
* Added a hint in all delete confirmation dialogs explaining the shortcut.
* Added a `Ctrl + Shift + O` shortcut for creating a new note and displayed it in the workspace dropdown.
* Updated the alert dialog styling with improved spacing, button sizing, and text colors.

These changes make common actions faster for power users while keeping the confirmation dialog available by default. The new shortcut hints also make the behavior easier to discover.

* Faster deletion when confirmation isn't needed.
* Keyboard shortcut for quickly creating new notes.
* More consistent and polished alert dialog UI.
* Better overall workflow without changing the default experience for most users.
