### PR TITLE
refresh landing page footer

### DIFF
--- a/components/landingPage-components/Footer.tsx
+++ b/components/landingPage-components/Footer.tsx
@@ -34,8 +34,7 @@ export default function Footer() {
           </defs>
         </svg>
       </div>
-      <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 pb-10 bg-[#EFEFEF]">
-        <SignUpToday />
+      <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 pb-48 bg-[#EFEFEF]">
         <div className="max-w-6xl mx-auto py-5 px-6 md:px-12 lg:px-16">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
             <div>
@@ -163,6 +162,9 @@ export default function Footer() {
           </div>
         </div>
       </footer>
+      <h1 className="z-50 bg-gradient-to-b from-primary/30 from-60% to-100% to-transparent text-transparent bg-clip-text inline-block text-nowrap  text-[200px] absolute -bottom-6 right-0 align-bottom text-center pointer-events-none select-none w-full overflow-hidden font-bold tracking-tighter leading-[9rem] -indent-8">
+        Notes Without The Hassle
+      </h1>
     </div>
   );
 }


### PR DESCRIPTION
### what changed
i think this is coooolll 
<img width="1634" height="581" alt="image" src="https://github.com/user-attachments/assets/a7e1e5c3-add8-4f4e-ac6e-4578d3f6a2ae" />


* Removed the **Sign Up Today** section from the footer.
* Increased the footer's bottom spacing to make room for a new decorative element.
* Added a large background headline, **"Notes Without The Hassle"**, positioned at the bottom of the page with a subtle gradient text effect.
* Kept the new headline non-interactive so it serves purely as a visual design element.


The previous footer ended with an additional signup section that felt repetitive alongside the existing calls to action on the landing page. This update simplifies the footer while introducing a stronger visual ending that better reinforces the product's branding.