### PR TITLE
improve toggle controls and color picker styling

### DIFF
--- a/components/selectors/color-selector.tsx
+++ b/components/selectors/color-selector.tsx
@@ -129,7 +129,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
       </PopoverTrigger>
       <PopoverContent
         sideOffset={5}
-        className="my-1 rounded-tl-lg border border-border bg-muted px-1 py-2 transition-all [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
+        className="my-1 rounded-tl-lg px-1 py-2 transition-all flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
         align="start"
       >
         <div className="flex flex-col">

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -350,32 +350,32 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
 
         <div className="ml-auto flex items-center transition-opacity duration-150 ease-in-out opacity-0 group-hover:opacity-100">
           <Popover>
-            <PopoverTrigger>
-              <Tooltip open={customTooltip.open} disableHoverableContent>
-                <TooltipTrigger asChild>
+            <Tooltip open={customTooltip.open} disableHoverableContent>
+              <PopoverTrigger asChild>
+                <TooltipTrigger asChild {...customTooltip.triggerProps}>
                   <Button
                     type="button"
                     variant="Trigger"
                     size="icon"
                     className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
                     style={contrastStyle}
-                    aria-label=""
-                    {...customTooltip.triggerProps}
+                    aria-label="Customize toggle appearance"
                   >
                     <Palette className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
+              </PopoverTrigger>
 
-                <TooltipContent
-                  side="bottom"
-                  align="center"
-                  sideOffset={5}
-                  className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
-                >
-                  <p>Customize toggle appearance</p>
-                </TooltipContent>
-              </Tooltip>
-            </PopoverTrigger>
+              <TooltipContent
+                side="bottom"
+                align="center"
+                sideOffset={5}
+                className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
+              >
+                <p>Customize toggle appearance</p>
+              </TooltipContent>
+            </Tooltip>
+
             <PopoverContent
               align="end"
               side="bottom"


### PR DESCRIPTION
## what changed

* Removed the custom border, background, and scrollbar styling from the color selector popover.
* Simplified the color selector styling to rely more on the default popover appearance.
* Fixed the toggle customization button structure by properly nesting the tooltip and popover triggers.
* Added a clear `aria-label` for the toggle appearance customization button.
* Improved the tooltip setup so it is directly associated with the customization control.
* Kept the existing toggle customization popover behavior while making the trigger structure cleaner.

The color selector had extra styling that was no longer needed, while the toggle customization control had a more complicated tooltip/popover trigger structure than necessary. Simplifying both makes the components cleaner and improves the accessibility and reliability of the toggle control.
