### PR TITLE
improve search dialog shortcuts

### DIFF
--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -133,11 +133,10 @@ function NoteItem({
       )}
     >
       <FileText size={14} />
-      <div className="flex-1 overflow-hidden flex justify-start items-center gap-2">
+      <div className="flex-1 overflow-hidden">
         <p className="text-sm text-foreground font-medium truncate transition-colors">
           <HighlightedText text={note.title || "Untitled"} query={query} />
         </p>
-        <ShortcutBadge keys="In Pane `Alt + Click`" />
       </div>
       <div className="flex items-center gap-1 text-xs shrink-0 text-muted-foreground">
         <Clock className="h-3 w-3" />
@@ -182,11 +181,10 @@ function PdfItem({
       )}
     >
       <File size={14} />
-      <div className="flex-1 overflow-hidden flex justify-start items-center gap-2">
+      <div className="flex-1 overflow-hidden">
         <p className="text-sm text-foreground font-medium truncate transition-colors">
           <HighlightedText text={pdf.title || "Untitled"} query={query} />
         </p>
-        <ShortcutBadge keys="In Pane `Alt + Click`" />
       </div>
       <div className="flex items-center gap-1 text-xs shrink-0 text-muted-foreground">
         <Clock className="h-3 w-3" />
@@ -658,14 +656,20 @@ export default function SearchDialog({
                 <kbd className="pointer-events-none border border-border inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-background px-2 font-mono text-[11px] font-medium text-muted-foreground">
                   <Undo2 size={14} />
                 </kbd>
-                <p className="text-foreground font-mono text-xs">Open</p>
+                <p className="text-foreground text-xs">Open</p>
+              </span>
+              <span className="flex justify-center items-center gap-2">
+                <kbd className="pointer-events-none border border-border inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-background px-2 font-mono text-[11px] font-medium text-muted-foreground">
+                  Alt + click
+                </kbd>
+                <p className="text-foreground text-xs">Open in pane</p>
               </span>
             </span>
             <span className="flex justify-center items-center gap-2">
               <kbd className="pointer-events-none border border-border inline-flex h-6 select-none items-center gap-1.5 rounded-md bg-background px-2 font-mono text-[11px] font-medium text-muted-foreground">
                 ESC
               </kbd>
-              <p className="text-foreground font-mono text-xs">Close</p>
+              <p className="text-foreground  text-xs">Close</p>
             </span>
           </div>
         </DialogFooter>


### PR DESCRIPTION
### what changed
before : 
<img width="920" height="626" alt="image" src="https://github.com/user-attachments/assets/a06d4a49-b382-42b8-93c6-be5a2204ea5b" />


now : 
<img width="929" height="640" alt="image" src="https://github.com/user-attachments/assets/1424687d-d636-4090-8ca7-dc0253ac1c6e" />


* Moved the **Open in pane** shortcut hint from individual search results to the footer of the search dialog.
* Added a dedicated **Alt + Click** keyboard hint alongside the existing shortcuts.
* Simplified the search result layout by removing the inline shortcut badges, giving titles more room.
* Cleaned up the footer shortcut labels for a more consistent appearance.

Showing the shortcut on every search result added unnecessary visual noise and reduced the space available for note and PDF titles. Moving the hint to the footer keeps the feature discoverable while making the results easier to scan.

