### PR TITLE
add open in pane shortcuts from the sidebar

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1276,8 +1276,6 @@ function CalendarTimelineView({
       ),
     ).sort((a, b) => a - b);
 
-    // Minimum width a collapsed gap segment needs so its marker and the
-    // cards on either side of it never overlap.
     const collapsedGapWidth = Math.max(
       CALENDAR_CARD_WIDTH +
         CALENDAR_CLUSTER_GAP * 2 +
@@ -1290,10 +1288,6 @@ function CalendarTimelineView({
       if (endDay === undefined) return [];
       const emptyDays = endDay - startDay - 1;
       if (emptyDays < CALENDAR_COLLAPSE_EMPTY_DAYS) return [];
-      // Only worth collapsing if it actually saves visible space — at
-      // coarse zoom levels a handful of days may already render smaller
-      // than the collapsed placeholder, so collapsing them would do
-      // nothing (or even grow them) once expanded.
       const naturalWidth = emptyDays * config.pxPerDay;
       if (naturalWidth <= collapsedGapWidth + CALENDAR_GAP_MIN_SAVINGS) {
         return [];

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
   Gavel,
   FolderPlus,
   SquarePen,
+  PanelRightOpen,
 } from "lucide-react";
 import { TbSelector } from "react-icons/tb";
 import {
@@ -85,6 +86,8 @@ import { useQuery } from "@/cache/useQuery";
 import SkeletonSidebar from "../ui/skeleton-sidebar";
 import NoteContextMenu from "./NoteContextMenu";
 import { FaGithub } from "react-icons/fa6";
+import { useHomePane } from "./HomePaneDrawer";
+import { ShortcutBadge } from "../ui/shortcut-badge";
 
 interface SidebarHeaderSectionProps {
   getWorkingSpaces: Doc<"workingSpaces">[] | undefined;
@@ -111,6 +114,46 @@ const PINNED_NOTES_EXPANDED_STORAGE_KEY =
   "notevo_sidebar_pinned_notes_expanded";
 const PINNED_UPLOADS_EXPANDED_STORAGE_KEY =
   "notevo_sidebar_pinned_uploads_expanded";
+
+function OpenInPaneButton({
+  label,
+  onOpen,
+}: {
+  label: string;
+  onOpen: () => void;
+}) {
+  const tooltip = useHoverTooltip(100);
+
+  return (
+    <Tooltip open={tooltip.open}>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="SidebarMenuButton"
+          className="px-1.5 h-7 hover:bg-card text-muted-foreground"
+          aria-label={label}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onOpen();
+            tooltip.hide();
+          }}
+          {...tooltip.triggerProps}
+        >
+          <PanelRightOpen size={16} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="right"
+        sideOffset={5}
+        className="flex justify-center items-center gap-2 !rounded-none"
+      >
+        Open in Pane
+        <ShortcutBadge keys="Alt + Click" />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 function useStoredExpandedState(storageKey: string, defaultValue = true) {
   const [isExpanded, setIsExpanded] = useState(defaultValue);
@@ -389,6 +432,7 @@ interface PinnedNoteItemProps {
 const PinnedNoteItem = memo(
   function PinnedNoteItem({ note, pathname, open }: PinnedNoteItemProps) {
     const titleTooltip = useHoverTooltip(300);
+    const { openPane } = useHomePane();
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editedTitle, setEditedTitle] = useState(note.title || "Untitled");
@@ -488,7 +532,7 @@ const PinnedNoteItem = memo(
     );
 
     const textClassName = isHovered
-      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-40% via-transparent via-60% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
 
     const content = (
@@ -524,6 +568,17 @@ const PinnedNoteItem = memo(
                     <IntentPrefetchLink
                       href={noteHref}
                       className="flex items-center gap-2 flex-grow min-w-0"
+                      onClick={(event) => {
+                        if (event.button === 0 && event.altKey) {
+                          event.preventDefault();
+                          openPane({
+                            type: "note",
+                            id: note._id,
+                            title: note.title || "Untitled",
+                          });
+                          titleTooltip.hide();
+                        }
+                      }}
                     >
                       {isHovered || isActive ? (
                         <ChevronRight
@@ -554,8 +609,19 @@ const PinnedNoteItem = memo(
           </SidebarMenuItem>
         </SidebarMenu>
         <div
-          className={`absolute right-0 ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
+          className={`absolute right-0 flex items-center ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
+          onMouseEnter={titleTooltip.hide}
         >
+          <OpenInPaneButton
+            label="open-note-in-pane"
+            onOpen={() =>
+              openPane({
+                type: "note",
+                id: note._id,
+                title: note.title || "Untitled",
+              })
+            }
+          />
           <NoteSettingsSidbar
             noteId={note._id}
             noteTitle={note.title}
@@ -698,6 +764,7 @@ interface PinnedUploadItemProps {
 const PinnedUploadItem = memo(
   function PinnedUploadItem({ pdf, pathname, open }: PinnedUploadItemProps) {
     const titleTooltip = useHoverTooltip(300);
+    const { openPane } = useHomePane();
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editedTitle, setEditedTitle] = useState(pdf.title || "Untitled");
@@ -777,9 +844,8 @@ const PinnedUploadItem = memo(
     );
 
     const textClassName = isHovered
-      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-40% via-transparent via-60% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
-
     return (
       <SidebarGroupContent
         className="relative h-8 my-0.5 w-full flex justify-between items-center overflow-hidden group/item"
@@ -813,6 +879,17 @@ const PinnedUploadItem = memo(
                     <IntentPrefetchLink
                       href={pdfHref}
                       className="flex items-center gap-2 flex-grow min-w-0"
+                      onClick={(event) => {
+                        if (event.button === 0 && event.altKey) {
+                          event.preventDefault();
+                          openPane({
+                            type: "pdf",
+                            id: pdf._id,
+                            title: pdf.title || "Untitled",
+                          });
+                          titleTooltip.hide();
+                        }
+                      }}
                     >
                       {isHovered || isActive ? (
                         <ChevronRight
@@ -843,8 +920,19 @@ const PinnedUploadItem = memo(
           </SidebarMenuItem>
         </SidebarMenu>
         <div
-          className={`absolute right-0 ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
+          className={`absolute right-0 flex items-center ${isHovered && !isEditing ? "opacity-100 translate-x-0" : "opacity-0 translate-x-2 pointer-events-none"}`}
+          onMouseEnter={titleTooltip.hide}
         >
+          <OpenInPaneButton
+            label="open-upload-in-pane"
+            onOpen={() =>
+              openPane({
+                type: "pdf",
+                id: pdf._id,
+                title: pdf.title || "Untitled",
+              })
+            }
+          />
           <PdfSettingsSidebar pdfId={pdf._id} />
         </div>
       </SidebarGroupContent>
@@ -975,6 +1063,7 @@ interface WorkspaceItemProps {
 const WorkspaceItem = memo(
   function WorkspaceItem({ workingSpace, pathname, open }: WorkspaceItemProps) {
     const titleTooltip = useHoverTooltip(300);
+    const { openPane } = useHomePane();
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editedName, setEditedName] = useState(
@@ -1099,7 +1188,7 @@ const WorkspaceItem = memo(
     );
 
     const textClassName = isHovered
-      ? "truncate flex-grow bg-gradient-to-r from-foreground from-75% via-transparent via-85% to-transparent to-100% text-transparent bg-clip-text"
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
 
     return (
@@ -1135,6 +1224,17 @@ const WorkspaceItem = memo(
                     <IntentPrefetchLink
                       href={workspaceHref}
                       className="flex items-center gap-2 flex-grow min-w-0"
+                      onClick={(event) => {
+                        if (event.button === 0 && event.altKey) {
+                          event.preventDefault();
+                          openPane({
+                            type: "workspace",
+                            id: workingSpace._id,
+                            title: workingSpace.name || "Untitled",
+                          });
+                          titleTooltip.hide();
+                        }
+                      }}
                     >
                       {isHovered || isActive ? (
                         <FolderOpen
@@ -1165,8 +1265,19 @@ const WorkspaceItem = memo(
           </SidebarMenuItem>
         </SidebarMenu>
         <div
-          className={`absolute right-0 ${isHovered && !isEditing ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          className={`absolute right-0 flex items-center ${isHovered && !isEditing ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          onMouseEnter={titleTooltip.hide}
         >
+          <OpenInPaneButton
+            label="open-workspace-in-pane"
+            onOpen={() =>
+              openPane({
+                type: "workspace",
+                id: workingSpace._id,
+                title: workingSpace.name || "Untitled",
+              })
+            }
+          />
           <WorkingSpaceSettingsSidbar
             workingSpaceId={workingSpace._id}
             workingspaceName={workingSpace.name}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -28,6 +28,7 @@ import PublicNote from "../PublicNote";
 import { motion } from "framer-motion";
 import { NOISE_PNG } from "@/lib/data";
 import { useTheme } from "next-themes";
+import { HomePaneProvider } from "@/components/home-components/HomePaneDrawer";
 const fadeTransition = {
   show: { ease: "easeInOut" as const, duration: 0 },
   hide: { ease: "easeInOut" as const, duration: 0 },
@@ -143,7 +144,9 @@ HomeContent.displayName = "homeContent";
 const HomeClientLayout = memo(({ children }: { children: ReactNode }) => {
   return (
     <SidebarProvider>
-      <HomeContent>{children}</HomeContent>
+      <HomePaneProvider>
+        <HomeContent>{children}</HomeContent>
+      </HomePaneProvider>
     </SidebarProvider>
   );
 });

--- a/components/home-components/HomePaneDrawer.tsx
+++ b/components/home-components/HomePaneDrawer.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import {
+  createContext,
+  memo,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { PanelRightClose, X } from "lucide-react";
+import NotePageClient from "@/app/home/[id]/[slug]/NotePageClient";
+import PdfViewerPageClient from "@/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient";
+import WorkingSpacePageClient from "@/app/home/[id]/WorkingSpacePageClient";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerPortal,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import { cn } from "@/lib/utils";
+import type { Id } from "@/convex/_generated/dataModel";
+
+type HomePaneItem =
+  | {
+      type: "note";
+      id: Id<"notes">;
+      title?: string;
+    }
+  | {
+      type: "pdf";
+      id: Id<"pdfs">;
+      title?: string;
+    }
+  | {
+      type: "workspace";
+      id: Id<"workingSpaces">;
+      title?: string;
+    };
+
+type HomePaneContextValue = {
+  activeItem: HomePaneItem | null;
+  openPane: (item: HomePaneItem) => void;
+  closePane: () => void;
+};
+
+const HomePaneContext = createContext<HomePaneContextValue | null>(null);
+
+const PANE_WIDTH_STORAGE_KEY = "notevo_home_pane_width";
+const MIN_PANE_WIDTH = 360;
+const MAX_PANE_WIDTH = 960;
+const DEFAULT_PANE_WIDTH = 560;
+
+function clampPaneWidth(width: number) {
+  if (typeof window === "undefined") return width;
+  const maxViewportWidth = Math.max(MIN_PANE_WIDTH, window.innerWidth - 120);
+  return Math.min(
+    Math.max(width, MIN_PANE_WIDTH),
+    Math.min(MAX_PANE_WIDTH, maxViewportWidth),
+  );
+}
+
+function getPaneTitle(item: HomePaneItem | null) {
+  if (!item) return "Pane";
+  if (item.title) return item.title;
+  if (item.type === "pdf") return "Upload";
+  if (item.type === "workspace") return "Workspace";
+  return "Note";
+}
+
+function HomePaneContent({ item }: { item: HomePaneItem }) {
+  if (item.type === "note") {
+    return <NotePageClient noteId={item.id} />;
+  }
+
+  if (item.type === "pdf") {
+    return <PdfViewerPageClient pdfId={item.id} />;
+  }
+
+  return <WorkingSpacePageClient workingSpaceId={item.id} />;
+}
+
+function HomePaneDrawer({
+  activeItem,
+  closePane,
+}: {
+  activeItem: HomePaneItem | null;
+  closePane: () => void;
+}) {
+  const [paneWidth, setPaneWidth] = useState(DEFAULT_PANE_WIDTH);
+  const paneRef = useRef<HTMLDivElement | null>(null);
+  const isResizingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(DEFAULT_PANE_WIDTH);
+  const rafRef = useRef<number>(0);
+  const closeTooltip = useHoverTooltip(100);
+
+  useEffect(() => {
+    const savedWidth = window.localStorage.getItem(PANE_WIDTH_STORAGE_KEY);
+    if (!savedWidth) return;
+
+    const parsedWidth = Number(savedWidth);
+    if (Number.isFinite(parsedWidth)) {
+      setPaneWidth(clampPaneWidth(parsedWidth));
+    }
+  }, []);
+
+  const handleResizeStart = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      isResizingRef.current = true;
+      startXRef.current = event.clientX;
+      startWidthRef.current = paneWidth;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [paneWidth],
+  );
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!isResizingRef.current) return;
+
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+
+      rafRef.current = requestAnimationFrame(() => {
+        const nextWidth = clampPaneWidth(
+          startWidthRef.current + startXRef.current - event.clientX,
+        );
+        if (paneRef.current) {
+          paneRef.current.style.width = `${nextWidth}px`;
+        }
+      });
+    };
+
+    const handleMouseUp = () => {
+      if (!isResizingRef.current) return;
+      isResizingRef.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+
+      if (!paneRef.current) return;
+      const nextWidth = clampPaneWidth(
+        paneRef.current.getBoundingClientRect().width,
+      );
+      setPaneWidth(nextWidth);
+      window.localStorage.setItem(
+        PANE_WIDTH_STORAGE_KEY,
+        String(Math.round(nextWidth)),
+      );
+      paneRef.current.style.width = "";
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <Drawer
+      open={Boolean(activeItem)}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) closePane();
+      }}
+      direction="right"
+      modal={false}
+      shouldScaleBackground={false}
+    >
+      <DrawerPortal>
+        <div
+          ref={paneRef}
+          className={cn(
+            "fixed inset-y-0 right-0 z-[70000] hidden min-h-0 flex-col border-l border-border bg-background text-foreground shadow-2xl md:flex",
+            activeItem ? "translate-x-0" : "translate-x-full",
+          )}
+          style={{ width: paneWidth }}
+        >
+          <div
+            aria-hidden
+            className="group/resize absolute inset-y-0 left-0 z-20 w-2 -translate-x-1 cursor-col-resize"
+            onMouseDown={handleResizeStart}
+          >
+            <div className="mx-auto h-full w-px bg-gradient-to-b from-transparent from-5% via-border to-transparent to-95% group-hover/resize:via-primary" />
+          </div>
+          <div className="flex h-10 shrink-0 items-center justify-between border-b border-border bg-card/80 px-3 backdrop-blur">
+            <div className="flex min-w-0 items-center gap-2">
+              <PanelRightClose className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <DrawerTitle className="truncate text-sm font-medium">
+                {getPaneTitle(activeItem)}
+              </DrawerTitle>
+            </div>
+            <Tooltip open={closeTooltip.open}>
+              <TooltipTrigger asChild>
+                <DrawerClose asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label="close-pane"
+                    {...closeTooltip.triggerProps}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </DrawerClose>
+              </TooltipTrigger>
+              <TooltipContent side="left" className="text-xs px-1.5 py-1">
+                Close Pane
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <div
+            className={cn(
+              "scrollbar-gutter-stable min-h-0 flex-1 bg-background [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:h-[0.4rem] [&::-webkit-scrollbar]:w-[0.4rem]",
+              activeItem?.type === "pdf"
+                ? "overflow-hidden"
+                : "overflow-y-auto py-10",
+            )}
+          >
+            {activeItem ? <HomePaneContent item={activeItem} /> : null}
+          </div>
+        </div>
+      </DrawerPortal>
+    </Drawer>
+  );
+}
+
+export const HomePaneProvider = memo(function HomePaneProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [activeItem, setActiveItem] = useState<HomePaneItem | null>(null);
+
+  const openPane = useCallback((item: HomePaneItem) => {
+    setActiveItem(item);
+  }, []);
+
+  const closePane = useCallback(() => {
+    setActiveItem(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      activeItem,
+      openPane,
+      closePane,
+    }),
+    [activeItem, closePane, openPane],
+  );
+
+  return (
+    <HomePaneContext.Provider value={value}>
+      {children}
+      <HomePaneDrawer activeItem={activeItem} closePane={closePane} />
+    </HomePaneContext.Provider>
+  );
+});
+
+export function useHomePane() {
+  const context = useContext(HomePaneContext);
+  if (!context) {
+    throw new Error("useHomePane must be used within HomePaneProvider.");
+  }
+  return context;
+}

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -366,7 +366,7 @@ export default function NoteSettings({
             <DropdownMenuSeparator />
             <Button
               variant="SidebarMenuButton_destructive"
-              className="w-full h-8 px-2 text-sm"
+              className="w-full h-8 px-2 text-sm text-foreground"
               onClick={initiateDelete}
               aria-label="delete-note"
             >

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -130,7 +130,7 @@ export default function NoteSettingsSidbar({
             <Button
               onClick={handleFavoritePin}
               variant="SidebarMenuButton"
-              className="px-1.5 h-7 hover:bg-card"
+              className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="pin-note"
               {...pinTooltip.triggerProps}
             >

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -305,7 +305,7 @@ export default function PdfSettings({
             <DropdownMenuSeparator />
             <Button
               variant="SidebarMenuButton_destructive"
-              className="w-full h-8 px-2 text-sm"
+              className="w-full h-8 px-2 text-sm text-foreground"
               onClick={initiateDelete}
               aria-label="delete-upload"
             >

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -260,7 +260,7 @@ export default function WorkingSpaceSettings({
           <DropdownMenuGroup>
             <Button
               variant="SidebarMenuButton_destructive"
-              className="w-full h-8 px-2 text-sm"
+              className="w-full h-8 px-2 text-sm text-foreground"
               onClick={initiateDelete}
               disabled={isDeleting}
               aria-label="delete-workspace"
@@ -272,7 +272,8 @@ export default function WorkingSpaceSettings({
                 </>
               ) : (
                 <>
-                  <FaRegTrashCan size={14} className=" text-current" /> Delete
+                  <FaRegTrashCan size={14} className=" text-muted-foreground" />{" "}
+                  Delete
                 </>
               )}
             </Button>

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -115,7 +115,7 @@ export default function WorkingSpaceSettingsSidbar({
           <TooltipTrigger asChild>
             <Button
               variant="SidebarMenuButton_destructive"
-              className="px-1.5 h-7 hover:bg-card"
+              className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="delete-workspace"
               {...deleteTooltip.triggerProps}
               onMouseDown={initiateDelete}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
         SidebarMenuButton:
           "flex justify-start items-center gap-2 bg-none w-full text-foreground hover:bg-border",
         SidebarMenuButton_destructive:
-          "flex justify-start items-center gap-2 bg-none w-full text-foreground hover:bg-border hover:text-destructive",
+          "flex justify-start items-center gap-2 bg-none w-full text-muted-foreground hover:bg-border hover:text-destructive",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "turndown": "^7.2.2",
     "use-debounce": "^10.0.4",
     "uuid": "^13.0.0",
+    "vaul": "^1.1.2",
     "zod": "^3.25.67"
   },
   "devDependencies": {


### PR DESCRIPTION
## what changed
<img width="414" height="130" alt="image" src="https://github.com/user-attachments/assets/5510a89a-0348-44cf-af4c-5b2a823845d1" />

<img width="1752" height="950" alt="image" src="https://github.com/user-attachments/assets/2fa49260-457c-40bd-8ee4-e7ec45c757d8" />

this is cute 

- Added an "Open in Pane" action for workspaces, notes, and PDFs directly from the sidebar.
- Added support for `Alt + Click` on sidebar items to open them in a pane without navigating away.
- Introduced a shared `HomePaneProvider` to manage pane state across the home layout.
- Updated sidebar item hover actions and tooltips to surface the new functionality.
- Tweaked sidebar button styling and destructive actions for a more consistent look and feel.
- Added the `vaul` dependency to support the new pane experience.

Opening content in a side pane previously required extra navigation, making it slower to compare or reference multiple items. This update makes multitasking easier while also cleaning up some sidebar interactions and styling.

## now

- You can open notes, workspaces, and PDFs in a pane with a single click or `Alt + Click`.
- It's much easier to keep your current context while viewing other content.
- Sidebar actions are more discoverable and visually consistent.
- Destructive actions have clearer styling and better visual hierarchy.