### PR TITLE
add toggle appearance customization

### DIFF
--- a/components/link-hover-card.tsx
+++ b/components/link-hover-card.tsx
@@ -23,7 +23,7 @@ type HoveredLinkState = {
   left: number;
 };
 
-const HIDE_DELAY_MS = 16;
+const HIDE_DELAY_MS = 0;
 const COPY_FEEDBACK_MS = 1600;
 const CARD_WIDTH_PX = 320;
 
@@ -38,6 +38,7 @@ export function LinkHoverCard({
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const hideTimerRef = useRef<number | null>(null);
   const copiedTimerRef = useRef<number | null>(null);
+  const isPinnedRef = useRef(false);
   const clearHideTimer = useCallback(() => {
     if (hideTimerRef.current !== null) {
       window.clearTimeout(hideTimerRef.current);
@@ -54,12 +55,14 @@ export function LinkHoverCard({
 
   const hideCard = useCallback(() => {
     clearHideTimer();
+    isPinnedRef.current = false;
     hoveredAnchorRef.current = null;
     setCopied(false);
     setHoveredLink(null);
   }, [clearHideTimer]);
 
   const scheduleHide = useCallback(() => {
+    if (isPinnedRef.current) return;
     clearHideTimer();
     hideTimerRef.current = window.setTimeout(() => {
       hoveredAnchorRef.current = null;
@@ -143,9 +146,42 @@ export function LinkHoverCard({
       scheduleHide();
     };
 
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+
+      const anchor = target.closest("a.novel-link");
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+
+      clearHideTimer();
+      isPinnedRef.current = true;
+      hoveredAnchorRef.current = anchor;
+      updateCardPosition(anchor);
+    };
+
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      if (!isPinnedRef.current) return;
+
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+
+      if (popoverRef.current?.contains(target)) return;
+      if (hoveredAnchorRef.current?.contains(target)) return;
+
+      hideCard();
+    };
+
     const handleViewportChange = () => {
       if (!hoveredAnchorRef.current) return;
       updateCardPosition(hoveredAnchorRef.current);
+    };
+
+    const handleScroll = () => {
+      if (isPinnedRef.current) {
+        hideCard();
+        return;
+      }
+      handleViewportChange();
     };
 
     const handleEscape = (event: KeyboardEvent) => {
@@ -156,14 +192,18 @@ export function LinkHoverCard({
 
     editorElement.addEventListener("mouseover", handleMouseOver);
     editorElement.addEventListener("mouseout", handleMouseOut);
-    window.addEventListener("scroll", handleViewportChange, true);
+    editorElement.addEventListener("click", handleClick);
+    document.addEventListener("mousedown", handleDocumentMouseDown, true);
+    window.addEventListener("scroll", handleScroll, true);
     window.addEventListener("resize", handleViewportChange);
     window.addEventListener("keydown", handleEscape);
 
     return () => {
       editorElement.removeEventListener("mouseover", handleMouseOver);
       editorElement.removeEventListener("mouseout", handleMouseOut);
-      window.removeEventListener("scroll", handleViewportChange, true);
+      editorElement.removeEventListener("click", handleClick);
+      document.removeEventListener("mousedown", handleDocumentMouseDown, true);
+      window.removeEventListener("scroll", handleScroll, true);
       window.removeEventListener("resize", handleViewportChange);
       window.removeEventListener("keydown", handleEscape);
       clearHideTimer();

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -8,14 +8,163 @@ import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
-import { ChevronDown, ChevronRight, Blocks } from "lucide-react";
+import { ChevronDown, ChevronRight, Blocks, Palette, Ban } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Slider } from "@/components/ui/slider";
+import { Separator } from "@/components/ui/separator";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import { Input } from "./ui/input";
+import { cn } from "@/lib/utils";
+
 const DEFAULT_TOGGLE_TITLE = "toggle action";
+
+type ToggleStyle = {
+  bgColor: string | null;
+  bgOpacity: number;
+};
+
+const DEFAULT_STYLE: ToggleStyle = {
+  bgColor: null,
+  bgOpacity: 100,
+};
+
+const SWATCHES: { name: string; light: string; dark: string }[] = [
+  { name: "purple", light: "#7c3aed", dark: "#a78bfa" },
+  { name: "rose", light: "#e11d48", dark: "#fb7185" },
+  { name: "blue", light: "#2563eb", dark: "#60a5fa" },
+  { name: "green", light: "#15803d", dark: "#4ade80" },
+  { name: "orange", light: "#c2410c", dark: "#fb923c" },
+  { name: "pink", light: "#be185d", dark: "#f472b6" },
+  { name: "slate", light: "#475569", dark: "#94a3b8" },
+];
+
+function resolveSwatch(name: string | null, isDark: boolean) {
+  if (!name) return null;
+  const swatch = SWATCHES.find((entry) => entry.name === name);
+  if (!swatch) return null;
+  return isDark ? swatch.dark : swatch.light;
+}
+
+function generateId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `toggle-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function storageKey(id: string) {
+  return `toggle-action-style:${id}`;
+}
+
+function hexToRgbComponents(hex: string) {
+  const normalized = hex.replace("#", "");
+  const bigint = parseInt(normalized, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+}
+
+function hexToRgba(hex: string, opacityPercent: number) {
+  const { r, g, b } = hexToRgbComponents(hex);
+  const alpha = Math.min(100, Math.max(0, opacityPercent)) / 100;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+const MAX_BG_OPACITY = 70;
+
+function getReadableTextColor(
+  hex: string,
+  opacityPercent: number,
+  isDark: boolean,
+) {
+  const { r, g, b } = hexToRgbComponents(hex);
+  const alpha = Math.min(100, Math.max(0, opacityPercent)) / 100;
+  const base = isDark ? 0 : 255;
+  const blendedR = r * alpha + base * (1 - alpha);
+  const blendedG = g * alpha + base * (1 - alpha);
+  const blendedB = b * alpha + base * (1 - alpha);
+  const luminance =
+    (0.299 * blendedR + 0.587 * blendedG + 0.114 * blendedB) / 255;
+  return luminance > 0.55 ? "#1a1a1a" : "#f5f5f5";
+}
+
+function useIsDarkMode() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const update = () => setIsDark(root.classList.contains("dark"));
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}
+
+function ColorRow({
+  label,
+  value,
+  isDark,
+  onChange,
+}: {
+  label: string;
+  value: string | null;
+  isDark: boolean;
+  onChange: (value: string | null) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="No color"
+          onClick={() => onChange(null)}
+          className={cn(
+            "h-5 w-5 !rounded text-muted-foreground hover:bg-transparent hover:text-foreground",
+            value === null && "outline-1 outline-muted-foreground",
+          )}
+        >
+          <Ban className="h-5 w-5" />
+        </Button>
+        {SWATCHES.map((swatch) => (
+          <Button
+            key={swatch.name}
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={swatch.name}
+            onClick={() => onChange(swatch.name)}
+            style={{ backgroundColor: isDark ? swatch.dark : swatch.light }}
+            className={cn(
+              "h-5 w-5 !rounded p-0 transition-transform hover:scale-110",
+              value === swatch.name && " outline-1 outline-muted-foreground",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -31,6 +180,61 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const titleTooltip = useHoverTooltip(100);
   const toggleTooltip = useHoverTooltip(100);
+  const customTooltip = useHoverTooltip(100);
+  const isDark = useIsDarkMode();
+
+  const [style, setStyle] = useState<ToggleStyle>(DEFAULT_STYLE);
+
+  useEffect(() => {
+    if (!node.attrs.id) {
+      updateAttributes({ id: generateId() });
+    }
+  }, [node.attrs.id, updateAttributes]);
+
+  // Load any previously saved appearance for this toggle.
+  useEffect(() => {
+    const id = node.attrs.id;
+    if (!id || typeof window === "undefined") return;
+
+    try {
+      const raw = window.localStorage.getItem(storageKey(id));
+      if (raw) {
+        setStyle({ ...DEFAULT_STYLE, ...JSON.parse(raw) });
+      }
+    } catch {
+      // Ignore malformed or inaccessible storage.
+    }
+  }, [node.attrs.id]);
+
+  const persistStyle = useCallback(
+    (next: ToggleStyle) => {
+      setStyle(next);
+      const id = node.attrs.id;
+      if (!id || typeof window === "undefined") return;
+
+      try {
+        window.localStorage.setItem(storageKey(id), JSON.stringify(next));
+      } catch {
+        // Ignore storage errors (quota exceeded, private mode, etc.).
+      }
+    },
+    [node.attrs.id],
+  );
+
+  const resolvedBgColor = resolveSwatch(style.bgColor, isDark);
+  const effectiveOpacity = (style.bgOpacity / 100) * MAX_BG_OPACITY;
+
+  const wrapperStyle = {
+    backgroundColor: resolvedBgColor
+      ? hexToRgba(resolvedBgColor, effectiveOpacity)
+      : undefined,
+  };
+
+  const contrastColor = resolvedBgColor
+    ? getReadableTextColor(resolvedBgColor, effectiveOpacity, isDark)
+    : undefined;
+  const contrastStyle = contrastColor ? { color: contrastColor } : undefined;
+
   const saveTitle = () => {
     const nextTitle = draftTitle.trim() || DEFAULT_TOGGLE_TITLE;
     updateAttributes({ title: nextTitle });
@@ -52,7 +256,8 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
   return (
     <NodeViewWrapper
       data-toggle-action
-      className="my-3 rounded-tl-lg border border-border bg-muted/20 text-foreground transition-colors"
+      style={wrapperStyle}
+      className="my-3 rounded-tl-lg border border-border bg-muted/20 text-foreground transition-colors group"
     >
       <div
         contentEditable={false}
@@ -60,9 +265,12 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
       >
         <Tooltip open={toggleTooltip.open} disableHoverableContent>
           <TooltipTrigger asChild>
-            <button
+            <Button
               type="button"
-              className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+              variant="Trigger"
+              size="icon"
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+              style={contrastStyle}
               onClick={() => {
                 updateAttributes({ open: !isOpen });
                 toggleTooltip.hide();
@@ -75,7 +283,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               ) : (
                 <ChevronRight className="h-4 w-4" />
               )}
-            </button>
+            </Button>
           </TooltipTrigger>
 
           <TooltipContent
@@ -89,7 +297,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
         </Tooltip>
 
         {isEditingTitle ? (
-          <input
+          <Input
             ref={inputRef}
             autoFocus
             value={draftTitle}
@@ -111,13 +319,15 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               }
               titleTooltip.hide();
             }}
-            className="min-w-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none"
+            style={contrastStyle}
+            className="min-w-0 h-6 !p-0 !m-0 !border-0 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none"
           />
         ) : (
           <Tooltip open={titleTooltip.open} disableHoverableContent>
             <TooltipTrigger asChild>
               <button
                 type="button"
+                style={contrastStyle}
                 className="min-w-0 truncate text-left text-sm cursor-text font-medium text-muted-foreground"
                 onDoubleClick={handleDoubleClick}
                 aria-label="Double click to rename"
@@ -137,6 +347,72 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
             </TooltipContent>
           </Tooltip>
         )}
+
+        <div className="ml-auto flex items-center transition-opacity duration-150 ease-in-out opacity-0 group-hover:opacity-100">
+          <Popover>
+            <PopoverTrigger>
+              <Tooltip open={customTooltip.open} disableHoverableContent>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="Trigger"
+                    size="icon"
+                    className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                    style={contrastStyle}
+                    aria-label=""
+                    {...customTooltip.triggerProps}
+                  >
+                    <Palette className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+
+                <TooltipContent
+                  side="bottom"
+                  align="center"
+                  sideOffset={5}
+                  className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
+                >
+                  <p>Customize toggle appearance</p>
+                </TooltipContent>
+              </Tooltip>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              side="bottom"
+              sideOffset={8}
+              className="w-64 space-y-3 p-2"
+            >
+              <ColorRow
+                label="Background color"
+                value={style.bgColor}
+                isDark={isDark}
+                onChange={(value) => persistStyle({ ...style, bgColor: value })}
+              />
+              <Separator />
+              <div className="space-y-2">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Background opacity
+                </p>
+                <div className="flex items-center gap-2">
+                  <Slider
+                    value={[style.bgOpacity]}
+                    min={0}
+                    max={100}
+                    step={1}
+                    disabled={!style.bgColor}
+                    onValueChange={([value]) =>
+                      persistStyle({ ...style, bgOpacity: value })
+                    }
+                    className={cn("flex-1", !style.bgColor && "opacity-40")}
+                  />
+                  <span className="w-8 text-right text-xs text-muted-foreground">
+                    {style.bgOpacity}%
+                  </span>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
       </div>
       <NodeViewContent
         className={`px-5 pb-4 pt-1 ${isOpen ? "block" : "hidden"}`}
@@ -154,6 +430,12 @@ export const ToggleAction = Node.create({
 
   addAttributes() {
     return {
+      id: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-id"),
+        renderHTML: (attributes) =>
+          attributes.id ? { "data-id": attributes.id } : {},
+      },
       open: {
         default: true,
         parseHTML: (element) => element.getAttribute("data-open") !== "false",

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-      "z-50 w-72 app-radius-lg border bg-accent p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 app-radius-lg border border-border bg-accent p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-popover": "^1.1.5",
     "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-separator": "^1.1.2",
+    "@radix-ui/react-slider": "^1.4.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.4",
     "@radix-ui/react-toast": "^1.2.5",


### PR DESCRIPTION
### what changed
<img width="812" height="210" alt="image" src="https://github.com/user-attachments/assets/4879ea9a-b125-4e6f-a347-ab5a61db6ced" />


* Added a customization menu for toggle actions, allowing users to change the toggle's background color and opacity.
* Introduced a set of preset color swatches with support for both light and dark themes.
* Persisted each toggle's appearance using a unique ID and local storage so custom styles are preserved between sessions.
* Automatically adjusted text and icon colors based on the selected background to maintain readability.
* Improved toggle interactions by replacing several native elements with shared UI components (`Button`, `Input`, `Popover`, `Slider`, and `Separator`) for a more consistent experience.
* Enhanced the link hover card by allowing it to stay open after clicking a link and close only when clicking elsewhere or scrolling.
* Updated the shared popover styling with a consistent border and added the Radix Slider dependency to support the new appearance controls.

Toggle actions all looked the same, making it difficult to visually organize different sections of content. This change gives users an easy way to personalize toggles and improve document organization while keeping the UI consistent. It also improves the link preview experience by making it easier to interact with without it disappearing immediately.

* Users can visually distinguish important toggle sections with custom colors.
* Link previews are more reliable and easier to interact with, resulting in a smoother editing experience.
