### PR TITLE
improve toggle action node styling

### DIFF
--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -257,11 +257,11 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
     <NodeViewWrapper
       data-toggle-action
       style={wrapperStyle}
-      className="my-2 text-foreground transition-colors group"
+      className="my-2 text-foreground bg-muted/50 rounded transition-colors group"
     >
       <div
         contentEditable={false}
-        className="flex min-h-10 items-center gap-0 px-1 py-1.5"
+        className="flex min-h-10 items-center gap-0 px-2 py-1.5"
       >
         <Tooltip open={toggleTooltip.open} disableHoverableContent>
           <TooltipTrigger asChild>


### PR DESCRIPTION
before : 
<img width="798" height="115" alt="image" src="https://github.com/user-attachments/assets/3b203f28-471b-4cf1-8c41-b290a19d77ba" />

now : 
<img width="899" height="142" alt="image" src="https://github.com/user-attachments/assets/3919ce9d-2002-47ee-b6ec-63299f4290bc" />


added a light muted background and rounded corners to the toggle action node, plus a bit more horizontal padding.
it was blending in too much before. now it stands out a little better and feels cleaner.