### PR TITLE
improve toggle action interactions

### DIFF
--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Node, mergeAttributes } from "@tiptap/core";
 import {
   NodeViewContent,
@@ -9,7 +9,12 @@ import {
   ReactNodeViewRenderer,
 } from "@tiptap/react";
 import { ChevronDown, ChevronRight, Blocks } from "lucide-react";
-
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useHoverTooltip } from "@/hooks/useHoverTooltip";
 const DEFAULT_TOGGLE_TITLE = "toggle action";
 
 function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
@@ -23,13 +28,26 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
   useEffect(() => {
     setDraftTitle(title);
   }, [title]);
-
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleTooltip = useHoverTooltip(100);
+  const toggleTooltip = useHoverTooltip(100);
   const saveTitle = () => {
     const nextTitle = draftTitle.trim() || DEFAULT_TOGGLE_TITLE;
     updateAttributes({ title: nextTitle });
     setDraftTitle(nextTitle);
     setIsEditingTitle(false);
   };
+  const handleDoubleClick = useCallback(() => {
+    setIsEditingTitle(true);
+    requestAnimationFrame(() => {
+      const input = inputRef.current;
+      if (!input) return;
+      input.focus();
+      input.select();
+      input.scrollLeft = 0;
+    });
+    titleTooltip.hide();
+  }, [isEditingTitle, titleTooltip.open]);
 
   return (
     <NodeViewWrapper
@@ -40,26 +58,47 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
         contentEditable={false}
         className="flex min-h-10 items-center gap-2 px-3 py-2"
       >
-        <button
-          type="button"
-          aria-label={
-            isOpen ? "Collapse toggle action" : "Expand toggle action"
-          }
-          className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
-          onClick={() => updateAttributes({ open: !isOpen })}
-        >
-          {isOpen ? (
-            <ChevronDown className="h-4 w-4" />
-          ) : (
-            <ChevronRight className="h-4 w-4" />
-          )}
-        </button>
+        <Tooltip open={toggleTooltip.open} disableHoverableContent>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => {
+                updateAttributes({ open: !isOpen });
+                toggleTooltip.hide();
+              }}
+              aria-label="toggle action"
+              {...toggleTooltip.triggerProps}
+            >
+              {isOpen ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+            </button>
+          </TooltipTrigger>
+
+          <TooltipContent
+            side="bottom"
+            align="start"
+            sideOffset={10}
+            className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
+          >
+            <p>{isOpen ? "Collapse toggle action" : "Expand toggle action"}</p>
+          </TooltipContent>
+        </Tooltip>
+
         {isEditingTitle ? (
           <input
+            ref={inputRef}
             autoFocus
             value={draftTitle}
-            onChange={(event) => setDraftTitle(event.target.value)}
+            onChange={(event) => {
+              setDraftTitle(event.target.value);
+              titleTooltip.hide();
+            }}
             onBlur={saveTitle}
+            placeholder="Rename"
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
@@ -70,19 +109,33 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
                 setDraftTitle(title);
                 setIsEditingTitle(false);
               }
+              titleTooltip.hide();
             }}
             className="min-w-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none"
           />
         ) : (
-          <button
-            type="button"
-            title="Double click to rename"
-            className="min-w-0 truncate text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-            onDoubleClick={() => setIsEditingTitle(true)}
-            onClick={() => updateAttributes({ open: !isOpen })}
-          >
-            {title}
-          </button>
+          <Tooltip open={titleTooltip.open} disableHoverableContent>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="min-w-0 truncate text-left text-sm cursor-text font-medium text-muted-foreground"
+                onDoubleClick={handleDoubleClick}
+                aria-label="Double click to rename"
+                {...titleTooltip.triggerProps}
+              >
+                {title}
+              </button>
+            </TooltipTrigger>
+
+            <TooltipContent
+              side="bottom"
+              align="start"
+              sideOffset={10}
+              className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
+            >
+              <p>Double click to rename</p>
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
       <NodeViewContent


### PR DESCRIPTION
### what changed
<img width="875" height="136" alt="image" src="https://github.com/user-attachments/assets/6da3ba7f-fa37-4182-a5ac-d68f9e8de455" />
<img width="813" height="117" alt="image" src="https://github.com/user-attachments/assets/4cf2cc1b-db32-48e3-b64c-86db4892eaf1" />

* Added tooltips to the toggle expand/collapse button and the toggle title to make their actions more discoverable.
* Improved the rename flow by automatically focusing and selecting the title when entering edit mode.
* Added a placeholder while renaming and cleaned up the editing behavior by hiding tooltips during interactions.
* Extracted the rename logic into a dedicated callback to simplify the component and keep the editing flow consistent.
* Updated the toggle title styling to better communicate that it's editable.


The toggle action relied on users discovering interactions like double-clicking to rename or using the expand/collapse button without much guidance. Renaming also required extra clicks before editing could begin. These changes make the component more intuitive and reduce friction when working with toggle blocks.

* The overall toggle action experience is more polished, discoverable, and user-friendly.
