### PR TITLE
fix pdf viewer layering in pane

### DIFF
--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -572,7 +572,7 @@ function PdfViewerContent({
       }
     >
       <div className=" relative min-w-full min-h-full bg-transparent ">
-        <div className=" pointer-events-none absolute inset-x-0 top-1 z-50">
+        <div className=" pointer-events-none absolute inset-x-0 top-1 z-20">
           <div
             className={cn(
               "pointer-events-auto mx-auto flex w-fit flex-nowrap items-center justify-between gap-1 border border-border bg-card/95 px-0.5 py-0.5 backdrop-blur-xl",
@@ -715,7 +715,7 @@ function PdfViewerContent({
           </div>
         ) : null}
 
-        <div className=" absolute inset-y-0 right-0 z-30 flex h-screen w-full items-center justify-center border-b border-border bg-background">
+        <div className=" absolute inset-y-0 right-0 z-10 flex h-screen w-full items-center justify-center border-b border-border bg-background">
           <Pages className="scrollbar-gutter-stable [&::-webkit-scrollbar-track]:bg-transparent h-full min-h-0 w-full transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border">
             <Page>
               <CanvasLayer />


### PR DESCRIPTION
### what changed
before : 
<img width="1692" height="566" alt="image" src="https://github.com/user-attachments/assets/020e7c34-4423-4431-8871-9a2c09071c3f" />


now : 
<img width="1692" height="710" alt="image" src="https://github.com/user-attachments/assets/72bbe36a-2dc7-4cca-b3d4-abc72df0ad33" />

* Lowered the PDF viewer toolbar `z-index` from `z-50` to `z-20`.
* Lowered the PDF pages container `z-index` from `z-30` to `z-10`.

The previous stacking order caused the PDF viewer elements to overlap with other UI layers, especially when rendered inside the pane.

* The PDF viewer respects the app's layering hierarchy.
* Toolbar and page content no longer interfere with surrounding UI.
* Pane rendering is more consistent with the rest of the application.
