### PR TITLE
improve home page spacing and container width

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -140,7 +140,7 @@ export default function HomePageClient() {
   }, [viewer]);
 
   return (
-    <MaxWContainer className="relative my-5">
+    <MaxWContainer className="relative">
       {/* Hero Section */}
       <div className="overflow-hidden border border-border app-radius-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
         <header className="relative max-w-3xl mx-auto text-center">

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -965,7 +965,7 @@ export default function WorkingSpacePageClient({
   }, [workspace?.name, tables?.length]);
 
   return (
-    <MaxWContainer className="my-5 grid grid-cols-1">
+    <MaxWContainer className="grid grid-cols-1">
       <header>
         <div className="border border-border bg-muted app-radius-md flex justify-between items-end w-full">
           <div className="flex-1 px-1.5">

--- a/components/ui/MaxWContainer.tsx
+++ b/components/ui/MaxWContainer.tsx
@@ -8,7 +8,7 @@ export default function MaxWContainer({
   className,
 }: MaxWContainerProps) {
   return (
-    <div className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 ${className}`}>
+    <div className={`max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 ${className}`}>
       {children}
     </div>
   );


### PR DESCRIPTION
## what changed
before : 
<img width="1589" height="783" alt="image" src="https://github.com/user-attachments/assets/90a275b6-bc93-452c-b821-014499aeb12a" />

now :
<img width="1576" height="675" alt="image" src="https://github.com/user-attachments/assets/17398df5-e8ff-4c23-860a-7f77b4b8180d" />


* Removed the extra vertical margin from the home page and workspace page containers.
* Increased the maximum width of `MaxWContainer` from `max-w-7xl` to `1400px`.
* Kept the existing responsive horizontal padding and centered layout unchanged.

The previous container width and vertical margins were limiting how much space the home and workspace layouts could use. Removing the extra top/bottom spacing and increasing the max width gives the main content more room while keeping the layout centered and responsive.

### what's better now
* Home and workspace content can use more of the available screen width.
* The layout feels less constrained on larger displays.
