### PR TITLE
polish new note actions and search dialog responsiveness

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -269,7 +269,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
                 <>redirecting...</>
               ) : (
                 <>
-                  <SquarePen size={16} /> Create Note
+                  <SquarePen size={16} className=" mt-px" /> New Note
                 </>
               )}
             </Button>
@@ -286,7 +286,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
                   <>redirecting...</>
                 ) : (
                   <>
-                    <SquarePen size={16} /> Create Note
+                    <SquarePen size={16} className=" mt-px" /> New Note
                   </>
                 )}
               </Button>

--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -545,7 +545,7 @@ export default function SearchDialog({
         </DialogTrigger>
       )}
 
-      <DialogContent className="p-0 overflow-hidden bg-card border-border md:h-fit h-dvh w-full max-w-full sm:w-[90vw] sm:max-w-3xl md:max-w-4xl gap-0 shadow-2xl z-[900001]">
+      <DialogContent className="p-0 overflow-hidden bg-card border-border sm:h-fit h-dvh w-full max-w-full sm:w-[90vw] sm:max-w-3xl md:max-w-4xl gap-0 shadow-2xl z-[900001]">
         <DialogTitle className="sr-only">Search Notes</DialogTitle>
         <DialogDescription className="sr-only">
           Search across workspaces, tables, and notes, then open the selected
@@ -571,7 +571,7 @@ export default function SearchDialog({
         <div
           ref={resultsScrollRef}
           onScroll={handleResultsScroll}
-          className=" md:min-h-[50vh] md:max-h-[50vh] min-h-[85dvh]  overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
+          className=" sm:min-h-[50vh] sm:max-h-[50vh] min-h-[85dvh]  overflow-y-auto scrollbar-gutter-stable [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3"
         >
           {canScroll && scrollTop > 8 && (
             <div


### PR DESCRIPTION
## what changed

* Renamed the "Create Note" action to "New Note" in the sidebar.
* Added a small alignment adjustment to the new note icon.
* Updated the search dialog to switch to its desktop layout at the `sm` breakpoint instead of `md`.
* Applied the same breakpoint change to the search results container height.

These changes improve UI consistency and make the search dialog better utilize available space on smaller screens while keeping the new note action aligned with the rest of the interface.