### PR TITLE
add links to workspace search

### DIFF
--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   Folder,
   FolderOpen,
+  Link2,
 } from "lucide-react";
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
@@ -194,6 +195,33 @@ function PdfItem({
   );
 }
 
+function LinkItem({ link, onClick, isSelected, query, indented = false }: any) {
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-2 mb-px py-1.5 px-2 cursor-pointer app-radius-lg transition-all",
+        indented && "ml-7",
+        isSelected ? "bg-border" : "hover:bg-border",
+      )}
+    >
+      <Link2 size={14} />
+      <div className="flex-1 overflow-hidden">
+        <p className="text-sm text-foreground font-medium truncate transition-colors">
+          <HighlightedText
+            text={link.title || link.url || "Untitled"}
+            query={query}
+          />
+        </p>
+      </div>
+      <div className="flex items-center gap-1 text-xs shrink-0 text-muted-foreground">
+        <Clock className="h-3 w-3" />
+        <span>{getRelativeTime(new Date(link.createdAt))}</span>
+      </div>
+    </div>
+  );
+}
+
 // Tables are now collapsible — each manages its own open/close state
 function TableSection({
   table,
@@ -206,6 +234,7 @@ function TableSection({
   const [isExpanded, setIsExpanded] = useState(true);
   const notes: any[] = table.notes ?? [];
   const pdfs: any[] = table.pdfs ?? [];
+  const links: any[] = table.links ?? [];
   const items = [
     ...notes.map((note) => ({ ...note, kind: "note" as const })),
     ...pdfs.map((pdf) => ({
@@ -213,6 +242,7 @@ function TableSection({
       kind: "pdf" as const,
       slug: buildPdfSlug(pdf.title),
     })),
+    ...links.map((link) => ({ ...link, kind: "link" as const })),
   ].sort((a, b) => b.createdAt - a.createdAt);
 
   return (
@@ -254,6 +284,19 @@ function TableSection({
                 isSelected={selectedNoteId === String(item._id)}
                 query={query}
                 onIntentPrefetch={onIntentPrefetch}
+                indented
+              />
+            ) : item.kind === "link" ? (
+              <LinkItem
+                key={item._id}
+                link={{
+                  ...item,
+                  workingSpaceName: workspace.name,
+                  tableName: table.name,
+                }}
+                onClick={(e: any) => onNoteClick(item, e)}
+                isSelected={selectedNoteId === String(item._id)}
+                query={query}
                 indented
               />
             ) : (
@@ -411,6 +454,12 @@ export default function SearchDialog({
           workingSpaceName: ws.name,
           tableName: t.name,
         })),
+        ...(t.links ?? []).map((link: any) => ({
+          ...link,
+          kind: "link" as const,
+          workingSpaceName: ws.name,
+          tableName: t.name,
+        })),
       ]),
     );
   }, [searchTargets]);
@@ -473,7 +522,7 @@ export default function SearchDialog({
   useEffect(() => {
     if (!open) return;
     const note = allNotes[selectedIndex];
-    if (!note) return;
+    if (!note || note.kind === "link") return;
     const href =
       note.kind === "pdf"
         ? `/home/${note.workingSpaceId}/pdf/${note.slug}?pdfId=${note._id}`
@@ -491,6 +540,10 @@ export default function SearchDialog({
   const { openPane } = useHomePane();
   const handleNoteClick = (note: any, event: any) => {
     setOpen(false);
+    if (note.kind === "link") {
+      window.open(note.url, "_blank", "noopener,noreferrer");
+      return;
+    }
     if (note.kind === "pdf") {
       if (event.button === 0 && event.altKey) {
         event.preventDefault();

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -464,11 +464,19 @@ export const getWorkspaceTree = query({
                 )
                 .order("desc")
                 .collect();
+              const allLinks = await ctx.db
+                .query("links")
+                .withIndex("by_notesTableId", (q) =>
+                  q.eq("notesTableId", table._id),
+                )
+                .order("desc")
+                .collect();
 
               return {
                 ...table,
                 notes: allNotes.map(({ body, ...rest }) => rest),
                 pdfs: allPdfs,
+                links: allLinks,
               };
             }
 
@@ -486,18 +494,29 @@ export const getWorkspaceTree = query({
               )
               .order("desc")
               .take(TREE_NOTES_PER_TABLE);
+            const firstLinks = await ctx.db
+              .query("links")
+              .withIndex("by_notesTableId", (q) =>
+                q.eq("notesTableId", table._id),
+              )
+              .order("desc")
+              .take(TREE_NOTES_PER_TABLE);
 
             return {
               ...table,
               notes: firstNotes.map(({ body, ...rest }) => rest),
               pdfs: firstPdfs,
+              links: firstLinks,
             };
           }),
         );
 
-        // Only keep tables that have at least one note or pdf
+        // Only keep tables that have at least one note, pdf, or link
         const nonEmptyTables = tablesWithNotes.filter(
-          (table) => table.notes.length > 0 || table.pdfs.length > 0,
+          (table) =>
+            table.notes.length > 0 ||
+            table.pdfs.length > 0 ||
+            (table.links?.length ?? 0) > 0,
         );
 
         // Drop workspace entirely if it has no non-empty tables
@@ -523,10 +542,22 @@ export const getWorkspaceTree = query({
             const matchingPdfs = table.pdfs.filter((pdf: any) =>
               normalizeSearchText(pdf.title).includes(normalizedQuery),
             );
+            const matchingLinks = (table.links ?? []).filter((link: any) =>
+              normalizeSearchText(link.title).includes(normalizedQuery),
+            );
 
             if (tableMatches) return table;
-            if (matchingNotes.length > 0 || matchingPdfs.length > 0)
-              return { ...table, notes: matchingNotes, pdfs: matchingPdfs };
+            if (
+              matchingNotes.length > 0 ||
+              matchingPdfs.length > 0 ||
+              matchingLinks.length > 0
+            )
+              return {
+                ...table,
+                notes: matchingNotes,
+                pdfs: matchingPdfs,
+                links: matchingLinks,
+              };
 
             return null;
           })


### PR DESCRIPTION
## what changed
<img width="1276" height="687" alt="image" src="https://github.com/user-attachments/assets/558ff2a7-c623-4218-82b9-174065f606a2" />
<img width="896" height="603" alt="image" src="https://github.com/user-attachments/assets/1f7daa4a-78e8-4da2-83f5-7b339abb1cca" />


* Added links to the global workspace search alongside notes and PDFs.
* Added a dedicated link search result with title, URL fallback, and relative creation time.
* Updated table sections to include saved links and keep them sorted with other content by creation date.
* Added link results to the overall search target list so they can be found across workspaces and tables.
* Added support for opening links directly in a new browser tab from search results.
* Prevented the search dialog from trying to prefetch or generate internal navigation URLs for external links.
* Updated the workspace tree query to return links for each table, including when searching.
* Updated the empty-table filtering logic so tables containing only links are still included in the workspace search tree.
* Added link title matching to the existing search filtering.

Links are now a first-class content type in Notevo, so they shouldn't be isolated from the existing search experience. Users should be able to find saved links through the same search flow they already use for notes and PDFs.