### PR TITLE
refine create note workspace menu

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -88,6 +88,7 @@ import NoteContextMenu from "./NoteContextMenu";
 import { FaGithub } from "react-icons/fa6";
 import { useHomePane } from "./HomePaneDrawer";
 import { ShortcutBadge } from "../ui/shortcut-badge";
+import { DialogTitle } from "@radix-ui/react-dialog";
 
 interface SidebarHeaderSectionProps {
   getWorkingSpaces: Doc<"workingSpaces">[] | undefined;
@@ -345,19 +346,23 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
                 <DropdownMenuContent
                   side="bottom"
                   align="end"
-                  className="app-radius-xl p-1 bg-background/90 backdrop-blur border border-solid border-border w-52"
+                  className="!rounded-none p-1 bg-background w-52 "
                 >
-                  <DropdownMenuGroup className="flex-col">
+                  <DropdownMenuGroup className="relative flex-col">
+                    <DropdownMenuLabel className=" px-px pb-px pt-0.5 text-[11px] text-muted-foreground">
+                      Workspaces
+                    </DropdownMenuLabel>
                     {getWorkingSpaces?.map((workingSpace) => (
                       <DropdownMenuItem
                         key={workingSpace._id}
-                        className="relative flex-1 px-2 h-7 py-1.5 data-[highlighted]:bg-foreground app-radius-lg"
+                        className="relative flex-1 mx-1 px-1 h-7 py-1.5 data-[highlighted]:bg-foreground !rounded-none"
                         onSelect={() =>
                           void createNoteInWorkspace(workingSpace)
                         }
                         disabled={loading}
                       >
-                        <FolderClosed size="16" className="mr-2" />
+                        <div className=" absolute top-0 -left-[2.5px] h-full w-px bg-border" />
+                        <FolderClosed size="16" />
                         <span>
                           {formatWorkspaceNameForCreateSideBarBtn(
                             workingSpace.name,


### PR DESCRIPTION
## What's changed

before : 
<img width="260" height="178" alt="image" src="https://github.com/user-attachments/assets/d1e2c762-3e92-4ad5-80ce-5fa54be4ae5c" />

now : waaay better 

<img width="384" height="338" alt="image" src="https://github.com/user-attachments/assets/c2da9d32-51ec-4359-bd25-6a35401ca979" />

* Updated the workspace selection dropdown with a flatter, cleaner appearance by removing the backdrop blur, border styling, and rounded corners.
* Added a **"Workspaces"** label at the top of the dropdown to provide clearer context.
* Refined the workspace list layout with improved spacing and alignment.
* Added a subtle vertical guide line alongside each workspace item to improve visual hierarchy.
* Simplified the workspace item presentation by removing the extra spacing around the folder icon.
* Updated highlighted menu items to use the new square styling for better consistency with other menus.

The previous dropdown felt visually heavier than the rest of the sidebar UI. These changes simplify the component, improve readability, and make the workspace picker feel more consistent with the application's overall design system while making it easier to scan when multiple workspaces are available.
