### PR TITLE
make renderedInPane prop explicit in editor

### DIFF
--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -249,7 +249,7 @@ export default function NotePageClient({
         </div>
       </div>
       <TailwindAdvancedEditor
-        renderedInPane
+        renderedInPane={renderedInPane}
         editorBubblePlacement={false}
         initialContent={content ?? serverContent}
         onUpdate={(editor) => {

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -47,7 +47,7 @@ const TailwindAdvancedEditor = ({
   initialContent,
   onUpdate,
   editorBubblePlacement,
-  renderedInPane = false,
+  renderedInPane,
 }: {
   initialContent: any;
   onUpdate: (editor: EditorInstance) => void;


### PR DESCRIPTION
made the `renderedInPane` prop explicit in NotePageClient and advanced-editor component (removed default false).

this improves clarity and avoids potential confusion with boolean props.