### PR TITLE
change table renaming

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -499,98 +499,75 @@ function TableTab({ table }: { table: any }) {
 
   return (
     <>
-      <Popover
-        open={isRenameOpen}
-        onOpenChange={(open) => {
-          if (open) {
-            setIsRenameOpen(true);
-            return;
-          }
-          handleRenameCancel();
-        }}
+      <div
+        className=" relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-44"
+        onMouseEnter={handleContentMouseEnter}
+        onMouseLeave={handleContentMouseLeave}
       >
-        <PopoverAnchor asChild>
-          <div
-            className=" relative flex-shrink-0 overflow-hidden group/tab hover:bg-card app-radius-lg min-w-44"
-            onMouseEnter={handleContentMouseEnter}
-            onMouseLeave={handleContentMouseLeave}
-          >
-            <TabsTrigger
-              value={table._id}
-              data-tab-id={table._id}
-              className=" px-4 py-2.5 rounded-none rounded-tl-lg w-full text-start whitespace-nowrap flex items-center gap-1.5 border-2 border-transparent border-b-0 data-[state=active]:border-border"
-              onDoubleClick={handleDoubleClick}
-              aria-label="rename-table"
-            >
-              <p className={cn(textClassName, "w-full")}>
-                {formatTableName(table.name)}
-              </p>
-            </TabsTrigger>
-            <div
-              className={cn(
-                "absolute inset-y-0 right-2 flex items-center",
-                isHovered ? "opacity-100 " : "opacity-0 pointer-events-none",
-              )}
-            >
-              <Tooltip open={deleteTooltip.open}>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={(e) => {
-                      if (e.button === 0 && e.shiftKey) {
-                        e.preventDefault();
-                        handleDelete();
-                      } else {
-                        setIsDeleteAlertOpen(true);
-                      }
-                    }}
-                    className=" px-1.5 h-7 text-foreground hover:text-destructive"
-                    aria-label="delete-table"
-                    {...deleteTooltip.triggerProps}
-                  >
-                    <X size={16} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent
-                  className=" !rounded-none"
-                  side="right"
-                  sideOffset={5}
-                >
-                  Delete table
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-        </PopoverAnchor>
-        <PopoverContent
-          align="start"
-          side="bottom"
-          sideOffset={3}
-          className="w-52 border-0 bg-transparent p-0"
-        >
-          <div className=" relative flex items-center gap-2">
+        {isRenameOpen ? (
+          <div className=" relative flex items-center gap-1.5 px-2 py-2 rounded-none rounded-tl-lg w-full border-2 border-border border-b-0 bg-card">
             <Input
               ref={inputRef as any}
               value={editedName}
               onChange={(e) => setEditedName(e.target.value)}
               onKeyDown={handleKeyDown}
+              onBlur={() => void handleRenameSave()}
               placeholder="Rename table"
-              className="h-8 border-border bg-background px-1 py-1"
+              aria-label="rename-table-input"
+              className="h-6 flex-grow border-none bg-transparent px-1 py-0 shadow-none focus-visible:ring-1 focus-visible:ring-ring"
             />
-            <Button
-              variant="ghost"
-              type="button"
-              size="icon"
-              onClick={() => void handleRenameSave()}
-              className=" absolute top-1/2 -translate-y-1/2 right-1 h-6 w-6 shrink-0 bg-primary text-primary-foreground hover:text-primary-foreground hover:bg-primary/80"
-              aria-label="save-table-name"
-            >
-              <Check className="h-4 w-4" />
-            </Button>
           </div>
-        </PopoverContent>
-      </Popover>
+        ) : (
+          <TabsTrigger
+            value={table._id}
+            data-tab-id={table._id}
+            className=" px-4 py-2.5 rounded-none rounded-tl-lg w-full text-start whitespace-nowrap flex items-center gap-1.5 border-2 border-transparent border-b-0 data-[state=active]:border-border"
+            onDoubleClick={handleDoubleClick}
+            aria-label="rename-table"
+          >
+            <p className={cn(textClassName, "w-full")}>
+              {formatTableName(table.name)}
+            </p>
+          </TabsTrigger>
+        )}
+        <div
+          className={cn(
+            "absolute inset-y-0 right-2 flex items-center",
+            isHovered && !isRenameOpen
+              ? "opacity-100 "
+              : "opacity-0 pointer-events-none",
+          )}
+        >
+          <Tooltip open={deleteTooltip.open}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={(e) => {
+                  if (e.button === 0 && e.shiftKey) {
+                    e.preventDefault();
+                    handleDelete();
+                  } else {
+                    setIsDeleteAlertOpen(true);
+                  }
+                }}
+                className=" px-1.5 h-7 text-foreground hover:text-destructive"
+                aria-label="delete-table"
+                {...deleteTooltip.triggerProps}
+              >
+                <X size={16} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent
+              className=" !rounded-none"
+              side="right"
+              sideOffset={5}
+            >
+              Delete table
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
 
       <AlertDialog open={isDeleteAlertOpen} onOpenChange={setIsDeleteAlertOpen}>
         <AlertDialogContent className="bg-card border border-border text-card-foreground">


### PR DESCRIPTION
## what changed
from : 
<img width="271" height="147" alt="image" src="https://github.com/user-attachments/assets/f5d558f7-b398-42c4-86f4-eff37d5faf8e" />

to : 
<img width="226" height="79" alt="image" src="https://github.com/user-attachments/assets/a6c2acab-ecc9-46d6-9a5c-b42a308d4abf" />


* Removed the popover-based table renaming UI.
* Renaming now happens directly inside the table tab instead of opening a separate popover.
* Added an inline input that replaces the table name while editing.
* Added automatic saving when the input loses focus.
* Kept the existing keyboard handling for saving/canceling the rename.
* Moved the delete button outside of the rename UI so it stays part of the tab and is hidden while renaming.
* Simplified the overall table tab structure by removing the extra popover anchor/content layers.

The previous rename flow added an extra UI layer just to edit a table name. Since the table name is already displayed directly in the tab, editing it in place is more natural and requires less interaction.

### what's better now

* Double-clicking a table name gives a more direct inline editing experience.
* No popover needs to open or position itself around the tab.
* Renaming feels faster and more natural.
