### PR TITLE
improve pane behavior and sync pane state with url

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -580,6 +580,7 @@ hr {
   height: 1.5rem;
   justify-content: center;
   width: 1.5rem;
+  z-index: 10 !important;
 
   svg {
     width: 1.25rem;
@@ -591,7 +592,7 @@ hr {
 [data-drag-handle] {
   position: absolute !important;
   pointer-events: auto !important;
-  z-index: 25 !important;
+  z-index: 20 !important;
   opacity: 0 !important;
 }
 

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -660,8 +660,10 @@ function SliderTabsList({
 
 export default function WorkingSpacePageClient({
   workingSpaceId,
+  renderedInPane = false,
 }: {
   workingSpaceId: Id<"workingSpaces">;
+  renderedInPane?: boolean;
 }) {
   const cached = workspacePageMemoryCache.get(
     workingSpaceId as unknown as string,
@@ -774,6 +776,14 @@ export default function WorkingSpacePageClient({
       if (workspaceName !== currentTitle) {
         try {
           updateWorkingSpace({ _id: workingSpaceId, name: workspaceName });
+          if (renderedInPane) {
+            const currentUrl = new URL(window.location.href);
+            currentUrl.searchParams.set(
+              "paneTitle",
+              generateSlug(workspaceName),
+            );
+            window.history.replaceState({}, "", currentUrl.href);
+          }
         } catch (error) {
           console.error("Error updating workspace name:", error);
         }

--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -23,7 +23,13 @@ const noteTitleSchema = z
   .min(1, "Title cannot be empty")
   .max(60, "Title must be 60 characters or less");
 
-export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
+export default function NotePageClient({
+  noteId,
+  renderedInPane = false,
+}: {
+  noteId: Id<"notes">;
+  renderedInPane?: boolean;
+}) {
   const { noteWidth } = useNoteWidth();
   const note = useQuery(api.notes.getNoteById, { _id: noteId });
   const [lastNote, setLastNote] = useState<typeof note>(() => {
@@ -131,12 +137,15 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
         return;
       }
       const currentUrl = new URL(window.location.href);
+      const nextSlug = generateSlug(trimmedTitle);
 
-      const segments = currentUrl.pathname.split("/");
-
-      segments[3] = generateSlug(trimmedTitle);
-
-      currentUrl.pathname = segments.join("/");
+      if (renderedInPane) {
+        currentUrl.searchParams.set("paneTitle", nextSlug);
+      } else {
+        const segments = currentUrl.pathname.split("/");
+        segments[3] = nextSlug;
+        currentUrl.pathname = segments.join("/");
+      }
 
       window.history.replaceState({}, "", currentUrl.href);
 
@@ -240,6 +249,7 @@ export default function NotePageClient({ noteId }: { noteId: Id<"notes"> }) {
         </div>
       </div>
       <TailwindAdvancedEditor
+        renderedInPane
         editorBubblePlacement={false}
         initialContent={content ?? serverContent}
         onUpdate={(editor) => {

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -51,6 +51,7 @@ import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
 import { useDebouncedCallback } from "use-debounce";
 import { useToast } from "@/hooks/use-toast";
 import z from "zod";
+import { generateSlug } from "@/lib/generateSlug";
 
 GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/legacy/build/pdf.worker.mjs",
@@ -478,11 +479,13 @@ function PdfViewerContent({
   title,
   pdfId,
   pdftitle,
+  renderedInPane,
 }: {
   fileUrl: string;
   title: string;
   pdfId: Id<"pdfs">;
   pdftitle: string;
+  renderedInPane?: boolean;
 }) {
   const { open, isMobile } = useSidebar();
   const [query, setQuery] = useState("");
@@ -545,6 +548,11 @@ function PdfViewerContent({
     if (newTitle !== currentTitle) {
       try {
         void updatePdf({ _id: pdfId, title: newTitle });
+        if (renderedInPane) {
+          const currentUrl = new URL(window.location.href);
+          currentUrl.searchParams.set("paneTitle", generateSlug(newTitle));
+          window.history.replaceState({}, "", currentUrl.href);
+        }
       } catch (error) {
         console.error("Error updating PDF title:", error);
         toast({
@@ -566,48 +574,56 @@ function PdfViewerContent({
       <div className=" relative min-w-full min-h-full bg-transparent ">
         <div className=" pointer-events-none absolute inset-x-0 top-1 z-50">
           <div
-            className={`pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-1 app-radius-lg border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl`}
+            className={cn(
+              "pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-1 border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl",
+              !renderedInPane && "app-radius-lg",
+            )}
           >
             {(!open || isMobile) && (
               <Button
                 variant="outline"
                 size="icon"
-                className="h-8 w-8 border border-border"
+                className={cn(
+                  "h-8 w-8 border border-border",
+                  renderedInPane && "!rounded-none",
+                )}
                 aria-label="show-search-panel"
               >
                 <SidebarTrigger />
               </Button>
             )}
-            <div
-              className={` px-1.5 h-8 py-0 border border-border bg-background hover:border-muted-foreground/50 ${!open || isMobile ? "!rounded-none" : "app-radius-md"} `}
-            >
-              <h1
-                onDoubleClick={handleNameDoubleClick}
-                title="Double-click to rename"
-                className=" md:text-lg cursor-text flex justify-start items-center min-w-[16rem] overflow-hidden "
+            {!renderedInPane && (
+              <div
+                className={` px-1.5 h-8 py-0 border border-border bg-background hover:border-muted-foreground/50 ${!open || isMobile ? "!rounded-none" : "app-radius-md"} `}
               >
-                {isEditingName ? (
-                  <Input
-                    ref={nameInputRef as any}
-                    value={editedName}
-                    onChange={(e: any) => {
-                      setEditedName(e.target.value);
-                      debouncedUpdatePdfTitle(e.target.value.trim());
-                    }}
-                    onKeyDown={handleNameKeyDown}
-                    onBlur={() => {
-                      setIsEditingName(false);
-                    }}
-                    placeholder="Untitled PDF"
-                    className=" !w-full placeholder:text-muted-foreground/50 border-transparent bg-transparent px-0 py-0 my-0 md:text-lg font-bol h-8 cursor-text leading-12 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
-                  />
-                ) : (
-                  <span className=" w-full overflow-hidden text-nowrap">
-                    {pdftitle || "Untitled PDF"}
-                  </span>
-                )}
-              </h1>
-            </div>
+                <h1
+                  onDoubleClick={handleNameDoubleClick}
+                  title="Double-click to rename"
+                  className=" md:text-lg cursor-text flex justify-start items-center min-w-[16rem] overflow-hidden "
+                >
+                  {isEditingName ? (
+                    <Input
+                      ref={nameInputRef as any}
+                      value={editedName}
+                      onChange={(e: any) => {
+                        setEditedName(e.target.value);
+                        debouncedUpdatePdfTitle(e.target.value.trim());
+                      }}
+                      onKeyDown={handleNameKeyDown}
+                      onBlur={() => {
+                        setIsEditingName(false);
+                      }}
+                      placeholder="Untitled PDF"
+                      className=" !w-full placeholder:text-muted-foreground/50 border-transparent bg-transparent px-0 py-0 my-0 md:text-lg font-bol h-8 cursor-text leading-12 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 "
+                    />
+                  ) : (
+                    <span className=" w-full overflow-hidden text-nowrap">
+                      {pdftitle || "Untitled PDF"}
+                    </span>
+                  )}
+                </h1>
+              </div>
+            )}
             <div className="flex items-center gap-0">
               <Tooltip open={searchTooltip.open}>
                 <TooltipTrigger asChild>
@@ -668,15 +684,17 @@ function PdfViewerContent({
               <ZoomDropdown />
             </div>
             <PageNavigator />
-            <PdfSettings
-              pdfId={pdfId}
-              pdfTitle={pdftitle}
-              iconVariant="horizontal_icon"
-              dropdownMenuContentAlign="end"
-              tooltipContentAlign="end"
-              btnVariant="outline"
-              btnClassName="h-8 w-8 m-0 px-1 border-border !rounded-none"
-            />
+            {!renderedInPane && (
+              <PdfSettings
+                pdfId={pdfId}
+                pdfTitle={pdftitle}
+                iconVariant="horizontal_icon"
+                dropdownMenuContentAlign="end"
+                tooltipContentAlign="end"
+                btnVariant="outline"
+                btnClassName="h-8 w-8 m-0 px-1 border-border !rounded-none"
+              />
+            )}
           </div>
         </div>
 
@@ -716,11 +734,13 @@ function PdfViewerShell({
   title,
   pdfId,
   pdftitle,
+  renderedInPane,
 }: {
   fileUrl: string;
   title: string;
   pdfId: Id<"pdfs">;
   pdftitle: string;
+  renderedInPane?: boolean;
 }) {
   const { open, isMobile } = useSidebar();
 
@@ -728,7 +748,10 @@ function PdfViewerShell({
     <Root
       source={fileUrl}
       isZoomFitWidth
-      className={`${open && !isMobile ? `app-radius-lg` : null} pdf-viewer-shell relative h-full w-full overflow-hidden rounded-none border-0 bg-background flex flex-col justify-stretch`}
+      className={cn(
+        "pdf-viewer-shell relative h-full w-full overflow-hidden rounded-none border-0 bg-background flex flex-col justify-stretch",
+        open && !isMobile && !renderedInPane && "app-radius-lg",
+      )}
       loader={
         <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
           Loading PDF...
@@ -744,12 +767,19 @@ function PdfViewerShell({
         title={title}
         pdfId={pdfId}
         pdftitle={pdftitle}
+        renderedInPane={renderedInPane}
       />
     </Root>
   );
 }
 
-export default function PdfViewerPageClient({ pdfId }: { pdfId: Id<"pdfs"> }) {
+export default function PdfViewerPageClient({
+  pdfId,
+  renderedInPane = false,
+}: {
+  pdfId: Id<"pdfs">;
+  renderedInPane?: boolean;
+}) {
   const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });
   const [isViewerReady, setIsViewerReady] = useState(false);
   const [hasMeasuredViewport, setHasMeasuredViewport] = useState(false);
@@ -840,6 +870,7 @@ export default function PdfViewerPageClient({ pdfId }: { pdfId: Id<"pdfs"> }) {
           title={pdf.title || "Untitled PDF"}
           pdfId={pdf._id}
           pdftitle={pdf.title || "Untitled PDF"}
+          renderedInPane={renderedInPane}
         />
       ) : (
         <div className="flex-1 bg-card animate-pulse" />

--- a/components/ToC.tsx
+++ b/components/ToC.tsx
@@ -438,7 +438,7 @@ export const CompactFloatingToC = ({
   }
 
   return (
-    <div className="fixed right-3 top-24 z-50">
+    <div className="fixed right-3 top-24 z-40">
       <div
         className={`
           transition-all duration-150 ease-linear px-0.5 border border-solid rounded-tl-lg bg-background 

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -47,10 +47,12 @@ const TailwindAdvancedEditor = ({
   initialContent,
   onUpdate,
   editorBubblePlacement,
+  renderedInPane = false,
 }: {
   initialContent: any;
   onUpdate: (editor: EditorInstance) => void;
   editorBubblePlacement: Boolean;
+  renderedInPane?: boolean;
 }) => {
   const [openNode, setOpenNode] = useState(false);
   const [openColor, setOpenColor] = useState(false);
@@ -128,11 +130,6 @@ const TailwindAdvancedEditor = ({
   };
 
   const openPlusMenu = (editor: EditorInstance, buttonEl: HTMLElement) => {
-    const dragHandleEl =
-      buttonEl.closest("[data-drag-handle]")?.parentElement ??
-      buttonEl.closest(".novel-drag-handle")?.parentElement ??
-      buttonEl.parentElement?.parentElement;
-
     const rect = buttonEl.getBoundingClientRect();
     const editorView = (editor as any).view;
 
@@ -204,34 +201,37 @@ const TailwindAdvancedEditor = ({
               <LinkHoverCard editor={editorInstance} disabled={openLink} />
               <TableControls editor={editorInstance} />
               <DragHandle editor={editorInstance}>
-                <div className="lg:flex items-center justify-center hidden ">
-                  <Tooltip delayDuration={150} disableHoverableContent>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="Insert block below"
-                        className="flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
-                        onMouseDown={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          openPlusMenu(
-                            editorInstance,
-                            event.currentTarget as HTMLElement,
-                          );
-                        }}
-                      >
-                        <Plus className="h-4 w-4 " />
-                      </button>
-                    </TooltipTrigger>
+                <div className="lg:flex items-center justify-center hidden">
+                  {!renderedInPane && (
+                    <Tooltip delayDuration={150} disableHoverableContent>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="Insert block below"
+                          className="flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
+                          onMouseDown={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            openPlusMenu(
+                              editorInstance,
+                              event.currentTarget as HTMLElement,
+                            );
+                          }}
+                        >
+                          <Plus className="h-4 w-4 " />
+                        </button>
+                      </TooltipTrigger>
 
-                    <TooltipContent
-                      side="left"
-                      align="center"
-                      className=" text-xs font-bold py-0.5 px-1.5 !rounded-none "
-                    >
-                      <p> Click to insert block below </p>
-                    </TooltipContent>
-                  </Tooltip>
+                      <TooltipContent
+                        side="left"
+                        align="center"
+                        className=" text-xs font-bold py-0.5 px-1.5 !rounded-none"
+                      >
+                        <p> Click to insert block below </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+
                   <Tooltip delayDuration={150} disableHoverableContent>
                     <TooltipTrigger asChild>
                       <div className="flex h-5 w-5 items-center justify-center">
@@ -265,7 +265,7 @@ const TailwindAdvancedEditor = ({
                     <TooltipContent
                       side="left"
                       align="center"
-                      className=" text-xs font-bold py-0.5 px-1.5 !rounded-none "
+                      className=" text-xs font-bold py-0.5 px-1.5 !rounded-none"
                     >
                       <p>Drag</p>
                     </TooltipContent>
@@ -278,7 +278,7 @@ const TailwindAdvancedEditor = ({
             initialContent={initialContent}
             extensions={extensions}
             autofocus={true}
-            className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder"
+            className="advanced-editor-shell relative w-full bg-transparent text-foreground placeholder "
             editorProps={{
               handleDOMEvents: {
                 keydown: (_view, event) => handleCommandNavigation(event),

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -1188,7 +1188,7 @@ const WorkspaceItem = memo(
     );
 
     const textClassName = isHovered
-      ? "truncate flex-grow bg-gradient-to-r from-foreground from-50% via-transparent via-75% to-transparent to-100% text-transparent bg-clip-text"
+      ? "truncate flex-grow bg-gradient-to-r from-foreground from-75% via-transparent via-85% to-transparent to-100% text-transparent bg-clip-text"
       : "truncate flex-grow";
 
     return (
@@ -1224,17 +1224,6 @@ const WorkspaceItem = memo(
                     <IntentPrefetchLink
                       href={workspaceHref}
                       className="flex items-center gap-2 flex-grow min-w-0"
-                      onClick={(event) => {
-                        if (event.button === 0 && event.altKey) {
-                          event.preventDefault();
-                          openPane({
-                            type: "workspace",
-                            id: workingSpace._id,
-                            title: workingSpace.name || "Untitled",
-                          });
-                          titleTooltip.hide();
-                        }
-                      }}
                     >
                       {isHovered || isActive ? (
                         <FolderOpen
@@ -1268,16 +1257,6 @@ const WorkspaceItem = memo(
           className={`absolute right-0 flex items-center ${isHovered && !isEditing ? "opacity-100" : "opacity-0 pointer-events-none"}`}
           onMouseEnter={titleTooltip.hide}
         >
-          <OpenInPaneButton
-            label="open-workspace-in-pane"
-            onOpen={() =>
-              openPane({
-                type: "workspace",
-                id: workingSpace._id,
-                title: workingSpace.name || "Untitled",
-              })
-            }
-          />
           <WorkingSpaceSettingsSidbar
             workingSpaceId={workingSpace._id}
             workingspaceName={workingSpace.name}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -95,7 +95,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           open && !isMobile ? `rounded-tl-lg border-t border-l mt-3` : ""
         } rounded-none`}
       >
-        <div className="z-[60000] absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
+        <div className="z-30 absolute top-0 left-0 w-full flex items-center justify-start gap-3 mx-auto bg-none rounded-tl-lg border-none">
           <div className="flex justify-between items-center w-full px-4 py-2 ">
             <div className="flex justify-start items-center gap-3">
               {(!open || isMobile) && !isPdfRoute && <SidebarTrigger />}
@@ -128,7 +128,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
             initial={{ opacity: 0 }}
             animate={{ opacity: showTopFade ? 1 : 0 }}
             transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
-            className="rounded-tl-lg absolute top-0 left-0 w-full h-[4rem] bg-gradient-to-b from-background from-0% via-background/65 via-45% to-100% to-transparent z-[50000] pointer-events-none -mb-16"
+            className="rounded-tl-lg absolute top-0 left-0 w-full h-[4rem] bg-gradient-to-b from-background from-0% via-background/65 via-45% to-100% to-transparent z-20 pointer-events-none -mb-16"
             aria-hidden
           />
           {children}

--- a/components/home-components/HomePaneDrawer.tsx
+++ b/components/home-components/HomePaneDrawer.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from "react";
 import { PanelRightClose, X } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import NotePageClient from "@/app/home/[id]/[slug]/NotePageClient";
 import PdfViewerPageClient from "@/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient";
 import WorkingSpacePageClient from "@/app/home/[id]/WorkingSpacePageClient";
@@ -29,6 +30,8 @@ import {
 } from "@/components/ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import { cn } from "@/lib/utils";
+import { generateSlug } from "@/lib/generateSlug";
+import { parseSlug } from "@/lib/parseSlug";
 import type { Id } from "@/convex/_generated/dataModel";
 
 type HomePaneItem =
@@ -57,6 +60,9 @@ type HomePaneContextValue = {
 const HomePaneContext = createContext<HomePaneContextValue | null>(null);
 
 const PANE_WIDTH_STORAGE_KEY = "notevo_home_pane_width";
+const PANE_TYPE_PARAM = "pane";
+const PANE_ID_PARAM = "paneId";
+const PANE_TITLE_PARAM = "paneTitle";
 const MIN_PANE_WIDTH = 360;
 const MAX_PANE_WIDTH = 960;
 const DEFAULT_PANE_WIDTH = 560;
@@ -72,7 +78,7 @@ function clampPaneWidth(width: number) {
 
 function getPaneTitle(item: HomePaneItem | null) {
   if (!item) return "Pane";
-  if (item.title) return item.title;
+  if (item.title) return parseSlug(item.title);
   if (item.type === "pdf") return "Upload";
   if (item.type === "workspace") return "Workspace";
   return "Note";
@@ -80,14 +86,14 @@ function getPaneTitle(item: HomePaneItem | null) {
 
 function HomePaneContent({ item }: { item: HomePaneItem }) {
   if (item.type === "note") {
-    return <NotePageClient noteId={item.id} />;
+    return <NotePageClient noteId={item.id} renderedInPane />;
   }
 
   if (item.type === "pdf") {
-    return <PdfViewerPageClient pdfId={item.id} />;
+    return <PdfViewerPageClient pdfId={item.id} renderedInPane />;
   }
 
-  return <WorkingSpacePageClient workingSpaceId={item.id} />;
+  return <WorkingSpacePageClient workingSpaceId={item.id} renderedInPane />;
 }
 
 function HomePaneDrawer({
@@ -193,7 +199,7 @@ function HomePaneDrawer({
         <div
           ref={paneRef}
           className={cn(
-            "fixed inset-y-0 right-0 z-[70000] hidden min-h-0 flex-col border-l border-border bg-background text-foreground shadow-2xl md:flex",
+            "fixed inset-y-0 right-0 z-40 hidden min-h-0 flex-col border-l border-border bg-background text-foreground shadow-2xl md:flex",
             activeItem ? "translate-x-0" : "translate-x-full",
           )}
           style={{ width: paneWidth }}
@@ -212,24 +218,17 @@ function HomePaneDrawer({
                 {getPaneTitle(activeItem)}
               </DrawerTitle>
             </div>
-            <Tooltip open={closeTooltip.open}>
-              <TooltipTrigger asChild>
-                <DrawerClose asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
-                    aria-label="close-pane"
-                    {...closeTooltip.triggerProps}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                </DrawerClose>
-              </TooltipTrigger>
-              <TooltipContent side="left" className="text-xs px-1.5 py-1">
-                Close Pane
-              </TooltipContent>
-            </Tooltip>
+            <DrawerClose asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                aria-label="close-pane"
+                {...closeTooltip.triggerProps}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </DrawerClose>
           </div>
           <div
             className={cn(
@@ -252,15 +251,75 @@ export const HomePaneProvider = memo(function HomePaneProvider({
 }: {
   children: ReactNode;
 }) {
-  const [activeItem, setActiveItem] = useState<HomePaneItem | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  const openPane = useCallback((item: HomePaneItem) => {
-    setActiveItem(item);
-  }, []);
+  const activeItem = useMemo<HomePaneItem | null>(() => {
+    const paneType = searchParams.get(PANE_TYPE_PARAM);
+    const paneId = searchParams.get(PANE_ID_PARAM);
+    const paneTitle = searchParams.get(PANE_TITLE_PARAM) ?? undefined;
+
+    if (!paneId) return null;
+
+    if (paneType === "note") {
+      return {
+        type: "note",
+        id: paneId as Id<"notes">,
+        title: paneTitle,
+      };
+    }
+
+    if (paneType === "pdf") {
+      return {
+        type: "pdf",
+        id: paneId as Id<"pdfs">,
+        title: paneTitle,
+      };
+    }
+
+    if (paneType === "workspace") {
+      return {
+        type: "workspace",
+        id: paneId as Id<"workingSpaces">,
+        title: paneTitle,
+      };
+    }
+
+    return null;
+  }, [searchParams]);
+
+  const buildPaneHref = useCallback(
+    (nextParams: URLSearchParams) => {
+      const queryString = nextParams.toString();
+      return queryString ? `${pathname}?${queryString}` : pathname;
+    },
+    [pathname],
+  );
+
+  const openPane = useCallback(
+    (item: HomePaneItem) => {
+      const nextParams = new URLSearchParams(searchParams.toString());
+      nextParams.set(PANE_TYPE_PARAM, item.type);
+      nextParams.set(PANE_ID_PARAM, item.id);
+      nextParams.set(
+        PANE_TITLE_PARAM,
+        generateSlug(item.title || getPaneTitle(item).toLowerCase()),
+      );
+
+      router.push(buildPaneHref(nextParams), { scroll: false });
+    },
+    [buildPaneHref, router, searchParams],
+  );
 
   const closePane = useCallback(() => {
-    setActiveItem(null);
-  }, []);
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.delete(PANE_TYPE_PARAM);
+    nextParams.delete(PANE_ID_PARAM);
+    nextParams.delete(PANE_TITLE_PARAM);
+
+    router.push(buildPaneHref(nextParams), { scroll: false });
+  }, [buildPaneHref, router, searchParams]);
 
   const value = useMemo(
     () => ({

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -83,7 +83,7 @@ export default function PdfSettingsSidebar({
             <Button
               onClick={handleFavoritePin}
               variant="SidebarMenuButton"
-              className="px-1.5 h-7 hover:bg-card"
+              className="px-1.5 h-7 hover:bg-card !rounded-none"
               aria-label="pin-upload"
               {...pinTooltip.triggerProps}
             >

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -115,7 +115,7 @@ export default function WorkingSpaceSettingsSidbar({
           <TooltipTrigger asChild>
             <Button
               variant="SidebarMenuButton_destructive"
-              className="px-1.5 h-7 hover:bg-card !rounded-none"
+              className="px-1.5 h-7 hover:bg-card"
               aria-label="delete-workspace"
               {...deleteTooltip.triggerProps}
               onMouseDown={initiateDelete}


### PR DESCRIPTION
### what changed
<img width="1138" height="730" alt="image" src="https://github.com/user-attachments/assets/636ed6b3-a948-4e35-b926-fdf120191e7a" />
before : 
<img width="1684" height="955" alt="image" src="https://github.com/user-attachments/assets/a3a00dac-bb7b-4ed6-bfd8-8bbc59eaa34e" />

now :  just a little bit better less things when the user open the side pane 
<img width="1679" height="951" alt="image" src="https://github.com/user-attachments/assets/b6401c86-07a2-4c0e-be22-adde5b3283ed" />

* Moved pane state to URL search params (`pane`, `paneId`, `paneTitle`) so the active pane is reflected in the URL.
* Added `renderedInPane` support to notes, workspaces, PDFs, and the editor to render a pane-specific UI.
* Updated rename flows to keep the pane title in the URL in sync when a note, workspace, or PDF is renamed.
* Simplified the pane UI by hiding controls that aren't needed in pane mode (PDF title editing, settings, editor insert button, etc.).
* Cleaned up stacking (`z-index`) and a few styling tweaks to avoid layering issues.
* Removed the workspace "open in pane" entry points from the sidebar.

The pane was managed only in local state, which meant it wasn't reflected in the URL and could get out of sync with renamed items. Pane-specific views also showed controls that only make sense in the full page experience.


* Pane state is shareable and survives navigation since it's URL-driven.
* Renaming notes, workspaces, and PDFs immediately updates the pane title in the URL.
* Pane views are cleaner and more focused with only the relevant controls.
* Improved layering and styling consistency across the pane experience.
