### PR TITLE
refresh button styles and workspace ui

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -876,9 +876,9 @@ export default function WorkingSpacePageClient({
   return (
     <MaxWContainer className="my-5 grid grid-cols-1">
       <header>
-        <div className=" relative flex justify-between items-end w-full">
-          <div className="flex-1 px-1.5 border border-border bg-muted app-radius-md">
-            <h1 className="text-3xl md:text-5xl font-bol my-4 h-[3rem]">
+        <div className="border border-border bg-muted app-radius-md flex justify-between items-end w-full">
+          <div className="flex-1 px-1.5">
+            <h1 className="text-3xl md:text-5xl font-bol my-3 h-[3rem]">
               {!workspace ? (
                 <div className="bg-border app-radius-md animate-pulse h-10 w-64 inline-block" />
               ) : isEditingName ? (
@@ -912,7 +912,7 @@ export default function WorkingSpacePageClient({
             <CreateTableBtn
               label="New Table"
               workingSpaceId={workingSpaceId}
-              className=" z-10 absolute -bottom-[0.04rem] right-0 h-9 rounded-tr-none rounded-b-none hover:translate-x-[-2px] hover:translate-y-[-2px] hover:rounded-b-none hover:rounded-tr-none hover:shadow-[2px_2px_0px]"
+              className=" h-9 rounded-tr-none rounded-b-none "
               aria-label="create-table"
             />
           )}
@@ -1977,7 +1977,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
       </CardContent>
 
       <CardFooter className="py-4 flex items-center justify-between border-t border-border">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground ">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground overflow-visible ">
           <Calendar className="h-3.5 w-3.5" />
           {typeof window !== "undefined" ? (
             <span>{new Date(note.updatedAt).toLocaleDateString()}</span>
@@ -1988,7 +1988,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
         <Button
           size="sm"
           asChild
-          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]  absolute bottom-0 right-0 h-9 px-2 text-xs"
+          className="absolute bottom-0 right-0 h-10 px-4 text-xs"
           aria-label="open-note"
         >
           <IntentPrefetchLink
@@ -2134,7 +2134,7 @@ function ListNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
             <Button
               size="sm"
               asChild
-              className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] absolute right-0 bottom-0 h-4/5 px-2 text-xs"
+              className="absolute right-0 bottom-0 h-4/5 px-2 text-xs"
             >
               <IntentPrefetchLink
                 href={`/home/${workspaceId}/${note.slug}?id=${note._id}`}
@@ -2259,7 +2259,7 @@ function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
         <Button
           size="sm"
           asChild
-          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] absolute bottom-0 right-0 h-9 px-2 text-xs"
+          className="absolute bottom-0 right-0 h-10 px-4 text-xs"
           aria-label="open-upload"
         >
           <IntentPrefetchLink href={pdfHref}>Open</IntentPrefetchLink>
@@ -2373,7 +2373,7 @@ function PdfListCard({ pdf, onDelete }: PdfCardProps) {
             <Button
               size="sm"
               asChild
-              className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px] absolute right-0 bottom-0 h-4/5 px-2 text-xs"
+              className="absolute right-0 bottom-0 h-4/5 px-2 text-xs"
             >
               <IntentPrefetchLink href={pdfHref}>
                 <span aria-label="open-upload">Open</span>

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -292,8 +292,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
       </div>
       {getWorkingSpaces?.length === 0 && (
         <Button
-          variant="outline"
-          className="font-medium w-full h-9 flex justify-start items-center gap-1.5 bg-primary text-primary-foreground hover:bg-primary/80"
+          className="font-medium w-full h-9 flex justify-start items-center gap-1.5"
           onClick={handleCreateWorkingSpace}
         >
           <FolderPlus size={16} /> Create Workspace
@@ -303,8 +302,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
         ? getWorkingSpaces.map((workingSpace) => (
             <Button
               key={workingSpace._id}
-              variant="outline"
-              className="font-medium w-full h-9 flex justify-start items-center gap-1.5 bg-primary text-primary-foreground hover:bg-primary/80"
+              className="font-medium w-full h-9 flex justify-start items-center gap-1.5 "
               disabled={loading}
               onMouseDown={() => void createNoteInWorkspace(workingSpace)}
             >
@@ -318,10 +316,10 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
             </Button>
           ))
         : createNoteWorkspace && (
-            <div className="flex h-9 w-full items-center overflow-hidden app-radius-lg">
+            <div className="flex h-[42px] p-[3px] bg-gradient-to-br from-primary/60 via-border to-muted-foreground/70 w-full items-center rounded-tl-[0.6rem] overflow-hidden ">
               <Button
-                variant="outline"
-                className="font-medium h-9 flex-1 justify-start gap-1.5 !rounded-r-none bg-primary text-primary-foreground hover:bg-primary/90"
+                variant="aniDefault"
+                className="font-medium h-9 flex-1 justify-start gap-1.5  disabled:before:opacity-40 !rounded-r-none disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80"
                 disabled={loading}
                 onClick={() => void createNoteInWorkspace(createNoteWorkspace)}
               >
@@ -336,8 +334,8 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    variant="outline"
-                    className=" font-medium h-9 px-2 !rounded-l-none border-l-0 bg-primary text-primary-foreground hover:bg-primary/90"
+                    variant="aniDefault"
+                    className=" font-medium h-9 px-2 border-l border-border  disabled:before:opacity-40 !rounded-none disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80"
                     disabled={loading}
                     aria-label="select-create-note-workspace"
                   >

--- a/components/home-components/Feedback.tsx
+++ b/components/home-components/Feedback.tsx
@@ -139,7 +139,7 @@ export default function Feedback() {
               />
               <DialogFooter className=" pb-6 relative">
                 <Button
-                  className=" absolute -bottom-6 -right-6"
+                  className=" absolute -bottom-6 -right-6 before:bg-gradient-to-br before:from-primary/60 before:via-transparent before:to-transparent"
                   type="submit"
                   disabled={loading}
                 >

--- a/components/landingPage-components/HeroSection.tsx
+++ b/components/landingPage-components/HeroSection.tsx
@@ -261,27 +261,6 @@ export default function HeroSection() {
               Active users
             </p>
           </motion.div>
-          <div className="flex gap-2 justify-start items-center">
-            <Button
-              asChild
-              size="lg"
-              className="relative group overflow-hidden h-9"
-            >
-              <Link prefetch={true} href="/signup">
-                Get Started for Free
-              </Link>
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              asChild
-              className="relative group h-9 !rounded-none"
-            >
-              <Link prefetch={true} href="#features">
-                Learn More
-              </Link>
-            </Button>
-          </div>
         </motion.div>
 
         <motion.div

--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -78,7 +78,6 @@ export default function Navbar() {
             ))}
           </nav>
         </div>
-
         <Button asChild className="hidden lg:block relative group h-9">
           <Link prefetch={true} href="/signup" className="text-sm font-medium">
             Login Or Create An Account

--- a/components/slash-command.tsx
+++ b/components/slash-command.tsx
@@ -100,7 +100,7 @@ function YoutubeDialog({
           <Button
             disabled={!youtubeUrlSchema.safeParse(url).success}
             onClick={handleSubmit}
-            className=" h-8 !rounded-none"
+            className=" h-8 !rounded-none before:!rounded-none before:inset-[-2px]"
           >
             Embed
           </Button>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -104,7 +104,11 @@ const AlertDialogAction = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={cn(buttonVariants(), `h-8   !rounded-none`, className)}
+    className={cn(
+      buttonVariants({ variant: "destructive" }),
+      `h-8   !rounded-none`,
+      className,
+    )}
     {...props}
   />
 ));

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground transform-gpu backface-hidden will-change-transform transition-all duration-300 border-r border-b border-transparent hover:border-muted/50 hover:translate-x-[-2px] hover:translate-y-[-2px] hover:rounded-tl-lg hover:shadow-[2px_2px_0px] hover:shadow-primary active:translate-x-[0px] active:translate-y-[0px]",
+          "relative bg-primary/80 hover:bg-primary transition-all duration-200 text-primary-foreground disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80 before:content-[''] before:backdrop-blur before:absolute before:-z-10 before:inset-[-3px] before:rounded-tl-[0.6rem] before:bg-gradient-to-br before:from-primary/60 before:via-border before:to-muted-foreground/70 disabled:before:opacity-40",
+        aniDefault: "bg-primary/80 text-primary-foreground hover:bg-primary",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
### what changed
before : 
<img width="249" height="64" alt="image" src="https://github.com/user-attachments/assets/540f9c7e-988b-447d-9035-b6e872a92a7d" />

<img width="232" height="58" alt="image" src="https://github.com/user-attachments/assets/062f4ddf-1468-4412-9ccf-495353f6ceb0" />

now : 



* Redesigned the default button variant with a softer appearance, gradient backdrop, and updated hover/disabled states.
* Added a new `aniDefault` button variant for cases where a simpler primary button style is needed.
* Updated workspace creation controls in the sidebar to use the new button styles and improved the split-button layout.
* Refreshed the workspace header by simplifying its structure, adjusting spacing, and cleaning up the "New Table" action.
* Updated note and PDF cards with cleaner action buttons and improved footer spacing.
* Applied the new button styling to the feedback form, YouTube embed dialog, and alert dialog destructive actions for a more consistent look.
* Removed the duplicate hero CTA buttons, keeping the landing page focused on the primary navigation.

The UI contained several different button styles and layouts that had evolved over time, leading to inconsistencies across the app. This update unifies the design system, simplifies several workspace components, and creates a cleaner, more cohesive interface.

