### PR TITLE
improve loading skeletons across workspace views

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -2449,15 +2449,66 @@ function EmptyTableState({
 function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
   if (viewMode === "calendar") {
     return (
-      <div className="border border-border app-radius-lg bg-card p-4 space-y-6">
-        <div className="h-4 w-32 bg-border rounded animate-pulse" />
-        <div className="flex items-end gap-10 overflow-hidden">
-          {Array.from({ length: 6 }).map((_, index) => (
-            <div key={index} className="flex flex-col items-center gap-2">
-              <div className="h-2.5 w-2.5 rounded-full bg-border animate-pulse" />
-              <div className="h-16 w-32 bg-border rounded animate-pulse" />
+      <div className="grid grid-cols-1 gap-1.5 w-full max-w-full">
+        <div className="relative min-w-0 w-full max-w-full">
+          <div className="flex flex-wrap items-center justify-end absolute right-2 top-16 z-30 gap-0.5">
+            <div className="h-8 w-16 bg-border rounded animate-pulse" />
+            <div className="h-8 w-20 bg-border rounded animate-pulse" />
+          </div>
+          <div className="min-w-0 w-full max-w-full overflow-hidden">
+            <div className="relative w-full" style={{ height: 300 }}>
+              <div className="relative h-7 border-b border-border">
+                {[2, 34, 66].map((left, i) => (
+                  <div
+                    key={i}
+                    className="absolute top-0 h-7 flex items-center"
+                    style={{ left: `${left}%` }}
+                  >
+                    <div className="h-2.5 w-14 bg-border rounded animate-pulse" />
+                  </div>
+                ))}
+              </div>
+
+              <div className="relative h-8 border-b border-border">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="absolute top-1"
+                    style={{ left: `${i * 12.5 + 1}%` }}
+                  >
+                    <div className="h-2.5 w-4 bg-border rounded animate-pulse" />
+                  </div>
+                ))}
+              </div>
+
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div
+                  key={`line-${i}`}
+                  className="absolute w-px bg-border/40"
+                  style={{ left: `${i * 12.5 + 1}%`, top: 60, bottom: 0 }}
+                />
+              ))}
+
+              <div className="absolute left-0 right-0" style={{ top: 64 }}>
+                {[8, 24, 42, 58, 74, 90].map((left, index) => (
+                  <div
+                    key={index}
+                    className="absolute"
+                    style={{ left: `${left}%`, transform: "translateX(-50%)" }}
+                  >
+                    <div className="flex flex-col items-center">
+                      <div className="h-2.5 w-2.5 rounded-full bg-border animate-pulse" />
+                      <div className="w-px h-3 bg-border" />
+                      <div className="w-[168px] border border-border bg-card app-radius-md px-2.5 py-2 space-y-1.5">
+                        <div className="h-3 w-3/4 bg-border rounded animate-pulse" />
+                        <div className="h-2.5 w-1/2 bg-border rounded animate-pulse" />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-          ))}
+          </div>
         </div>
       </div>
     );
@@ -2520,23 +2571,70 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
 
 function TablesSkeleton() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-      {Array.from({ length: 8 }).map((_, index) => (
-        <Card key={index} className="bg-card/50 backdrop-blur-sm border-border">
-          <CardHeader className="pb-3">
-            <div className="h-5 w-3/4 bg-border rounded animate-pulse" />
-          </CardHeader>
-          <CardContent className="pb-3">
-            <div className="space-y-2">
-              <div className="h-4 w-full bg-border rounded animate-pulse" />
-              <div className="h-4 w-5/6 bg-border rounded animate-pulse" />
+    <div>
+      {/* Tab bar: simple flow layout sized to match the real ~44px tab strip */}
+      <div className="sticky top-0 left-0 mb-6 z-40">
+        <div className="flex items-center gap-1 px-1 pt-2 bg-muted border border-border border-b-0">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div
+              key={i}
+              className={`px-4 py-2.5 min-w-[110px] rounded-t-lg border-2 border-b-0 ${
+                i === 0 ? "border-border bg-card" : "border-transparent"
+              }`}
+            >
+              <div className="h-4 w-16 bg-border rounded animate-pulse" />
             </div>
-          </CardContent>
-          <CardFooter className="pt-3 border-t border-border">
-            <div className="h-4 w-24 bg-border rounded animate-pulse" />
-          </CardFooter>
-        </Card>
-      ))}
+          ))}
+        </div>
+        <div className="h-[2px] bg-border" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 w-full max-w-full">
+        <div className="flex flex-wrap gap-y-2 gap-x-4 items-start sm:items-center justify-between">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <div className="relative flex-1 min-w-0 md:max-w-md">
+              <div className="h-9 w-full bg-border rounded animate-pulse" />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 w-auto justify-end">
+            <div className="hidden sm:flex h-9 items-center border border-border app-radius-lg overflow-hidden">
+              <div className="h-9 w-10 bg-border animate-pulse" />
+              <div className="h-9 w-10 bg-border animate-pulse border-l border-r border-border" />
+              <div className="h-9 w-10 bg-border animate-pulse" />
+            </div>
+            <div className="h-9 w-28 bg-border rounded-lg animate-pulse" />
+            <div className="h-9 w-9 bg-border rounded-lg animate-pulse" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Card
+              key={index}
+              className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px]"
+            >
+              <CardHeader className="pb-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="h-5 w-3/4 bg-border rounded animate-pulse" />
+                  <div className="h-5 w-5 bg-border rounded animate-pulse" />
+                </div>
+              </CardHeader>
+              <CardContent className="flex-grow flex-1">
+                <div className="space-y-2">
+                  <div className="h-4 w-full bg-border rounded animate-pulse" />
+                  <div className="h-4 w-5/6 bg-border rounded animate-pulse" />
+                  <div className="h-4 w-4/6 bg-border rounded animate-pulse" />
+                </div>
+              </CardContent>
+              <CardFooter className="py-4 flex items-center justify-between border-t border-border">
+                <div className="h-4 w-24 bg-border rounded animate-pulse" />
+                <div className="h-9 w-12 bg-border rounded animate-pulse" />
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/home/[id]/loading.tsx
+++ b/app/home/[id]/loading.tsx
@@ -1,104 +1,87 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
-
-function Skeleton({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-border app-radius-md animate-pulse ${className}`} />
-  );
-}
-
-function TabsSkeleton({ count }: { count: number }) {
-  return (
-    <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-      <div className="inline-flex items-center gap-3 p-1 bg-card/90 backdrop-blur-sm app-radius-lg border border-border">
-        {Array.from({ length: count }).map((_, i) => (
-          <div key={i} className="px-6 py-2.5 app-radius-lg bg-muted/30">
-            <Skeleton className="h-5 w-24" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function NotesGridSkeleton({ count }: { count: number }) {
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-      {Array.from({ length: count }).map((_, i) => (
-        <div
-          key={i}
-          className="app-radius-xl border border-border bg-card/90 backdrop-blur-sm overflow-hidden min-h-[230px] flex flex-col"
-        >
-          <div className="p-4 pb-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex-1 min-w-0 space-y-2">
-                <Skeleton className="h-5 w-2/3" />
-                <Skeleton className="h-3 w-1/2" />
-              </div>
-              <Skeleton className="h-6 w-6" />
-            </div>
-          </div>
-          <div className="px-4 flex-grow flex-1 space-y-2">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-5/6" />
-            <Skeleton className="h-4 w-4/6" />
-          </div>
-          <div className="px-4 py-4 border-t border-border flex items-center justify-between">
-            <Skeleton className="h-3 w-24" />
-            <Skeleton className="h-9 w-12" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/components/ui/card";
 
 export default function Loading() {
   return (
-    <MaxWContainer className="my-5">
-      <header className="pb-5">
-        <div className="relative overflow-hidden app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8">
-          <div className="relative flex flex-col gap-4">
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex-1">
-                <Skeleton className="h-10 w-72 mb-3" />
-                <div className="flex items-center gap-4 text-sm">
-                  <span className="flex items-center gap-2 px-3 py-1 rounded-full backdrop-blur-sm">
-                    <Skeleton className="h-4 w-20" />
-                  </span>
-                </div>
-              </div>
-              <Skeleton className="h-10 w-36 app-radius-lg" />
-            </div>
+    <MaxWContainer className="my-5 grid grid-cols-1">
+      <header>
+        <div className="relative flex justify-between items-end w-full">
+          <div className="flex-1 px-1.5 border border-border bg-muted app-radius-md">
+            <h1 className="text-3xl md:text-5xl font-bol my-4 h-[3rem]">
+              <div className="bg-border app-radius-md animate-pulse h-10 w-64 inline-block" />
+            </h1>
           </div>
         </div>
       </header>
 
-      <div className="mt-6 mb-6">
-        <TabsSkeleton count={5} />
-      </div>
-
-      <div className="space-y-6">
-        <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
-          <div className="flex items-center gap-3 flex-1 w-full sm:w-auto">
-            <div className="relative flex-1 max-w-md w-full">
-              <Skeleton className="h-10 w-full" />
-            </div>
+      <div>
+        {/* Tab bar: simple flow layout sized to match the real ~44px tab strip */}
+        <div className="sticky top-0 left-0 mb-6 z-40">
+          <div className="flex items-center gap-1 px-1 pt-2 bg-muted border border-border border-b-0">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div
+                key={i}
+                className={`px-4 py-2.5 min-w-[110px] rounded-t-lg border-2 border-b-0 ${
+                  i === 0 ? "border-border bg-card" : "border-transparent"
+                }`}
+              >
+                <div className="h-4 w-16 bg-border rounded animate-pulse" />
+              </div>
+            ))}
           </div>
-
-          <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
-            <div className="hidden sm:flex items-center border border-border app-radius-lg overflow-hidden">
-              <Skeleton className="h-9 w-10 rounded-none" />
-              <Skeleton className="h-9 w-10 rounded-none" />
-            </div>
-            <Skeleton className="h-9 w-28 app-radius-lg" />
-            <Skeleton className="h-9 w-10 app-radius-lg" />
-          </div>
+          <div className="h-[2px] bg-border" />
         </div>
 
-        <NotesGridSkeleton count={6} />
+        <div className="grid grid-cols-1 gap-6 w-full max-w-full">
+          <div className="flex flex-wrap gap-y-2 gap-x-4 items-start sm:items-center justify-between">
+            <div className="flex items-center gap-3 flex-1 min-w-0">
+              <div className="relative flex-1 min-w-0 md:max-w-md">
+                <div className="h-9 w-full bg-border rounded animate-pulse" />
+              </div>
+            </div>
 
-        <div className="flex justify-center pt-2">
-          <Skeleton className="h-10 w-28 app-radius-lg" />
+            <div className="flex items-center gap-2 w-auto justify-end">
+              <div className="hidden sm:flex h-9 items-center border border-border app-radius-lg overflow-hidden">
+                <div className="h-9 w-10 bg-border animate-pulse" />
+                <div className="h-9 w-10 bg-border animate-pulse border-l border-r border-border" />
+                <div className="h-9 w-10 bg-border animate-pulse" />
+              </div>
+              <div className="h-9 w-28 bg-border rounded-lg animate-pulse" />
+              <div className="h-9 w-9 bg-border rounded-lg animate-pulse" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <Card
+                key={index}
+                className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px]"
+              >
+                <CardHeader className="pb-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="h-5 w-3/4 bg-border rounded animate-pulse" />
+                    <div className="h-5 w-5 bg-border rounded animate-pulse" />
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow flex-1">
+                  <div className="space-y-2">
+                    <div className="h-4 w-full bg-border rounded animate-pulse" />
+                    <div className="h-4 w-5/6 bg-border rounded animate-pulse" />
+                    <div className="h-4 w-4/6 bg-border rounded animate-pulse" />
+                  </div>
+                </CardContent>
+                <CardFooter className="py-4 flex items-center justify-between border-t border-border">
+                  <div className="h-4 w-24 bg-border rounded animate-pulse" />
+                  <div className="h-9 w-12 bg-border rounded animate-pulse" />
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
     </MaxWContainer>


### PR DESCRIPTION
### what changed

before : 
<img width="1268" height="503" alt="image" src="https://github.com/user-attachments/assets/bdec1098-8b56-49d0-ace9-49890a7b5c6a" />

after : 
<img width="1269" height="789" alt="image" src="https://github.com/user-attachments/assets/7991d559-e939-43a9-b737-a21925d340ae" />


* Reworked the loading skeleton for the **Calendar Timeline** view to closely match the actual timeline layout, including the header, date markers, timeline lines, controls, and note cards.
* Redesigned the **Tables** loading skeleton to better reflect the real interface by adding:

  * The tab bar
  * Search and toolbar controls
  * View toggle placeholders
  * More realistic table cards with headers, content, and footer actions
* Updated the workspace `loading.tsx` page to use the same improved loading experience, replacing the old generic skeletons with layouts that closely mirror the final UI.
* Reused the existing `Card` components for the loading state so the skeletons match the production layout more accurately.

The previous loading states were very generic and didn't resemble the actual workspace views, causing noticeable layout shifts once the content loaded. This made the application feel less polished and made it harder for users to anticipate where content would appear.

