### PR TITLE
add toggle action slash command

### DIFF
--- a/components/extensions.ts
+++ b/components/extensions.ts
@@ -33,6 +33,7 @@ import Heading from "@tiptap/extension-heading";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { CodeBlockComponent } from "./code-block-component";
 import TextAlign from "@tiptap/extension-text-align";
+import { ToggleAction } from "./toggle-action-node";
 
 const aiHighlight = AIHighlight;
 
@@ -259,4 +260,5 @@ export const defaultExtensions = [
   TipTapExtensionTableCell,
   TipTapExtensionTableHeader,
   textAlign,
+  ToggleAction,
 ];

--- a/components/slash-command.tsx
+++ b/components/slash-command.tsx
@@ -13,6 +13,7 @@ import {
   TextQuote,
   Youtube,
   Table,
+  ToggleLeft,
 } from "lucide-react";
 import { createSuggestionItems } from "novel";
 import { Command, renderItems } from "novel";
@@ -245,6 +246,31 @@ export const suggestionItems = createSuggestionItems([
         }
       };
       input.click();
+    },
+  },
+  {
+    title: "Toggle Action",
+    description: "Create a collapsible action block.",
+    searchTerms: ["toggle", "collapse", "accordion", "action", "atomic"],
+    icon: <ToggleLeft size={18} />,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent({
+          type: "toggleAction",
+          attrs: {
+            title: "toggle action",
+            open: true,
+          },
+          content: [
+            {
+              type: "paragraph",
+            },
+          ],
+        })
+        .run();
     },
   },
   {

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Node, mergeAttributes } from "@tiptap/core";
+import {
+  NodeViewContent,
+  NodeViewProps,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+} from "@tiptap/react";
+import { ChevronDown, ChevronRight, Blocks } from "lucide-react";
+
+const DEFAULT_TOGGLE_TITLE = "toggle action";
+
+function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(
+    node.attrs.title || DEFAULT_TOGGLE_TITLE,
+  );
+  const isOpen = node.attrs.open ?? true;
+  const title = node.attrs.title || DEFAULT_TOGGLE_TITLE;
+
+  useEffect(() => {
+    setDraftTitle(title);
+  }, [title]);
+
+  const saveTitle = () => {
+    const nextTitle = draftTitle.trim() || DEFAULT_TOGGLE_TITLE;
+    updateAttributes({ title: nextTitle });
+    setDraftTitle(nextTitle);
+    setIsEditingTitle(false);
+  };
+
+  return (
+    <NodeViewWrapper
+      data-toggle-action
+      className="my-3 rounded-tl-lg border border-border bg-muted/20 text-foreground transition-colors"
+    >
+      <div
+        contentEditable={false}
+        className="flex min-h-10 items-center gap-2 px-3 py-2"
+      >
+        <button
+          type="button"
+          aria-label={
+            isOpen ? "Collapse toggle action" : "Expand toggle action"
+          }
+          className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+          onClick={() => updateAttributes({ open: !isOpen })}
+        >
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
+        </button>
+        {isEditingTitle ? (
+          <input
+            autoFocus
+            value={draftTitle}
+            onChange={(event) => setDraftTitle(event.target.value)}
+            onBlur={saveTitle}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                saveTitle();
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setDraftTitle(title);
+                setIsEditingTitle(false);
+              }
+            }}
+            className="min-w-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none"
+          />
+        ) : (
+          <button
+            type="button"
+            title="Double click to rename"
+            className="min-w-0 truncate text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            onDoubleClick={() => setIsEditingTitle(true)}
+            onClick={() => updateAttributes({ open: !isOpen })}
+          >
+            {title}
+          </button>
+        )}
+      </div>
+      <NodeViewContent
+        className={`px-5 pb-4 pt-1 ${isOpen ? "block" : "hidden"}`}
+      />
+    </NodeViewWrapper>
+  );
+}
+
+export const ToggleAction = Node.create({
+  name: "toggleAction",
+  group: "block",
+  content: "block+",
+  defining: true,
+  isolating: true,
+
+  addAttributes() {
+    return {
+      open: {
+        default: true,
+        parseHTML: (element) => element.getAttribute("data-open") !== "false",
+        renderHTML: (attributes) => ({
+          "data-open": attributes.open ? "true" : "false",
+        }),
+      },
+      title: {
+        default: DEFAULT_TOGGLE_TITLE,
+        parseHTML: (element) =>
+          element.getAttribute("data-title") || DEFAULT_TOGGLE_TITLE,
+        renderHTML: (attributes) => ({
+          "data-title": attributes.title || DEFAULT_TOGGLE_TITLE,
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-type='toggle-action']" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        "data-type": "toggle-action",
+      }),
+      0,
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ToggleActionComponent);
+  },
+});


### PR DESCRIPTION
## what changed
<img width="864" height="643" alt="image" src="https://github.com/user-attachments/assets/59376074-89ab-4b7a-867b-8a439b18a825" />

* Added the new `ToggleAction` extension to the editor.
* Added a "Toggle Action" option to the slash command menu.
* Configured the slash command to insert a collapsible toggle block with a default title and paragraph.

This makes it easier to create collapsible sections directly from the editor without needing to build them manually.

