### PR TITLE
unify popover background styling

### DIFF
--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -380,7 +380,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               align="end"
               side="bottom"
               sideOffset={8}
-              className="w-64 space-y-3 p-2"
+              className="w-64 space-y-3 p-2 bg-muted"
             >
               <ColorRow
                 label="Background color"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 app-radius-lg border border-border bg-accent p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 app-radius-lg border border-border bg-muted p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}


### PR DESCRIPTION
## What's changed
before : 
<img width="277" height="137" alt="image" src="https://github.com/user-attachments/assets/997ab489-fa82-4fe4-88ce-44b4d261ac0a" />
after : 
<img width="284" height="162" alt="image" src="https://github.com/user-attachments/assets/2aecf4e9-38bf-4abb-a469-29c6af04d9bb" />

Different popovers were using different background colors, making the UI feel slightly inconsistent. By standardizing on the muted surface, popovers now blend more naturally with the rest of the interface while maintaining good contrast and improving the overall visual consistency of the editor.