### PR TITLE
polish workspace dropdown hierarchy

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -348,20 +348,20 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
                   align="end"
                   className="!rounded-none p-1 bg-background w-52 "
                 >
-                  <DropdownMenuGroup className="relative flex-col">
-                    <DropdownMenuLabel className=" px-px pb-px pt-0.5 text-[11px] text-muted-foreground">
+                  <DropdownMenuGroup className="relative flex-col ">
+                    <DropdownMenuLabel className=" p-px text-[11px] text-muted-foreground">
                       Workspaces
                     </DropdownMenuLabel>
                     {getWorkingSpaces?.map((workingSpace) => (
                       <DropdownMenuItem
                         key={workingSpace._id}
-                        className="relative flex-1 mx-1 px-1 h-7 py-1.5 data-[highlighted]:bg-foreground !rounded-none"
+                        className="relative *:text-foreground flex-1 ml-2.5 px-1 h-7 py-1.5 data-[highlighted]:bg-foreground !rounded-none"
                         onSelect={() =>
                           void createNoteInWorkspace(workingSpace)
                         }
                         disabled={loading}
                       >
-                        <div className=" absolute top-0 -left-[2.5px] h-full w-px bg-border" />
+                        <div className=" absolute top-0 -left-[7px] h-full w-px bg-muted-foreground/30" />
                         <FolderClosed size="16" />
                         <span>
                           {formatWorkspaceNameForCreateSideBarBtn(


### PR DESCRIPTION
before : 
<img width="232" height="139" alt="image" src="https://github.com/user-attachments/assets/7e6a94e0-0cf3-4147-a8f2-8878be4c4e74" />

now : just adjust the spaces
<img width="260" height="167" alt="image" src="https://github.com/user-attachments/assets/46808f24-a495-43b2-b800-ef8c31fea402" />

These refinements improve the visual structure of the workspace picker without changing its behavior. The updated spacing, alignment, and hierarchy make the dropdown easier to scan, while the subtler guide line helps organize the list without drawing unnecessary attention.