### PR TITLE
improve block actions in pane editor

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -220,7 +220,37 @@ const TailwindAdvancedEditor = ({
               <LinkHoverCard editor={editorInstance} disabled={openLink} />
               <TableControls editor={editorInstance} />
               <DragHandle editor={editorInstance}>
-                <div className="lg:flex items-center justify-center hidden mr-5">
+                <div
+                  className={`lg:flex items-center justify-center hidden ${!renderedInPane && "mr-5"}`}
+                >
+                  {/* Delete Block */}
+                  <Tooltip delayDuration={150} disableHoverableContent>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Delete block"
+                        className=" group flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          deleteCurrentNode(editorInstance);
+                        }}
+                      >
+                        <X
+                          strokeWidth={2.7}
+                          className="h-3.5 w-3.5 group-hover:text-destructive"
+                        />
+                      </button>
+                    </TooltipTrigger>
+
+                    <TooltipContent
+                      side="left"
+                      align="center"
+                      className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
+                    >
+                      <p>Delete block</p>
+                    </TooltipContent>
+                  </Tooltip>
                   {!renderedInPane && (
                     <Tooltip delayDuration={150} disableHoverableContent>
                       <TooltipTrigger asChild>
@@ -237,37 +267,10 @@ const TailwindAdvancedEditor = ({
                             );
                           }}
                         >
-                          <Plus strokeWidth={3.5} className="h-4 w-4 " />
+                          <Plus strokeWidth={3} className="h-4 w-4 " />
                         </button>
                       </TooltipTrigger>
-                      {/* Delete Block */}
-                      <Tooltip delayDuration={150} disableHoverableContent>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            aria-label="Delete block"
-                            className=" group flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
-                            onMouseDown={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                              deleteCurrentNode(editorInstance);
-                            }}
-                          >
-                            <X
-                              strokeWidth={3.5}
-                              className="h-3.5 w-3.5 group-hover:text-destructive"
-                            />
-                          </button>
-                        </TooltipTrigger>
 
-                        <TooltipContent
-                          side="left"
-                          align="center"
-                          className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
-                        >
-                          <p>Delete block</p>
-                        </TooltipContent>
-                      </Tooltip>
                       <TooltipContent
                         side="left"
                         align="center"


### PR DESCRIPTION
### what changed
before : 
![Uploading image.png…]()


* Moved the **Delete block** action so it's always available in the editor, including when rendering inside a pane.
* Updated the block handle spacing to only apply the extra right margin when the insert (`+`) button is shown.
* Fine-tuned the delete icon styling by slightly reducing its stroke width for better visual balance.

The delete action was previously grouped with controls that are hidden in pane mode, making it unavailable when editing content inside a pane. This change separates it from the pane-specific logic so it's consistently accessible across both editor layouts.
