### PR TITLE
fix calendar timeline layering z-indexing

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1673,7 +1673,7 @@ function CalendarTimelineView({
             ))}
 
             <div
-              className="absolute inset-0 w-px bg-primary z-20"
+              className="absolute inset-0 w-px bg-primary z-10"
               style={{ left: todayOffset }}
             >
               <div className=" absolute top-0 left-1/2 -translate-x-1/2 mb-1 px-2 py-0.5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold whitespace-nowrap">


### PR DESCRIPTION
### what changed
before : 
<img width="249" height="399" alt="image" src="https://github.com/user-attachments/assets/70521799-8f8f-4895-aa46-c6af02714bb6" />

now : 
<img width="197" height="343" alt="image" src="https://github.com/user-attachments/assets/b55e9766-4f67-483b-ad86-5234c8bdb3b7" />
* Lowered the calendar timeline's "today" indicator `z-index` from `z-20` to `z-10`.

The current stacking order caused the timeline indicator to appear above UI elements that should have higher priority.
