### PR TITLE
just calendar view uxui cleanup

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1467,16 +1467,6 @@ function CalendarTimelineView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [zoom, totalWidth]);
 
-  const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
-    if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-      const el = scrollRef.current;
-      if (el) {
-        el.scrollLeft += e.deltaY;
-        e.preventDefault();
-      }
-    }
-  }, []);
-
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
@@ -1780,7 +1770,7 @@ function CalendarGapMarker({
           size="sm"
           onClick={onToggle}
           className={cn(
-            "absolute z-10 min-h-16 w-7 -translate-x-1/2 flex-col gap-1 px-1 py-1 text-[10px] font-semibold shadow-sm !rounded-none",
+            "absolute z-10 min-h-16 w-7 -translate-x-1/2 flex-col gap-1 px-1 py-2 text-[10px] font-semibold shadow-sm !rounded-none",
             gap.expanded ? "top-20" : "top-16",
           )}
           style={{ left: gap.x }}


### PR DESCRIPTION
Removed the custom mouse wheel behavior that converted vertical scrolling into horizontal scrolling on the calendar timeline.
Adjusted the spacing of the calendar gap markers for better visual balance.

The custom scrolling behavior could feel unexpected and interfere with normal page navigation. These updates make the timeline interactions more intuitive while improving the appearance of the gap markers.

