### PR TITLE
add quick delete action for editor blocks

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -36,7 +36,7 @@ import {
 import { CompactFloatingToC } from "./ToC";
 import { useMediaQuery } from "react-responsive";
 import { Dialog, DialogContent } from "./ui/dialog";
-import { Plus } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { LinkHoverCard } from "./link-hover-card";
 import {
   Tooltip,
@@ -192,6 +192,25 @@ const TailwindAdvancedEditor = ({
     ...defaultExtensions,
     slashCommand,
   ];
+  const deleteCurrentNode = (editor: EditorInstance) => {
+    const { selection } = editor.state;
+    const $from = selection.$from;
+
+    const depth = $from.depth >= 1 ? 1 : $from.depth;
+    const nodeStart = $from.before(depth);
+    const node = editor.state.doc.nodeAt(nodeStart);
+
+    if (!node) return;
+
+    editor
+      .chain()
+      .focus()
+      .deleteRange({
+        from: nodeStart,
+        to: nodeStart + node.nodeSize,
+      })
+      .run();
+  };
   return (
     <>
       <EditorRoot>
@@ -201,7 +220,7 @@ const TailwindAdvancedEditor = ({
               <LinkHoverCard editor={editorInstance} disabled={openLink} />
               <TableControls editor={editorInstance} />
               <DragHandle editor={editorInstance}>
-                <div className="lg:flex items-center justify-center hidden">
+                <div className="lg:flex items-center justify-center hidden mr-5">
                   {!renderedInPane && (
                     <Tooltip delayDuration={150} disableHoverableContent>
                       <TooltipTrigger asChild>
@@ -218,10 +237,37 @@ const TailwindAdvancedEditor = ({
                             );
                           }}
                         >
-                          <Plus className="h-4 w-4 " />
+                          <Plus strokeWidth={3.5} className="h-4 w-4 " />
                         </button>
                       </TooltipTrigger>
+                      {/* Delete Block */}
+                      <Tooltip delayDuration={150} disableHoverableContent>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label="Delete block"
+                            className=" group flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              deleteCurrentNode(editorInstance);
+                            }}
+                          >
+                            <X
+                              strokeWidth={3.5}
+                              className="h-3.5 w-3.5 group-hover:text-destructive"
+                            />
+                          </button>
+                        </TooltipTrigger>
 
+                        <TooltipContent
+                          side="left"
+                          align="center"
+                          className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
+                        >
+                          <p>Delete block</p>
+                        </TooltipContent>
+                      </Tooltip>
                       <TooltipContent
                         side="left"
                         align="center"


### PR DESCRIPTION
### what changed

i thing this is cool : 
<img width="891" height="147" alt="image" src="https://github.com/user-attachments/assets/192bc41e-764a-4f61-8d01-49d14cbcf15d" />
<img width="978" height="170" alt="image" src="https://github.com/user-attachments/assets/df33a81e-1a38-4fa5-b347-d16af42f3f89" />

* Added a new **Delete block** action next to the existing insert (`+`) and drag controls in the editor's block handle.
* Implemented block deletion by removing the currently selected top-level node directly from the editor.
* Added a tooltip for the new action and updated the icon styling to better distinguish insert and delete actions.
* Slightly adjusted the drag handle layout to accommodate the additional control.


Deleting a block previously required using keyboard shortcuts or other editor interactions, which wasn't very discoverable. Adding a dedicated delete button makes the action much more accessible and keeps the most common block actions in one place.

* Users can delete blocks with a single click without relying on the keyboard.
* Block controls are more complete by grouping **insert**, **delete**, and **drag** actions together.
