### PR TITLE
refine primary button styling

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -361,7 +361,7 @@ function Slider({ children }: { children: React.ReactNode }) {
         <div className="z-10 absolute -bottom-8 right-0 flex justify-center items-center gap-2">
           <Button
             size="icon"
-            variant={canScrollLeft ? "default" : "outline"}
+            variant={canScrollLeft ? "revDefault" : "outline"}
             className="h-9 w-8"
             onClick={() => scroll("left")}
           >
@@ -369,7 +369,7 @@ function Slider({ children }: { children: React.ReactNode }) {
           </Button>
           <Button
             size="icon"
-            variant={canScrollRight ? "default" : "outline"}
+            variant={canScrollRight ? "revDefault" : "outline"}
             className="h-9 w-8 !rounded-none"
             onClick={() => scroll("right")}
           >
@@ -518,7 +518,7 @@ function WorkspaceCard({
         <Button
           size="sm"
           asChild
-          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]  absolute bottom-0 right-0 h-9 px-2 text-xs"
+          className=" absolute bottom-0 right-0 h-9 px-2 text-xs"
         >
           <IntentPrefetchLink href={`/home/${workspace._id}`}>
             Open
@@ -609,7 +609,7 @@ function NoteCard({ note }: { note: Note }) {
         <Button
           size="sm"
           asChild
-          className="hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-[2px_2px_0px]  absolute bottom-0 right-0 h-9 px-2 text-xs"
+          className="absolute bottom-0 right-0 h-9 px-2 text-xs"
         >
           <IntentPrefetchLink
             href={`/home/${note.workingSpaceId}/${note.slug}?id=${note._id}`}

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -318,7 +318,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
         : createNoteWorkspace && (
             <div className="flex h-[42px] p-[3px] bg-gradient-to-br from-primary/60 via-border to-muted-foreground/70 w-full items-center rounded-tl-[0.6rem] overflow-hidden ">
               <Button
-                variant="aniDefault"
+                variant="revDefault"
                 className="font-medium h-9 flex-1 justify-start gap-1.5  disabled:before:opacity-40 !rounded-r-none disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80"
                 disabled={loading}
                 onClick={() => void createNoteInWorkspace(createNoteWorkspace)}
@@ -334,7 +334,7 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    variant="aniDefault"
+                    variant="revDefault"
                     className=" font-medium h-9 px-2 border-l border-border  disabled:before:opacity-40 !rounded-none disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80"
                     disabled={loading}
                     aria-label="select-create-note-workspace"

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,8 +10,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "relative bg-primary/80 hover:bg-primary transition-all duration-200 text-primary-foreground disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80 before:content-[''] before:backdrop-blur before:absolute before:-z-10 before:inset-[-3px] before:rounded-tl-[0.6rem] before:bg-gradient-to-br before:from-primary/60 before:via-border before:to-muted-foreground/70 disabled:before:opacity-40",
-        aniDefault: "bg-primary/80 text-primary-foreground hover:bg-primary",
+          "relative bg-primary/90 hover:bg-primary transition-all duration-200 text-primary-foreground disabled:opacity-100 disabled:bg-primary/65 disabled:text-primary-foreground/80 before:content-[''] before:backdrop-blur before:absolute before:-z-10 before:inset-[-3px] before:rounded-tl-[0.6rem] before:bg-gradient-to-br before:from-primary/60 before:via-border before:to-muted-foreground/70 disabled:before:opacity-40",
+        revDefault: "bg-primary/90 text-primary-foreground hover:bg-primary",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
## what changed

* Renamed the lightweight primary button variant from `aniDefault` to `revDefault` for better clarity and consistency.
* Updated the new primary button variant across the app, including the home page slider controls and sidebar workspace actions.
* Slightly increased the opacity of the primary button background to improve visibility and contrast.
* Removed legacy hover translation and shadow effects from workspace and note action buttons on the home page to align with the updated button design.

The button system has been moving toward a cleaner, more consistent visual style. This update finalizes that transition by renaming the new variant, improving its appearance, and removing older interaction styles that no longer match the current design language.

