### PR TITLE
fix block deletion & improve link hover responsiveness

### DIFF
--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -192,12 +192,20 @@ const TailwindAdvancedEditor = ({
     ...defaultExtensions,
     slashCommand,
   ];
-  const deleteCurrentNode = (editor: EditorInstance) => {
-    const { selection } = editor.state;
-    const $from = selection.$from;
+  const deleteTargetNode = (editor: EditorInstance, buttonEl: HTMLElement) => {
+    const editorView = (editor as any).view;
+    const rect = buttonEl.getBoundingClientRect();
+    const posAtCoords = editorView.posAtCoords({
+      left: rect.right + 40,
+      top: rect.top + rect.height / 2,
+    });
 
-    const depth = $from.depth >= 1 ? 1 : $from.depth;
-    const nodeStart = $from.before(depth);
+    if (!posAtCoords) return;
+    const $pos = editor.state.doc.resolve(posAtCoords.pos);
+    const depth = $pos.depth > 0 ? $pos.depth : 1;
+    if (depth === 0 || $pos.node(depth) === editor.state.doc) return;
+
+    const nodeStart = $pos.before(depth);
     const node = editor.state.doc.nodeAt(nodeStart);
 
     if (!node) return;
@@ -211,6 +219,7 @@ const TailwindAdvancedEditor = ({
       })
       .run();
   };
+
   return (
     <>
       <EditorRoot>
@@ -229,11 +238,11 @@ const TailwindAdvancedEditor = ({
                       <button
                         type="button"
                         aria-label="Delete block"
-                        className=" group flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
+                        className="group flex h-5 w-5 mt-0.5 items-center justify-center text-muted-foreground rounded-none opacity-50 transition-colors hover:bg-border"
                         onMouseDown={(event) => {
                           event.preventDefault();
                           event.stopPropagation();
-                          deleteCurrentNode(editorInstance);
+                          deleteTargetNode(editorInstance, event.currentTarget);
                         }}
                       >
                         <X
@@ -251,6 +260,7 @@ const TailwindAdvancedEditor = ({
                       <p>Delete block</p>
                     </TooltipContent>
                   </Tooltip>
+
                   {!renderedInPane && (
                     <Tooltip delayDuration={150} disableHoverableContent>
                       <TooltipTrigger asChild>

--- a/components/link-hover-card.tsx
+++ b/components/link-hover-card.tsx
@@ -23,7 +23,7 @@ type HoveredLinkState = {
   left: number;
 };
 
-const HIDE_DELAY_MS = 120;
+const HIDE_DELAY_MS = 16;
 const COPY_FEEDBACK_MS = 1600;
 const CARD_WIDTH_PX = 320;
 


### PR DESCRIPTION
### what changed

* Updated the block deletion logic to target the block associated with the clicked delete button instead of relying on the editor's current selection.
* Resolved the editor position from the delete button's location, ensuring the correct block is identified and removed.
* Cleaned up the delete button implementation with minor formatting improvements.
* Reduced the link hover card hide delay from **120ms** to **16ms** for a much more responsive interaction.

The previous delete implementation depended on the current text selection, which could delete the wrong block if the selection didn't match the block being hovered. The link preview also remained visible slightly longer than necessary, making the interaction feel less responsive.


* Clicking **Delete block** always removes the block you're interacting with, making the action much more reliable.
* Link hover cards disappear almost instantly when the cursor leaves, making the editor feel more responsive and polished.
* Overall, interactions in the editor are more predictable and provide a smoother editing experience.
