### PR TITLE
revert pane url state and fix pane remounting

### DIFF
--- a/app/home/[id]/[slug]/NotePageClient.tsx
+++ b/app/home/[id]/[slug]/NotePageClient.tsx
@@ -12,7 +12,6 @@ import { useMutation } from "convex/react";
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import z from "zod";
-import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { generateSlug } from "@/lib/generateSlug";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
@@ -36,11 +35,7 @@ export default function NotePageClient({
     return noteMemoryCache.get(noteId as unknown as string) as typeof note;
   });
 
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { toast } = useToast();
-
   useEffect(() => {
     setLastNote(
       noteMemoryCache.get(noteId as unknown as string) as typeof note,
@@ -78,10 +73,8 @@ export default function NotePageClient({
   const [editedTitle, setEditedTitle] = useState(stableNote?.title || "");
 
   useEffect(() => {
-    if (stableNote?.title && !editedTitle) {
-      setEditedTitle(stableNote.title);
-    }
-  }, [stableNote?.title]);
+    setEditedTitle(stableNote?.title || "");
+  }, [noteId, stableNote?.title]);
 
   useEffect(() => {
     if (titleElRef.current) syncHeight(titleElRef.current);

--- a/components/home-components/HomePaneDrawer.tsx
+++ b/components/home-components/HomePaneDrawer.tsx
@@ -12,7 +12,6 @@ import {
   useState,
 } from "react";
 import { PanelRightClose, X } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import NotePageClient from "@/app/home/[id]/[slug]/NotePageClient";
 import PdfViewerPageClient from "@/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient";
 import WorkingSpacePageClient from "@/app/home/[id]/WorkingSpacePageClient";
@@ -23,14 +22,8 @@ import {
   DrawerPortal,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 import { cn } from "@/lib/utils";
-import { generateSlug } from "@/lib/generateSlug";
 import { parseSlug } from "@/lib/parseSlug";
 import type { Id } from "@/convex/_generated/dataModel";
 
@@ -60,9 +53,6 @@ type HomePaneContextValue = {
 const HomePaneContext = createContext<HomePaneContextValue | null>(null);
 
 const PANE_WIDTH_STORAGE_KEY = "notevo_home_pane_width";
-const PANE_TYPE_PARAM = "pane";
-const PANE_ID_PARAM = "paneId";
-const PANE_TITLE_PARAM = "paneTitle";
 const MIN_PANE_WIDTH = 360;
 const MAX_PANE_WIDTH = 960;
 const DEFAULT_PANE_WIDTH = 560;
@@ -86,14 +76,20 @@ function getPaneTitle(item: HomePaneItem | null) {
 
 function HomePaneContent({ item }: { item: HomePaneItem }) {
   if (item.type === "note") {
-    return <NotePageClient noteId={item.id} renderedInPane />;
+    return <NotePageClient key={item.id} noteId={item.id} renderedInPane />;
   }
 
   if (item.type === "pdf") {
-    return <PdfViewerPageClient pdfId={item.id} renderedInPane />;
+    return <PdfViewerPageClient key={item.id} pdfId={item.id} renderedInPane />;
   }
 
-  return <WorkingSpacePageClient workingSpaceId={item.id} renderedInPane />;
+  return (
+    <WorkingSpacePageClient
+      key={item.id}
+      workingSpaceId={item.id}
+      renderedInPane
+    />
+  );
 }
 
 function HomePaneDrawer({
@@ -251,75 +247,15 @@ export const HomePaneProvider = memo(function HomePaneProvider({
 }: {
   children: ReactNode;
 }) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const [activeItem, setActiveItem] = useState<HomePaneItem | null>(null);
 
-  const activeItem = useMemo<HomePaneItem | null>(() => {
-    const paneType = searchParams.get(PANE_TYPE_PARAM);
-    const paneId = searchParams.get(PANE_ID_PARAM);
-    const paneTitle = searchParams.get(PANE_TITLE_PARAM) ?? undefined;
-
-    if (!paneId) return null;
-
-    if (paneType === "note") {
-      return {
-        type: "note",
-        id: paneId as Id<"notes">,
-        title: paneTitle,
-      };
-    }
-
-    if (paneType === "pdf") {
-      return {
-        type: "pdf",
-        id: paneId as Id<"pdfs">,
-        title: paneTitle,
-      };
-    }
-
-    if (paneType === "workspace") {
-      return {
-        type: "workspace",
-        id: paneId as Id<"workingSpaces">,
-        title: paneTitle,
-      };
-    }
-
-    return null;
-  }, [searchParams]);
-
-  const buildPaneHref = useCallback(
-    (nextParams: URLSearchParams) => {
-      const queryString = nextParams.toString();
-      return queryString ? `${pathname}?${queryString}` : pathname;
-    },
-    [pathname],
-  );
-
-  const openPane = useCallback(
-    (item: HomePaneItem) => {
-      const nextParams = new URLSearchParams(searchParams.toString());
-      nextParams.set(PANE_TYPE_PARAM, item.type);
-      nextParams.set(PANE_ID_PARAM, item.id);
-      nextParams.set(
-        PANE_TITLE_PARAM,
-        generateSlug(item.title || getPaneTitle(item).toLowerCase()),
-      );
-
-      router.push(buildPaneHref(nextParams), { scroll: false });
-    },
-    [buildPaneHref, router, searchParams],
-  );
+  const openPane = useCallback((item: HomePaneItem) => {
+    setActiveItem(item);
+  }, []);
 
   const closePane = useCallback(() => {
-    const nextParams = new URLSearchParams(searchParams.toString());
-    nextParams.delete(PANE_TYPE_PARAM);
-    nextParams.delete(PANE_ID_PARAM);
-    nextParams.delete(PANE_TITLE_PARAM);
-
-    router.push(buildPaneHref(nextParams), { scroll: false });
-  }, [buildPaneHref, router, searchParams]);
+    setActiveItem(null);
+  }, []);
 
   const value = useMemo(
     () => ({

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Drawer = ({
   shouldScaleBackground = true,
@@ -13,14 +13,14 @@ const Drawer = ({
     shouldScaleBackground={shouldScaleBackground}
     {...props}
   />
-)
-Drawer.displayName = "Drawer"
+);
+Drawer.displayName = "Drawer";
 
-const DrawerTrigger = DrawerPrimitive.Trigger
+const DrawerTrigger = DrawerPrimitive.Trigger;
 
-const DrawerPortal = DrawerPrimitive.Portal
+const DrawerPortal = DrawerPrimitive.Portal;
 
-const DrawerClose = DrawerPrimitive.Close
+const DrawerClose = DrawerPrimitive.Close;
 
 const DrawerOverlay = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Overlay>,
@@ -28,11 +28,11 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn("fixed inset-0 z-50 bg-background/30", className)}
     {...props}
   />
-))
-DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
@@ -44,7 +44,7 @@ const DrawerContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
-        className
+        className,
       )}
       {...props}
     >
@@ -52,8 +52,8 @@ const DrawerContent = React.forwardRef<
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
-))
-DrawerContent.displayName = "DrawerContent"
+));
+DrawerContent.displayName = "DrawerContent";
 
 const DrawerHeader = ({
   className,
@@ -63,8 +63,8 @@ const DrawerHeader = ({
     className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
     {...props}
   />
-)
-DrawerHeader.displayName = "DrawerHeader"
+);
+DrawerHeader.displayName = "DrawerHeader";
 
 const DrawerFooter = ({
   className,
@@ -74,8 +74,8 @@ const DrawerFooter = ({
     className={cn("mt-auto flex flex-col gap-2 p-4", className)}
     {...props}
   />
-)
-DrawerFooter.displayName = "DrawerFooter"
+);
+DrawerFooter.displayName = "DrawerFooter";
 
 const DrawerTitle = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Title>,
@@ -85,12 +85,12 @@ const DrawerTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
-      className
+      className,
     )}
     {...props}
   />
-))
-DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 
 const DrawerDescription = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Description>,
@@ -101,8 +101,8 @@ const DrawerDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
 
 export {
   Drawer,
@@ -115,4 +115,4 @@ export {
   DrawerFooter,
   DrawerTitle,
   DrawerDescription,
-}
+};


### PR DESCRIPTION
### what changed

* Reverted pane state management from URL search params back to local React state.
* Added `key` props to pane content components so notes, PDFs, and workspaces remount correctly when switching between items.
* Updated note title state to reset whenever the active note changes.
* Cleaned up unused routing-related code and imports.
* Adjusted the drawer overlay styling to use a lighter background.

Managing the pane through the URL added extra complexity and wasn't needed for the current behavior. The pane also wasn't always resetting its internal state when switching between different items.

### what's better now

* Pane state is simpler and easier to maintain.
* Switching between notes, PDFs, and workspaces always renders fresh component state.
* Note titles stay in sync when opening different notes.
* Less routing-related code and a cleaner drawer experience.
