### PR TITLE
improve pdf viewer toolbar layout

### DIFF
--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import PdfSettings from "@/components/home-components/PdfSettings";
-import { useSidebar } from "@/components/ui/sidebar";
+import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
 import { useDebouncedCallback } from "use-debounce";
 import { useToast } from "@/hooks/use-toast";
 import z from "zod";
@@ -555,7 +555,6 @@ function PdfViewerContent({
       }
     }
   }, 300);
-
   return (
     <LectorSearch
       loading={
@@ -569,11 +568,23 @@ function PdfViewerContent({
           <div
             className={`pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-1 app-radius-lg border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl`}
           >
-            <div className="flex-1 px-1.5 py-0 border border-border bg-background hover:border-muted-foreground/50 app-radius-md">
+            {(!open || isMobile) && (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8 border border-border"
+                aria-label="show-search-panel"
+              >
+                <SidebarTrigger />
+              </Button>
+            )}
+            <div
+              className={` px-1.5 h-8 py-0 border border-border bg-background hover:border-muted-foreground/50 ${!open || isMobile ? "!rounded-none" : "app-radius-md"} `}
+            >
               <h1
                 onDoubleClick={handleNameDoubleClick}
                 title="Double-click to rename"
-                className=" md:text-lg h-8 cursor-text leading-12 app-radius-md w-[16rem] overflow-hidden "
+                className=" md:text-lg cursor-text flex justify-start items-center min-w-[16rem] overflow-hidden "
               >
                 {isEditingName ? (
                   <Input
@@ -588,7 +599,7 @@ function PdfViewerContent({
                       setIsEditingName(false);
                     }}
                     placeholder="Untitled PDF"
-                    className=" !w-full placeholder:text-muted-foreground/50 border-transparent bg-transparent px-0 py-0 md:text-lg font-bol h-8 cursor-text leading-12 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
+                    className=" !w-full placeholder:text-muted-foreground/50 border-transparent bg-transparent px-0 py-0 my-0 md:text-lg font-bol h-8 cursor-text leading-12 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
                   />
                 ) : (
                   <span className=" w-full overflow-hidden text-nowrap">


### PR DESCRIPTION
## what changed
<img width="762" height="139" alt="image" src="https://github.com/user-attachments/assets/5172e0ae-9b38-4415-9974-9ed987b31fab" />
<img width="704" height="117" alt="image" src="https://github.com/user-attachments/assets/2eb74dc8-7900-4453-aa27-5f15e5a02afb" />


* Added a sidebar toggle button to the PDF viewer toolbar when the sidebar is hidden or on mobile.
* Updated the PDF title container styling to better adapt to different sidebar states.
* Improved the title layout and input alignment for a cleaner editing experience.
* Made minor styling tweaks to keep the toolbar components visually consistent.

These changes make it easier to access the sidebar when it's hidden and improve the toolbar layout so it works better across different screen sizes and states.

