### PR TITLE
add link support & improve workspace content management

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -9,7 +9,10 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronDown,
+  Link2,
+  Trash2,
   X,
+  Filter,
 } from "lucide-react";
 import { useMediaQuery } from "react-responsive";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
@@ -19,6 +22,7 @@ import { useQuery } from "@/cache/useQuery";
 import type { Id } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
 import { z } from "zod";
+import { platformLabel, type LinkPlatform } from "@/lib/link-platform";
 import MaxWContainer from "@/components/ui/MaxWContainer";
 import CreateTableBtn from "@/components/home-components/CreateTableBtn";
 import CreateNoteBtn from "@/components/home-components/CreateNoteBtn";
@@ -106,6 +110,47 @@ const tableNotesMemoryCache = new Map<string, any[]>();
 
 type ViewMode = "grid" | "list" | "calendar";
 type CalendarZoom = "week" | "month" | "quarter" | "year";
+type ContentFilter =
+  | "all"
+  | "note"
+  | "pdf"
+  | "youtube"
+  | "x"
+  | "instagram"
+  | "linkedin";
+
+const CONTENT_FILTER_OPTIONS: {
+  value: ContentFilter;
+  label: string;
+}[] = [
+  { value: "all", label: "All" },
+  { value: "note", label: "Notes" },
+  { value: "pdf", label: "PDFs" },
+  { value: "youtube", label: "YouTube" },
+  { value: "x", label: "X" },
+  { value: "instagram", label: "Instagram" },
+  { value: "linkedin", label: "LinkedIn" },
+];
+
+function matchesLinkPlatform(
+  platform: LinkPlatform | string | undefined,
+  filter: ContentFilter,
+): boolean {
+  if (!platform) return false;
+  const p = String(platform).toLowerCase();
+  switch (filter) {
+    case "youtube":
+      return p.includes("youtube") || p === "yt";
+    case "x":
+      return p === "x" || p.includes("twitter");
+    case "instagram":
+      return p.includes("instagram") || p === "ig";
+    case "linkedin":
+      return p.includes("linkedin");
+    default:
+      return false;
+  }
+}
 
 interface Note {
   _id: Id<"notes">;
@@ -138,7 +183,36 @@ interface PdfItem {
   kind: "pdf";
 }
 
-type WorkspaceEntry = (Note & { kind: "note" }) | PdfItem;
+interface LinkItem {
+  _id: Id<"links">;
+  url: string;
+  platform: LinkPlatform;
+  metadata?: {
+    description?: string;
+    thumbnailUrl?: string;
+    authorName?: string;
+    authorHandle?: string;
+    authorAvatarUrl?: string;
+    publishedAt?: number;
+    viewCount?: string;
+    likeCount?: number;
+    repostCount?: number;
+    commentCount?: number;
+    duration?: string;
+    embedVideoId?: string;
+    siteName?: string;
+  };
+  title?: string;
+  favorite?: boolean;
+  userId?: Id<"users">;
+  workingSpaceId?: Id<"workingSpaces">;
+  notesTableId?: Id<"notesTables">;
+  createdAt: number;
+  updatedAt: number;
+  kind: "link";
+}
+
+type WorkspaceEntry = (Note & { kind: "note" }) | PdfItem | LinkItem;
 
 interface NotesDroppableContainerProps {
   tableId: Id<"notesTables">;
@@ -161,6 +235,11 @@ interface NoteCardProps {
 interface PdfCardProps {
   pdf: PdfItem;
   onDelete?: (pdfId: Id<"pdfs">) => void;
+}
+
+interface LinkCardProps {
+  link: LinkItem;
+  onDelete?: (linkId: Id<"links">) => void;
 }
 
 interface EmptySearchResultsProps {
@@ -763,7 +842,7 @@ export default function WorkingSpacePageClient({
             variant: "destructive",
           });
         } else if (issue.code === "too_big") {
-          setEditedName(workspace?.name);
+          setEditedName(workspace?.name || "Untitled");
           toast({
             title: "Naming failed",
             description: "Name must be 30 characters or less ",
@@ -926,7 +1005,7 @@ export default function WorkingSpacePageClient({
             onValueChange={handleTabChange}
             className="mt-6"
           >
-            <div className=" sticky top-0 left-0 mb-6 z-40">
+            <div className="mb-6">
               <SliderTabsList
                 tables={tables}
                 activeTableId={defaultTableId ?? ""}
@@ -984,6 +1063,9 @@ export function NotesDroppableContainer({
         }
       >
     | undefined;
+  const links = useQuery(api.links.getLinksByTableId, {
+    notesTableId: tableId,
+  }) as Array<Omit<LinkItem, "kind">> | undefined;
 
   const cachedNotes = tableNotesMemoryCache.get(tableId as unknown as string);
   useEffect(() => {
@@ -996,9 +1078,12 @@ export function NotesDroppableContainer({
     status === "LoadingFirstPage" && cachedNotes ? cachedNotes : results;
 
   const [deletedItemIds, setDeletedItemIds] = useState<Set<string>>(new Set());
+  const [contentFilter, setContentFilter] = useState<ContentFilter>("all");
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   useEffect(() => {
     setDeletedItemIds(new Set());
+    setContentFilter("all");
   }, [tableId]);
 
   const filteredItems = useMemo(() => {
@@ -1008,7 +1093,10 @@ export function NotesDroppableContainer({
     const pdfItems = (pdfs ?? []).map(
       (pdf) => ({ ...pdf, kind: "pdf" }) as WorkspaceEntry,
     );
-    const notDeletedItems = [...noteItems, ...pdfItems]
+    const linkItems = (links ?? []).map(
+      (link) => ({ ...link, kind: "link" }) as WorkspaceEntry,
+    );
+    let items = [...noteItems, ...pdfItems, ...linkItems]
       .filter((item) => item && !deletedItemIds.has(item._id))
       .sort((a, b) => {
         const aPinned = a.favorite ? 1 : 0;
@@ -1017,16 +1105,28 @@ export function NotesDroppableContainer({
         return b.updatedAt - a.updatedAt;
       });
 
-    if (!searchQuery.trim()) return notDeletedItems;
+    if (contentFilter !== "all") {
+      items = items.filter((item) => {
+        if (contentFilter === "note") return item.kind === "note";
+        if (contentFilter === "pdf") return item.kind === "pdf";
+        if (item.kind !== "link") return false;
+        return matchesLinkPlatform(item.platform, contentFilter);
+      });
+    }
+
+    if (!searchQuery.trim()) return items;
     const q = searchQuery.toLowerCase();
-    return notDeletedItems.filter((item) => {
+    return items.filter((item) => {
       const titleMatches = item.title?.toLowerCase().includes(q);
       if (item.kind === "pdf") return titleMatches;
+      if (item.kind === "link") {
+        return titleMatches || item.url.toLowerCase().includes(q);
+      }
 
       const searchableText = (item.preview ?? item.body ?? "").toLowerCase();
       return titleMatches || searchableText.includes(q);
     });
-  }, [deletedItemIds, pdfs, searchQuery, stableResults]);
+  }, [contentFilter, deletedItemIds, links, pdfs, searchQuery, stableResults]);
 
   const handleItemDelete = useCallback((itemId: string) => {
     setDeletedItemIds((prev) => {
@@ -1102,6 +1202,54 @@ export function NotesDroppableContainer({
             workingSpacesSlug={workspaceSlug}
             CNBP_notesTableId={tableId}
           />
+          <Popover open={isFilterOpen} onOpenChange={setIsFilterOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className={cn(
+                  "h-9 shrink-0 border-border gap-1.5 !rounded-none",
+                  contentFilter !== "all" && "bg-muted",
+                )}
+                aria-label="filter-content"
+              >
+                <Filter className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">
+                  {CONTENT_FILTER_OPTIONS.find((o) => o.value === contentFilter)
+                    ?.label ?? "All"}
+                </span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-32 p-1 border-border bg-card"
+            >
+              <div className="flex flex-col gap-0.5">
+                {CONTENT_FILTER_OPTIONS.map((option) => (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      "justify-start h-8 px-2 font-normal",
+                      contentFilter === option.value && "bg-muted",
+                    )}
+                    onClick={() => {
+                      setContentFilter(option.value);
+                      setIsFilterOpen(false);
+                    }}
+                  >
+                    {option.label}
+                    {contentFilter === option.value ? (
+                      <Check className="ml-auto h-3.5 w-3.5" />
+                    ) : null}
+                  </Button>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
           <TableSettings
             notesTableId={tableId}
             tableName={tables?.find((t) => t._id === tableId)?.name}
@@ -1109,12 +1257,24 @@ export function NotesDroppableContainer({
         </div>
       </div>
 
-      {status === "LoadingFirstPage" && !cachedNotes && pdfs === undefined ? (
+      {status === "LoadingFirstPage" &&
+      !cachedNotes &&
+      pdfs === undefined &&
+      links === undefined ? (
         <NotesSkeleton viewMode={viewMode} />
-      ) : searchQuery && filteredItems.length === 0 ? (
+      ) : (searchQuery || contentFilter !== "all") &&
+        filteredItems.length === 0 ? (
         <EmptySearchResults
-          searchQuery={searchQuery}
-          onClearSearch={() => setSearchQuery("")}
+          searchQuery={
+            searchQuery.trim()
+              ? searchQuery
+              : (CONTENT_FILTER_OPTIONS.find((o) => o.value === contentFilter)
+                  ?.label ?? "filter")
+          }
+          onClearSearch={() => {
+            setSearchQuery("");
+            setContentFilter("all");
+          }}
         />
       ) : filteredItems.length === 0 ? (
         <EmptyTableState
@@ -1135,12 +1295,19 @@ export function NotesDroppableContainer({
             <div
               className={
                 viewMode === "grid" || isMobile
-                  ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+                  ? "columns-1 sm:columns-2 md:columns-3 gap-4"
                   : "flex flex-col gap-3"
               }
             >
               {filteredItems.map((item) => (
-                <div key={item._id}>
+                <div
+                  key={item._id}
+                  className={
+                    viewMode === "grid" || isMobile
+                      ? "mb-4 break-inside-avoid"
+                      : undefined
+                  }
+                >
                   {item.kind === "pdf" ? (
                     viewMode === "grid" || isMobile ? (
                       <PdfGridCard
@@ -1151,6 +1318,18 @@ export function NotesDroppableContainer({
                       <PdfListCard
                         pdf={item}
                         onDelete={(pdfId) => handleItemDelete(pdfId)}
+                      />
+                    )
+                  ) : item.kind === "link" ? (
+                    viewMode === "grid" || isMobile ? (
+                      <LinkGridCard
+                        link={item}
+                        onDelete={(linkId) => handleItemDelete(linkId)}
+                      />
+                    ) : (
+                      <LinkListCard
+                        link={item}
+                        onDelete={(linkId) => handleItemDelete(linkId)}
                       />
                     )
                   ) : viewMode === "grid" || isMobile ? (
@@ -1821,28 +2000,38 @@ function TimelineMiniCard({
   inPopover?: boolean;
 }) {
   const isPdf = item.kind === "pdf";
+  const isLink = item.kind === "link";
   const href = isPdf
     ? `/home/${(item as PdfItem).workingSpaceId}/pdf/${generateSlug(
         (item as PdfItem).title || "untitled-pdf",
       )}?pdfId=${item._id}`
-    : `/home/${workspaceId}/${(item as Note).slug}?id=${item._id}`;
+    : isLink
+      ? `/home/${(item as LinkItem).workingSpaceId}/link/${generateSlug(
+          (item as LinkItem).title ||
+            (item as LinkItem).metadata?.authorName ||
+            "link",
+        )}?linkId=${item._id}`
+      : `/home/${workspaceId}/${(item as Note).slug}?id=${item._id}`;
 
   const createdDate = new Date(item.createdAt);
   const isDifferentYear =
     createdDate.getFullYear() !== new Date().getFullYear();
 
-  return (
-    <IntentPrefetchLink
-      href={href}
-      className={cn(
-        "group flex items-start gap-2 border border-border bg-card hover:border-primary/50 hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-[2px_2px_0px] shadow-primary transition-all app-radius-md px-2.5 py-2",
-        inPopover ? "w-full" : "w-[168px]",
+  const cardClassName = cn(
+    "group flex items-start gap-2 border border-border bg-card hover:border-primary/50 hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-[2px_2px_0px] shadow-primary transition-all app-radius-md px-2.5 py-2",
+    inPopover ? "w-full" : "w-[168px]",
+  );
+
+  const cardContent = (
+    <>
+      {isLink ? (
+        <Link2 className="h-3.5 w-3.5 text-primary mt-0.5 flex-shrink-0" />
+      ) : (
+        <FileText className="h-3.5 w-3.5 text-primary mt-0.5 flex-shrink-0" />
       )}
-    >
-      <FileText className="h-3.5 w-3.5 text-primary mt-0.5 flex-shrink-0" />
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium text-foreground line-clamp-2 leading-tight">
-          {item.title || "Untitled"}
+          {item.title || (isLink ? (item as LinkItem).url : "Untitled")}
         </p>
         <p className="text-[10px] text-muted-foreground mt-1">
           {createdDate.toLocaleDateString(undefined, {
@@ -1852,6 +2041,12 @@ function TimelineMiniCard({
           })}
         </p>
       </div>
+    </>
+  );
+
+  return (
+    <IntentPrefetchLink href={href} className={cardClassName}>
+      {cardContent}
     </IntentPrefetchLink>
   );
 }
@@ -1927,7 +2122,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
   return (
     <Card
       className={cn(
-        "group relative overflow-hidden bg-card border flex flex-col min-h-[230px]",
+        "group relative overflow-hidden bg-card border flex flex-col w-full min-h-[200px]",
         isEmpty
           ? "border-dashed border-border"
           : "border-border hover:border-border",
@@ -1989,7 +2184,7 @@ function GridNoteCard({ note, workspaceId, onDelete }: NoteCardProps) {
           size="sm"
           asChild
           variant="revDefault"
-          className="absolute bottom-0 right-0 h-10 px-4 text-xs"
+          className="absolute bottom-0 right-0 h-10 px-6 text-xs"
           aria-label="open-note"
         >
           <IntentPrefetchLink
@@ -2206,7 +2401,7 @@ function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
   );
 
   return (
-    <Card className="group relative overflow-hidden bg-card border border-border flex flex-col min-h-[230px]">
+    <Card className="group relative overflow-hidden bg-card border border-border flex flex-col w-full min-h-[200px]">
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
           {isEditingTitle ? (
@@ -2261,7 +2456,7 @@ function PdfGridCard({ pdf, onDelete }: PdfCardProps) {
         <Button
           size="sm"
           asChild
-          className="absolute bottom-0 right-0 h-10 px-4 text-xs"
+          className="absolute bottom-0 right-0 h-10 px-6 text-xs"
           variant="revDefault"
           aria-label="open-upload"
         >
@@ -2382,6 +2577,177 @@ function PdfListCard({ pdf, onDelete }: PdfCardProps) {
               <IntentPrefetchLink href={pdfHref}>
                 <span aria-label="open-upload">Open</span>
               </IntentPrefetchLink>
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LinkGridCard({ link, onDelete }: LinkCardProps) {
+  const deleteLink = useMutation(api.links.deleteLink);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const displayTitle =
+    link.title ||
+    link.metadata?.authorName ||
+    link.metadata?.siteName ||
+    link.url;
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await deleteLink({ _id: link._id });
+      onDelete?.(link._id);
+    } catch (error) {
+      console.error("Error deleting link:", error);
+      setIsDeleting(false);
+    }
+  }, [deleteLink, link._id, onDelete]);
+
+  return (
+    <Card className="group relative overflow-hidden bg-card border border-border flex flex-col w-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle
+            className="text-lg font-semibold text-foreground line-clamp-2 w-fit"
+            title={link.url}
+          >
+            {displayTitle}
+          </CardTitle>
+          <Button
+            type="button"
+            variant="Trigger"
+            size="icon"
+            onClick={() => void handleDelete()}
+            disabled={isDeleting}
+            aria-label="delete-link"
+            className="h-7 w-7 text-muted-foreground hover:text-destructive flex-shrink-0"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex-grow flex-1 flex flex-col justify-between">
+        {link.metadata?.thumbnailUrl ? (
+          <div className="w-full h-full app-radius-md overflow-hidden bg-muted">
+            <img
+              src={link.metadata.thumbnailUrl}
+              alt=""
+              className="w-full h-full object-cover"
+            />
+          </div>
+        ) : null}
+      </CardContent>
+
+      <CardFooter className="py-4 flex items-center justify-between border-t border-border">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Calendar className="h-3.5 w-3.5" />
+          {typeof window !== "undefined" ? (
+            <span>{new Date(link.updatedAt).toLocaleDateString()}</span>
+          ) : (
+            <SkeletonTextAnimation className="w-20" />
+          )}
+        </div>
+        <Button
+          size="sm"
+          asChild
+          className="absolute bottom-0 right-0 h-10 px-6 text-xs"
+          variant="revDefault"
+          aria-label="open-link"
+        >
+          <a href={link.url} target="_blank" rel="noopener noreferrer">
+            Open {link.metadata?.siteName}
+          </a>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function LinkListCard({ link, onDelete }: LinkCardProps) {
+  const deleteLink = useMutation(api.links.deleteLink);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const displayTitle =
+    link.title ||
+    link.metadata?.authorName ||
+    link.metadata?.siteName ||
+    link.url;
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await deleteLink({ _id: link._id });
+      onDelete?.(link._id);
+    } catch (error) {
+      console.error("Error deleting link:", error);
+      setIsDeleting(false);
+    }
+  }, [deleteLink, link._id, onDelete]);
+
+  return (
+    <Card className="group relative overflow-hidden flex justify-center items-center bg-card backdrop-blur-sm border border-border transition-all duration-300 w-full min-h-fit">
+      <CardContent className="p-3 flex-1">
+        <div className="flex items-center justify-center gap-4">
+          <div className="h-10 w-10 flex items-center justify-center flex-shrink-0">
+            {link.metadata?.thumbnailUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={link.metadata.thumbnailUrl}
+                alt="link metadata thumbnailUrl"
+                className="h-full w-full object-cover app-radius-md"
+              />
+            ) : (
+              <Link2 className="h-5 w-5 text-primary" />
+            )}
+          </div>
+          <div className="relative flex-1 min-w-0 h-[3.5rem] overflow-hidden">
+            <h3
+              className="text-lg font-semibold text-foreground line-clamp-2 flex-1 w-fit"
+              title={link.url}
+            >
+              {displayTitle}
+            </h3>
+            <p className="text-sm text-muted-foreground line-clamp-2">
+              {platformLabel(link.platform)}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <div className="relative flex items-center gap-2 text-xs text-muted-foreground">
+              <Calendar className="h-3.5 w-3.5" />
+              {typeof window !== "undefined" ? (
+                <span>{new Date(link.updatedAt).toLocaleDateString()}</span>
+              ) : (
+                <SkeletonTextAnimation className="w-20" />
+              )}
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => void handleDelete()}
+              disabled={isDeleting}
+              aria-label="delete-link"
+              className="h-7 w-7 pt-0 mr-10 mt-1.5 text-muted-foreground hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              asChild
+              variant="revDefault"
+              className="absolute right-0 bottom-0 h-4/5 px-2 text-xs"
+            >
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="open-link"
+              >
+                Open
+              </a>
             </Button>
           </div>
         </div>
@@ -2520,11 +2886,11 @@ function NotesSkeleton({ viewMode }: { viewMode: ViewMode }) {
 
   if (viewMode === "grid") {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      <div className="columns-1 sm:columns-2 md:columns-3 gap-4">
         {Array.from({ length: 5 }).map((_, index) => (
           <Card
             key={index}
-            className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px]"
+            className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px] w-full mb-4 break-inside-avoid"
           >
             <CardHeader className="pb-3">
               <div className="flex items-start justify-between gap-2">
@@ -2612,11 +2978,11 @@ function TablesSkeleton() {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div className="columns-1 sm:columns-2 md:columns-3 gap-4">
           {Array.from({ length: 6 }).map((_, index) => (
             <Card
               key={index}
-              className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px]"
+              className="bg-card/90 backdrop-blur-sm border-border flex flex-col min-h-[230px] w-full mb-4 break-inside-avoid"
             >
               <CardHeader className="pb-3">
                 <div className="flex items-start justify-between gap-2">

--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -8,8 +8,8 @@ import {
   useState,
   type ChangeEvent,
 } from "react";
-import { insertAtTop, useMutation } from "convex/react";
-import { ChevronDown, FileUp, FileText } from "lucide-react";
+import { insertAtTop, useAction, useMutation } from "convex/react";
+import { ChevronDown, FileUp, FileText, Link2 } from "lucide-react";
 import type { Id } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -19,12 +19,72 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
+import {
+  FaYoutube,
+  FaXTwitter,
+  FaLinkedin,
+  FaInstagram,
+  FaLink,
+} from "react-icons/fa6";
+
+import {
+  detectLinkPlatform,
+  normalizeLinkUrl,
+  type LinkPlatform,
+} from "@/lib/link-platform";
 
 type PreferredAction = "note" | "upload";
 
 const STORAGE_KEY = "notevo_workspace_primary_create_action";
+
+const PLATFORM_LABELS: Record<LinkPlatform, string> = {
+  youtube: "YouTube",
+  x: "X (Twitter)",
+  linkedin: "LinkedIn",
+  instagram: "Instagram",
+  generic: "Link",
+};
+
+const PLATFORM_COLORS: Record<LinkPlatform, string> = {
+  youtube: "text-[#FF0000]",
+  x: "text-foreground",
+  linkedin: "text-[#0A66C2]",
+  instagram: "text-[#E4405F]",
+  generic: "text-muted-foreground",
+};
+
+function PlatformIcon({
+  platform,
+  className,
+}: {
+  platform: LinkPlatform;
+  className?: string;
+}) {
+  const colorClass = PLATFORM_COLORS[platform];
+  switch (platform) {
+    case "youtube":
+      return <FaYoutube className={cn(colorClass, className)} />;
+    case "x":
+      return <FaXTwitter className={cn(colorClass, className)} />;
+    case "linkedin":
+      return <FaLinkedin className={cn(colorClass, className)} />;
+    case "instagram":
+      return <FaInstagram className={cn(colorClass, className)} />;
+    default:
+      return <FaLink className={cn(colorClass, className)} />;
+  }
+}
 
 interface WorkingspaceNewDropdownBtnProps {
   notesTableId?: Id<"notesTables">;
@@ -44,6 +104,20 @@ export default function WorkingspaceNewDropdownBtn({
   const [preferredAction, setPreferredAction] =
     useState<PreferredAction>("note");
   const [isUploading, setIsUploading] = useState(false);
+  const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkTitle, setLinkTitle] = useState("");
+  const [isInsertingLink, setIsInsertingLink] = useState(false);
+  const linkInputRef = useRef<HTMLInputElement>(null);
+
+  const detectedPlatform = useMemo(() => {
+    if (!linkUrl.trim()) return null;
+    // Only detect if it looks like a URL
+    if (!linkUrl.startsWith("http://") && !linkUrl.startsWith("https://")) {
+      return null;
+    }
+    return detectLinkPlatform(linkUrl);
+  }, [linkUrl]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -97,6 +171,8 @@ export default function WorkingspaceNewDropdownBtn({
 
   const generateUploadUrl = useMutation(api.pdfs.generateUploadUrl);
   const sendPdf = useMutation(api.pdfs.sendPdf);
+  const createLink = useMutation(api.links.createLink);
+  const fetchLinkMetadata = useAction(api.Linkmetadata.fetchLinkMetadata);
 
   const isDisabled = useMemo(
     () => !notesTableId || !workingSpaceId || !workingSpacesSlug || isUploading,
@@ -175,6 +251,81 @@ export default function WorkingspaceNewDropdownBtn({
     [generateUploadUrl, notesTableId, sendPdf, toast, workingSpaceId],
   );
 
+  const handleInsertLink = useCallback(async () => {
+    if (!notesTableId || !workingSpaceId) return;
+
+    const trimmedUrl = linkUrl.trim();
+    if (!trimmedUrl) {
+      toast({
+        title: "URL required",
+        description: "Please enter a valid URL.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    // Basic URL validation
+    const finalUrl = normalizeLinkUrl(trimmedUrl);
+
+    try {
+      new URL(finalUrl);
+    } catch {
+      toast({
+        title: "Invalid URL",
+        description: "Please enter a valid URL.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const platform = detectLinkPlatform(finalUrl);
+    const userTitle = linkTitle.trim() || undefined;
+
+    setIsInsertingLink(true);
+    try {
+      let fetchedTitle: string | undefined;
+      let metadata:
+        | Awaited<ReturnType<typeof fetchLinkMetadata>>["metadata"]
+        | any = undefined;
+      try {
+        const preview = await fetchLinkMetadata({ url: finalUrl, platform });
+        fetchedTitle = preview.title;
+        metadata = preview.metadata;
+      } catch (metadataError) {
+        console.error("Failed to fetch link preview:", metadataError);
+      }
+
+      await createLink({
+        url: finalUrl,
+        platform,
+        metadata,
+        title: userTitle ?? fetchedTitle,
+        workingSpaceId,
+        notesTableId,
+      });
+      setLinkUrl("");
+      setLinkTitle("");
+      setIsLinkDialogOpen(false);
+    } catch (error) {
+      console.error("Failed to insert link:", error);
+      toast({
+        title: "Could not insert link",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsInsertingLink(false);
+    }
+  }, [
+    createLink,
+    fetchLinkMetadata,
+    linkTitle,
+    linkUrl,
+    notesTableId,
+    toast,
+    workingSpaceId,
+  ]);
+
   const handlePrimaryAction = useCallback(async () => {
     if (preferredAction === "upload") {
       fileInputRef.current?.click();
@@ -204,11 +355,20 @@ export default function WorkingspaceNewDropdownBtn({
     fileInputRef.current?.click();
   }, [persistPreferredAction]);
 
+  const handleSelectInsertLink = useCallback(() => {
+    setLinkUrl("");
+    setLinkTitle("");
+    setIsLinkDialogOpen(true);
+    setTimeout(() => {
+      linkInputRef.current?.focus();
+    }, 100);
+  }, []);
+
   useEffect(() => {
     const handlerCreateNoteShortcut = (e: KeyboardEvent) => {
       if (
         (e.metaKey || e.ctrlKey) &&
-        (e.metaKey || e.shiftKey) &&
+        e.shiftKey &&
         e.key.toLowerCase() === "o"
       ) {
         e.preventDefault();
@@ -219,7 +379,7 @@ export default function WorkingspaceNewDropdownBtn({
     window.addEventListener("keydown", handlerCreateNoteShortcut);
     return () =>
       window.removeEventListener("keydown", handlerCreateNoteShortcut);
-  }, []);
+  }, [handleCreateNote]);
 
   return (
     <>
@@ -276,9 +436,74 @@ export default function WorkingspaceNewDropdownBtn({
               <FileUp className="h-4 w-4 text-muted-foreground" />
               Upload PDF
             </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleSelectInsertLink}>
+              <Link2 className="h-4 w-4 text-muted-foreground" />
+              Insert Link
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      {/* Insert Link Dialog */}
+      <Dialog open={isLinkDialogOpen} onOpenChange={setIsLinkDialogOpen}>
+        <DialogContent className="sm:max-w-md bg-card border-border px-4 pt-4 pb-2.5">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Link2 className="h-5 w-5 text-primary" />
+              Insert Link
+            </DialogTitle>
+            <DialogDescription className="text-muted-foreground">
+              Paste a link from YouTube, X, LinkedIn, Instagram, or any website.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground">
+              URL <span className="text-destructive">*</span>
+            </label>
+            <Input
+              ref={linkInputRef}
+              value={linkUrl}
+              onChange={(e) => setLinkUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !isInsertingLink) {
+                  e.preventDefault();
+                  void handleInsertLink();
+                }
+              }}
+              placeholder="https://youtube.com/watch?v=..."
+              className="border-border h-8"
+            />
+            {detectedPlatform && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground mt-1 px-1">
+                <PlatformIcon platform={detectedPlatform} className="h-4 w-4" />
+                <span>
+                  Detected:{" "}
+                  <span className="text-foreground font-medium">
+                    {PLATFORM_LABELS[detectedPlatform]}
+                  </span>
+                </span>
+              </div>
+            )}
+          </div>
+          <DialogFooter className=" flex-row-reverse w-full gap-2 pt-2.5">
+            <Button
+              variant="revDefault"
+              onClick={() => void handleInsertLink()}
+              disabled={isInsertingLink || !linkUrl.trim()}
+              className=" h-8 !rounded-none"
+            >
+              {isInsertingLink ? "Inserting..." : "Insert Link"}
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => setIsLinkDialogOpen(false)}
+              className="border-border h-8"
+            >
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-3.5", className)}
     {...props}
   />
 ));
@@ -57,7 +57,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-3.5 pt-0", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 
@@ -67,7 +67,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-3.5 pt-0", className)}
     {...props}
   />
 ));

--- a/convex/Linkmetadata.ts
+++ b/convex/Linkmetadata.ts
@@ -1,0 +1,355 @@
+import { action } from "./_generated/server";
+import { api } from "./_generated/api";
+import { v } from "convex/values";
+import { linkPlatformValidator, linkMetadataFields } from "./linkValidators";
+import {
+  extractYoutubeVideoId,
+  youtubeThumbnailUrl,
+} from "../lib/link-platform";
+
+const FETCH_TIMEOUT_MS = 12000;
+const MAX_HTML_LENGTH = 800_000;
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+type FetchedLinkMetadata = {
+  title?: string;
+  metadata: {
+    thumbnailUrl?: string;
+    authorName?: string;
+    authorHandle?: string;
+    publishedAt?: number;
+    duration?: string;
+    embedVideoId?: string;
+    siteName?: string;
+  };
+};
+
+async function fetchWithTimeout(url: string, init?: RequestInit) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      redirect: "follow",
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: "text/html,application/xhtml+xml,application/json,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        ...(init?.headers ?? {}),
+      },
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function decodeHtmlEntities(input: string): string {
+  if (!input) return input;
+  const named: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+  };
+  return input
+    .replace(/&(#x[0-9a-fA-F]+|#\d+|\w+);/g, (match, code: string) => {
+      if (code[0] === "#") {
+        const n =
+          code[1]?.toLowerCase() === "x"
+            ? parseInt(code.slice(2), 16)
+            : parseInt(code.slice(1), 10);
+        if (!Number.isNaN(n)) {
+          try {
+            return String.fromCodePoint(n);
+          } catch {
+            return match;
+          }
+        }
+        return match;
+      }
+      return named[code] ?? match;
+    })
+    .replace(/\\u003c/gi, "<")
+    .replace(/\\u003e/gi, ">")
+    .replace(/\\u0026/gi, "&");
+}
+
+function extractMeta(html: string, key: string): string | undefined {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+(?:property|name|itemprop)=["']${escapedKey}["'][^>]*content=["']([^"']*)["']`,
+      "i",
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']*)["'][^>]*(?:property|name|itemprop)=["']${escapedKey}["']`,
+      "i",
+    ),
+  ];
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) return decodeHtmlEntities(match[1]);
+  }
+  return undefined;
+}
+
+function extractTitleTag(html: string): string | undefined {
+  const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  return match?.[1] ? decodeHtmlEntities(match[1].trim()) : undefined;
+}
+
+async function fetchOgTags(url: string) {
+  const response = await fetchWithTimeout(url);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  const rawHtml = await response.text();
+  const html = rawHtml.slice(0, MAX_HTML_LENGTH);
+  return {
+    html,
+    title:
+      extractMeta(html, "og:title") ??
+      extractMeta(html, "twitter:title") ??
+      extractTitleTag(html),
+    image: extractMeta(html, "og:image") ?? extractMeta(html, "twitter:image"),
+    siteName: extractMeta(html, "og:site_name"),
+    author:
+      extractMeta(html, "twitter:creator") ??
+      extractMeta(html, "article:author") ??
+      extractMeta(html, "author"),
+  };
+}
+
+async function fetchYoutubeMetadata(url: string): Promise<FetchedLinkMetadata> {
+  const videoId = extractYoutubeVideoId(url) ?? undefined;
+
+  let title: string | undefined;
+  let authorName: string | undefined;
+  let thumbnailUrl: string | undefined = videoId
+    ? youtubeThumbnailUrl(videoId)
+    : undefined;
+  let publishedAt: number | undefined;
+  let duration: string | undefined;
+
+  try {
+    const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(
+      url,
+    )}&format=json`;
+    const response = await fetchWithTimeout(oembedUrl);
+    if (response.ok) {
+      const data = (await response.json()) as {
+        title?: string;
+        author_name?: string;
+        thumbnail_url?: string;
+      };
+      title = data.title;
+      authorName = data.author_name;
+      if (data.thumbnail_url) thumbnailUrl = data.thumbnail_url;
+    }
+  } catch (error) {
+    console.error("YouTube oEmbed failed:", error);
+  }
+
+  if (!videoId) {
+    return {
+      title,
+      metadata: {
+        thumbnailUrl,
+        authorName,
+        siteName: "YouTube",
+      },
+    };
+  }
+  return {
+    title,
+    metadata: {
+      thumbnailUrl,
+      authorName,
+      publishedAt,
+      duration,
+      siteName: "YouTube",
+      embedVideoId: videoId,
+    },
+  };
+}
+
+async function fetchXMetadata(url: string): Promise<FetchedLinkMetadata> {
+  let authorName: string | undefined;
+  let authorHandle: string | undefined;
+  let thumbnailUrl: string | undefined;
+
+  try {
+    const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(
+      url,
+    )}&omit_script=true`;
+    const response = await fetchWithTimeout(oembedUrl);
+    if (response.ok) {
+      const data = (await response.json()) as {
+        author_name?: string;
+        author_url?: string;
+        html?: string;
+      };
+      authorName = data.author_name;
+      authorHandle = data.author_url?.split("/").filter(Boolean).pop();
+    }
+  } catch (error) {
+    console.error("X oEmbed failed:", error);
+  }
+
+  try {
+    const og = await fetchOgTags(url);
+    thumbnailUrl = og.image;
+    if (!authorName && og.author) authorName = og.author.replace(/^@/, "");
+  } catch (error) {
+    console.error("X OG failed:", error);
+  }
+
+  return {
+    title: authorName ? `${authorName} on X` : undefined,
+    metadata: {
+      thumbnailUrl,
+      authorName,
+      authorHandle,
+      siteName: "X",
+    },
+  };
+}
+
+async function fetchInstagramMetadata(
+  url: string,
+): Promise<FetchedLinkMetadata> {
+  try {
+    const og = await fetchOgTags(url);
+    let authorName: string | undefined;
+    let authorHandle: string | undefined;
+    if (og.title) {
+      const titleDecoded = decodeHtmlEntities(og.title);
+      const onIg = titleDecoded.match(
+        /^(.+?)\s+on\s+Instagram\s*:?\s*[“"]?(.*?)[”"]?$/i,
+      );
+      if (onIg) {
+        authorName = onIg[1].trim();
+        authorHandle = onIg[1].trim();
+      }
+    }
+
+    return {
+      title: og.title ? decodeHtmlEntities(og.title) : undefined,
+      metadata: {
+        thumbnailUrl: og.image,
+        authorName,
+        authorHandle,
+        siteName: og.siteName ?? "Instagram",
+      },
+    };
+  } catch (error) {
+    console.error("Instagram OG failed:", error);
+    return { metadata: { siteName: "Instagram" } };
+  }
+}
+
+async function fetchLinkedInMetadata(
+  url: string,
+): Promise<FetchedLinkMetadata> {
+  try {
+    const og = await fetchOgTags(url);
+    return {
+      title: og.title ? decodeHtmlEntities(og.title) : undefined,
+      metadata: {
+        thumbnailUrl: og.image,
+        authorName: og.author,
+        siteName: og.siteName ?? "LinkedIn",
+      },
+    };
+  } catch (error) {
+    console.error("LinkedIn OG failed:", error);
+    return { metadata: { siteName: "LinkedIn" } };
+  }
+}
+
+async function fetchGenericOgMetadata(
+  url: string,
+): Promise<FetchedLinkMetadata> {
+  const og = await fetchOgTags(url);
+  return {
+    title: og.title ? decodeHtmlEntities(og.title) : undefined,
+    metadata: {
+      thumbnailUrl: og.image,
+      authorName: og.author,
+      siteName: og.siteName,
+    },
+  };
+}
+
+export const checkUrlEmbeddable = action({
+  args: { url: v.string() },
+  returns: v.object({ embeddable: v.boolean() }),
+  handler: async (_ctx, args) => {
+    try {
+      const parsed = new URL(args.url);
+      if (parsed.protocol !== "https:") {
+        return { embeddable: false };
+      }
+
+      const response = await fetchWithTimeout(args.url, { method: "GET" });
+      response.body?.cancel?.();
+
+      const xfo = response.headers.get("x-frame-options")?.toLowerCase();
+      if (xfo && (xfo.includes("deny") || xfo.includes("sameorigin"))) {
+        // SAMEORIGIN blocks us too since we're a different origin.
+        return { embeddable: false };
+      }
+
+      const csp = response.headers.get("content-security-policy");
+      if (csp) {
+        const match = csp.match(/frame-ancestors\s+([^;]+)/i);
+        if (match) {
+          const sources = match[1].trim();
+          if (sources === "'none'" || !sources.includes("*")) {
+            return { embeddable: false };
+          }
+        }
+      }
+
+      return { embeddable: true };
+    } catch (error) {
+      console.error("checkUrlEmbeddable failed:", error);
+      return { embeddable: false };
+    }
+  },
+});
+
+export const fetchLinkMetadata = action({
+  args: {
+    url: v.string(),
+    platform: linkPlatformValidator,
+  },
+  returns: v.object({
+    title: v.optional(v.string()),
+    metadata: v.object(linkMetadataFields),
+  }),
+  handler: async (_ctx, args): Promise<FetchedLinkMetadata> => {
+    try {
+      switch (args.platform) {
+        case "youtube":
+          return await fetchYoutubeMetadata(args.url);
+        case "x":
+          return await fetchXMetadata(args.url);
+        case "instagram":
+          return await fetchInstagramMetadata(args.url);
+        case "linkedin":
+          return await fetchLinkedInMetadata(args.url);
+        case "generic":
+        default:
+          return await fetchGenericOgMetadata(args.url);
+      }
+    } catch (error) {
+      console.error("fetchLinkMetadata failed:", error);
+      return { metadata: {} };
+    }
+  },
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,9 +8,12 @@
  * @module
  */
 
+import type * as Linkmetadata from "../Linkmetadata.js";
 import type * as ResendMagicLink from "../ResendMagicLink.js";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as linkValidators from "../linkValidators.js";
+import type * as links from "../links.js";
 import type * as messages from "../messages.js";
 import type * as notes from "../notes.js";
 import type * as notesTables from "../notesTables.js";
@@ -27,9 +30,12 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  Linkmetadata: typeof Linkmetadata;
   ResendMagicLink: typeof ResendMagicLink;
   auth: typeof auth;
   http: typeof http;
+  linkValidators: typeof linkValidators;
+  links: typeof links;
   messages: typeof messages;
   notes: typeof notes;
   notesTables: typeof notesTables;

--- a/convex/linkValidators.ts
+++ b/convex/linkValidators.ts
@@ -1,0 +1,27 @@
+import { v } from "convex/values";
+
+export const linkPlatformValidator = v.union(
+  v.literal("youtube"),
+  v.literal("x"),
+  v.literal("linkedin"),
+  v.literal("instagram"),
+  v.literal("generic"),
+);
+
+export const linkMetadataFields = {
+  description: v.optional(v.string()),
+  thumbnailUrl: v.optional(v.string()),
+  authorName: v.optional(v.string()),
+  authorHandle: v.optional(v.string()),
+  authorAvatarUrl: v.optional(v.string()),
+  publishedAt: v.optional(v.number()),
+  viewCount: v.optional(v.string()),
+  likeCount: v.optional(v.number()),
+  repostCount: v.optional(v.number()),
+  commentCount: v.optional(v.number()),
+  duration: v.optional(v.string()),
+  embedVideoId: v.optional(v.string()),
+  siteName: v.optional(v.string()),
+};
+
+export const linkMetadataValidator = v.optional(v.object(linkMetadataFields));

--- a/convex/links.ts
+++ b/convex/links.ts
@@ -1,0 +1,122 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { linkMetadataValidator, linkPlatformValidator } from "./linkValidators";
+
+async function assertTableAccess(
+  ctx: { db: any },
+  userId: string,
+  notesTableId: string | undefined,
+  workingSpaceId: string | undefined,
+) {
+  if (workingSpaceId) {
+    const workspace = await ctx.db.get(workingSpaceId);
+    if (!workspace || workspace.userId !== userId) {
+      throw new Error("Workspace not found or not authorized");
+    }
+  }
+
+  if (notesTableId) {
+    const table = await ctx.db.get(notesTableId);
+    if (!table) {
+      throw new Error("Table not found");
+    }
+
+    const workspace = await ctx.db.get(table.workingSpaceId);
+    if (!workspace || workspace.userId !== userId) {
+      throw new Error("Workspace not found or not authorized");
+    }
+
+    if (workingSpaceId && table.workingSpaceId !== workingSpaceId) {
+      throw new Error("Table does not belong to the provided workspace");
+    }
+  }
+}
+
+export const createLink = mutation({
+  args: {
+    url: v.string(),
+    platform: linkPlatformValidator,
+    metadata: linkMetadataValidator,
+    title: v.optional(v.string()),
+    workingSpaceId: v.optional(v.id("workingSpaces")),
+    notesTableId: v.optional(v.id("notesTables")),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    await assertTableAccess(
+      ctx,
+      userId,
+      args.notesTableId,
+      args.workingSpaceId,
+    );
+
+    const now = Date.now();
+    return await ctx.db.insert("links", {
+      url: args.url,
+      platform: args.platform,
+      metadata: args.metadata,
+      title: args.title,
+      userId,
+      workingSpaceId: args.workingSpaceId,
+      notesTableId: args.notesTableId,
+      favorite: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const getLinksByTableId = query({
+  args: {
+    notesTableId: v.id("notesTables"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const table = await ctx.db.get(args.notesTableId);
+    if (!table) {
+      throw new Error("Table not found");
+    }
+
+    const workspace = await ctx.db.get(table.workingSpaceId);
+    if (!workspace || workspace.userId !== userId) {
+      throw new Error("Workspace not found or not authorized");
+    }
+
+    return await ctx.db
+      .query("links")
+      .withIndex("by_notesTableId", (q) =>
+        q.eq("notesTableId", args.notesTableId),
+      )
+      .order("desc")
+      .collect();
+  },
+});
+
+export const deleteLink = mutation({
+  args: {
+    _id: v.id("links"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Unauthenticated");
+    }
+
+    const link = await ctx.db.get(args._id);
+    if (!link || link.userId !== userId) {
+      throw new Error("Link not found or not authorized");
+    }
+
+    await ctx.db.delete(args._id);
+    return args._id;
+  },
+});

--- a/convex/notesTables.ts
+++ b/convex/notesTables.ts
@@ -150,7 +150,7 @@ export const updateTable = mutation({
       throw new Error("Not authorized to update tables in this workspace");
     }
 
-    const generateSlugName = generateSlug(name ?? "Untitled");
+    const generateSlugName = generateSlug(name ?? table.name ?? "Untitled");
     // Check if the slug already exists and add incremental number if it does
     let slug = generateSlugName;
     let existingTable = await ctx.db
@@ -217,12 +217,26 @@ export const deleteTable = mutation({
       .collect();
 
     for (const note of notesToDelete) {
+      if (note.tags) {
+        for (const tagId of note.tags) {
+          await ctx.db.delete(tagId);
+        }
+      }
       await ctx.db.delete(note._id);
     }
 
     for (const pdf of pdfsToDelete) {
       await ctx.storage.delete(pdf.storageId);
       await ctx.db.delete(pdf._id);
+    }
+
+    const linksToDelete = await ctx.db
+      .query("links")
+      .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+      .collect();
+
+    for (const link of linksToDelete) {
+      await ctx.db.delete(link._id);
     }
 
     await ctx.db.delete(_id);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,7 @@
 import { authTables } from "@convex-dev/auth/server";
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { linkMetadataValidator, linkPlatformValidator } from "./linkValidators";
 
 export default defineSchema({
   ...authTables,
@@ -59,6 +60,22 @@ export default defineSchema({
   // New table for PDF uploads
   pdfs: defineTable({
     storageId: v.id("_storage"),
+    userId: v.id("users"),
+    workingSpaceId: v.optional(v.id("workingSpaces")),
+    notesTableId: v.optional(v.id("notesTables")),
+    title: v.optional(v.string()),
+    favorite: v.optional(v.boolean()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_workingSpaceId", ["workingSpaceId"])
+    .index("by_notesTableId", ["notesTableId"]),
+
+  links: defineTable({
+    url: v.string(),
+    platform: linkPlatformValidator,
+    metadata: linkMetadataValidator,
     userId: v.id("users"),
     workingSpaceId: v.optional(v.id("workingSpaces")),
     notesTableId: v.optional(v.id("notesTables")),

--- a/lib/link-platform.ts
+++ b/lib/link-platform.ts
@@ -1,0 +1,116 @@
+export type LinkPlatform =
+  | "youtube"
+  | "x"
+  | "linkedin"
+  | "instagram"
+  | "generic";
+
+export type LinkMetadata = {
+  description?: string;
+  thumbnailUrl?: string;
+  authorName?: string;
+  authorHandle?: string;
+  publishedAt?: number;
+  duration?: string;
+  embedVideoId?: string;
+  siteName?: string;
+};
+
+export function normalizeLinkUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+export function detectLinkPlatform(url: string): LinkPlatform {
+  try {
+    const parsed = new URL(normalizeLinkUrl(url));
+    const host = parsed.hostname.replace(/^www\./, "").toLowerCase();
+    if (host === "youtu.be" || host.endsWith("youtube.com")) return "youtube";
+    if (host === "x.com" || host === "twitter.com") return "x";
+    if (host.endsWith("linkedin.com")) return "linkedin";
+    if (host.endsWith("instagram.com")) return "instagram";
+    return "generic";
+  } catch {
+    return "generic";
+  }
+}
+
+export function extractYoutubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(normalizeLinkUrl(url));
+    const host = parsed.hostname.replace(/^www\./, "").toLowerCase();
+    if (host === "youtu.be") {
+      const id = parsed.pathname.slice(1).split("/")[0];
+      return id || null;
+    }
+    if (host.endsWith("youtube.com")) {
+      if (parsed.pathname.startsWith("/watch")) {
+        return parsed.searchParams.get("v");
+      }
+      if (parsed.pathname.startsWith("/embed/")) {
+        return parsed.pathname.split("/")[2] ?? null;
+      }
+      if (parsed.pathname.startsWith("/shorts/")) {
+        return parsed.pathname.split("/")[2] ?? null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function youtubeThumbnailUrl(videoId: string) {
+  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+}
+
+export function platformLabel(platform: LinkPlatform): string {
+  switch (platform) {
+    case "youtube":
+      return "YouTube";
+    case "x":
+      return "X";
+    case "linkedin":
+      return "LinkedIn";
+    case "instagram":
+      return "Instagram";
+    default:
+      return "Link";
+  }
+}
+
+export function buildDefaultLinkTitle(
+  url: string,
+  platform: LinkPlatform,
+  metadata?: LinkMetadata | null,
+): string {
+  if (metadata?.siteName && platform === "generic") {
+    return metadata.siteName;
+  }
+  if (metadata?.authorName && platform !== "generic") {
+    return metadata.authorName;
+  }
+  try {
+    const parsed = new URL(normalizeLinkUrl(url));
+    return parsed.hostname.replace(/^www\./, "");
+  } catch {
+    return "Saved link";
+  }
+}
+
+export function enrichMetadataForPlatform(
+  url: string,
+  platform: LinkPlatform,
+  metadata: LinkMetadata | undefined,
+): LinkMetadata | undefined {
+  if (platform !== "youtube") return metadata;
+  const videoId = extractYoutubeVideoId(url);
+  if (!videoId) return metadata;
+  return {
+    ...metadata,
+    embedVideoId: videoId,
+    thumbnailUrl: metadata?.thumbnailUrl ?? youtubeThumbnailUrl(videoId),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/file-saver": "^2.0.7",
-    "@types/node": "^20",
+    "@types/node": "^20.19.43",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/turndown": "^5.0.6",


### PR DESCRIPTION
## what changed
<img width="485" height="231" alt="image" src="https://github.com/user-attachments/assets/dd838b1f-3915-4fc9-b475-0f168185f3b9" />
<img width="1280" height="738" alt="image" src="https://github.com/user-attachments/assets/57d3583d-7a86-450c-8fc5-02a84fc41f96" />


* Added support for saving and managing links inside workspace tables.
* Added an **Insert Link** option to the create menu with a dedicated dialog for pasting URLs.
* Automatically detects supported platforms like YouTube, X, LinkedIn, and Instagram, fetches metadata when available, and stores link previews.
* Added new **Link** cards for both grid and list views, including thumbnails, platform information, quick open actions, and delete functionality.
* Added a content filter so users can quickly filter between Notes, PDFs, and different link types.
* Updated the workspace to display notes, PDFs, and links together in a single unified list while keeping search working across all supported content.
* Improved the timeline so links appear alongside notes and PDFs with the correct icon and navigation.
* Switched the grid layout to a masonry-style column layout for better use of available space and more consistent card sizing.
* Reduced card padding and adjusted card sizing to create a cleaner, more compact layout.
* Added the new Convex schema, API, and validators required for storing and managing links.
* Improved table cleanup by deleting associated links and note tags when a table is removed.
* Fixed a couple of edge cases, including safer workspace/table naming fallbacks and a keyboard shortcut dependency update.

Workspaces previously only supported notes and PDFs, making it difficult to keep external resources alongside related content. This change allows users to collect useful links directly inside their workspace while keeping everything organized in one place.

The new filtering options also make it much easier to focus on a specific type of content without affecting search, while the updated layout improves how mixed content is displayed.

### what's better 

* Users can save external resources directly inside their workspace instead of managing them elsewhere.
* Link previews make saved content easier to recognize and access.
* Filtering provides a faster way to browse large tables with mixed content.
* The masonry layout makes better use of screen space and creates a more balanced grid.
* Table deletion now performs a more complete cleanup by removing related links and tag records.
* Overall, the workspace feels more organized, flexible, and capable of handling different types of content in one place.
