### PR TITLE
prevent color picker autofocus

### DIFF
--- a/components/selectors/color-selector.tsx
+++ b/components/selectors/color-selector.tsx
@@ -129,6 +129,7 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
       </PopoverTrigger>
       <PopoverContent
         sideOffset={5}
+        onOpenAutoFocus={(event) => event.preventDefault()}
         className="my-1 rounded-tl-lg px-1 py-2 transition-all flex max-h-80 w-48 flex-col overflow-hidden overflow-y-auto p-1 shadow-xl"
         align="start"
       >


### PR DESCRIPTION
## what changed
<img width="219" height="326" alt="image" src="https://github.com/user-attachments/assets/60bbc500-476e-4015-b2fe-bdacab065551" />


* Prevented the color selector popover from automatically focusing an element when it opens.


Opening the color picker could cause focus to move unexpectedly to an element inside the popover. Preventing the default autofocus keeps the user's current focus and interaction state intact when opening the selector.

