### PR TITLE
improve link creation workflow

### DIFF
--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -44,7 +44,7 @@ import {
   type LinkPlatform,
 } from "@/lib/link-platform";
 
-type PreferredAction = "note" | "upload";
+type PreferredAction = "note" | "upload" | "link";
 
 const STORAGE_KEY = "notevo_workspace_primary_create_action";
 
@@ -122,7 +122,11 @@ export default function WorkingspaceNewDropdownBtn({
   useEffect(() => {
     if (typeof window === "undefined") return;
     const savedAction = window.localStorage.getItem(STORAGE_KEY);
-    if (savedAction === "note" || savedAction === "upload") {
+    if (
+      savedAction === "note" ||
+      savedAction === "upload" ||
+      savedAction === "link"
+    ) {
       setPreferredAction(savedAction);
     }
   }, []);
@@ -326,14 +330,29 @@ export default function WorkingspaceNewDropdownBtn({
     workingSpaceId,
   ]);
 
+  const handleSelectInsertLink = useCallback(() => {
+    persistPreferredAction("link");
+    setLinkUrl("");
+    setLinkTitle("");
+    setIsLinkDialogOpen(true);
+    setTimeout(() => {
+      linkInputRef.current?.focus();
+    }, 100);
+  }, [persistPreferredAction]);
+
   const handlePrimaryAction = useCallback(async () => {
     if (preferredAction === "upload") {
       fileInputRef.current?.click();
       return;
     }
 
+    if (preferredAction === "link") {
+      handleSelectInsertLink();
+      return;
+    }
+
     await handleCreateNote();
-  }, [handleCreateNote, preferredAction]);
+  }, [handleCreateNote, handleSelectInsertLink, preferredAction]);
 
   const handleFileChange = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -355,15 +374,6 @@ export default function WorkingspaceNewDropdownBtn({
     fileInputRef.current?.click();
   }, [persistPreferredAction]);
 
-  const handleSelectInsertLink = useCallback(() => {
-    setLinkUrl("");
-    setLinkTitle("");
-    setIsLinkDialogOpen(true);
-    setTimeout(() => {
-      linkInputRef.current?.focus();
-    }, 100);
-  }, []);
-
   useEffect(() => {
     const handlerCreateNoteShortcut = (e: KeyboardEvent) => {
       if (
@@ -380,6 +390,31 @@ export default function WorkingspaceNewDropdownBtn({
     return () =>
       window.removeEventListener("keydown", handlerCreateNoteShortcut);
   }, [handleCreateNote]);
+
+  useEffect(() => {
+    const handlerInsertLinkShortcut = (e: KeyboardEvent) => {
+      if (
+        e.shiftKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        e.key.toLowerCase() === "l"
+      ) {
+        const target = e.target as HTMLElement | null;
+        const tag = target?.tagName;
+        const isEditableTarget =
+          tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable;
+        if (isEditableTarget) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+        handleSelectInsertLink();
+      }
+    };
+    window.addEventListener("keydown", handlerInsertLinkShortcut);
+    return () =>
+      window.removeEventListener("keydown", handlerInsertLinkShortcut);
+  }, [handleSelectInsertLink]);
 
   return (
     <>
@@ -439,6 +474,14 @@ export default function WorkingspaceNewDropdownBtn({
             <DropdownMenuItem onClick={handleSelectInsertLink}>
               <Link2 className="h-4 w-4 text-muted-foreground" />
               Insert Link
+              <span className="inline-flex gap-0.5">
+                <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                  <span className="text-xs">Shift</span>
+                </kbd>
+                <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                  <span className="text-xs">L</span>
+                </kbd>
+              </span>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
## what changed
before : 
<img width="228" height="171" alt="image" src="https://github.com/user-attachments/assets/b65f9cf9-e945-464c-9d77-c71354ef9d9c" />

now : 
<img width="256" height="178" alt="image" src="https://github.com/user-attachments/assets/e210ccb1-e925-4d1f-867c-16261fc8942c" />

* Added **Link** as a supported primary create action, allowing users to keep it as their default action.
* Updated the primary create button to open the Insert Link dialog when Link is selected as the preferred action.
* Added a dedicated **Shift + L** keyboard shortcut to quickly open the Insert Link dialog from anywhere in the workspace.
* Displayed the new keyboard shortcut directly in the dropdown menu so it's easier to discover.
* Persisted the selected link action in local storage, keeping the user's preferred create action across sessions.

As link support becomes a core part of the workspace, creating links should be just as quick and accessible as creating notes or uploading PDFs. These changes reduce the number of clicks required, improve keyboard accessibility, and make the preferred workflow consistent between sessions.