### PR TITLE
simplify toggle action styling

### DIFF
--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -257,11 +257,11 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
     <NodeViewWrapper
       data-toggle-action
       style={wrapperStyle}
-      className="my-3 rounded-tl-lg border border-border bg-muted/20 text-foreground transition-colors group"
+      className="my-2 text-foreground transition-colors group"
     >
       <div
         contentEditable={false}
-        className="flex min-h-10 items-center gap-2 px-3 py-2"
+        className="flex min-h-10 items-center gap-0 px-1 py-1.5"
       >
         <Tooltip open={toggleTooltip.open} disableHoverableContent>
           <TooltipTrigger asChild>
@@ -269,7 +269,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               type="button"
               variant="Trigger"
               size="icon"
-              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground mt-px"
               style={contrastStyle}
               onClick={() => {
                 updateAttributes({ open: !isOpen });


### PR DESCRIPTION
## what changed

before : 
<img width="827" height="125" alt="image" src="https://github.com/user-attachments/assets/81edf147-b65b-468a-be4c-ddb8490a6086" />

now : 
<img width="905" height="164" alt="image" src="https://github.com/user-attachments/assets/b3c9692f-a26e-443c-99b2-81b3bf0788db" />


* Removed the bordered and muted background styling from toggle action blocks.
* Reduced the spacing around the toggle container to make it more compact.
* Tightened the padding and spacing inside the toggle header.
* Slightly adjusted the toggle button positioning for better vertical alignment.

The previous toggle styling added extra borders, background, and spacing that made the block feel heavier than the surrounding editor content. This update makes the toggle blend more naturally into the editor while keeping the interaction controls clear.