### PR TITLE
make auth button always visible in navbar

### DIFF
--- a/components/landingPage-components/Navbar.tsx
+++ b/components/landingPage-components/Navbar.tsx
@@ -78,7 +78,7 @@ export default function Navbar() {
             ))}
           </nav>
         </div>
-        <Button asChild className="hidden lg:block relative group h-9">
+        <Button asChild className="relative group h-9">
           <Link prefetch={true} href="/signup" className="text-sm font-medium">
             Login Or Create An Account
           </Link>


### PR DESCRIPTION
before : 
<img width="553" height="766" alt="image" src="https://github.com/user-attachments/assets/6b8ee8ba-8694-4faf-949d-085c45731e86" />

now : 
<img width="542" height="725" alt="image" src="https://github.com/user-attachments/assets/cd76a148-f530-490d-9197-34651caaa7c9" />

Keeping the authentication button visible on all screen sizes makes it easier for users to sign in or create an account without relying on an alternative navigation flow. 