### PR TITLE
improve tooltip hover delays

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -34,8 +34,8 @@ import { Textarea } from "@/components/ui/textarea";
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
-  const themeTooltip = useHoverTooltip(100);
-  const noteWidthTooltip = useHoverTooltip(100);
+  const themeTooltip = useHoverTooltip(200);
+  const noteWidthTooltip = useHoverTooltip(200);
   const { noteWidth, toggleWidth } = useNoteWidth();
   const isMobile = useMediaQuery({ maxWidth: 640 });
 

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -353,7 +353,7 @@ const CALENDAR_ZOOM_PADDING_DAYS: Record<CalendarZoom, number> = {
 };
 
 function TableTab({ table }: { table: any }) {
-  const deleteTooltip = useHoverTooltip(100);
+  const deleteTooltip = useHoverTooltip(200);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [editedName, setEditedName] = useState(table.name || "Untitled");
   const [isHovered, setIsHovered] = useState(false);
@@ -1966,7 +1966,7 @@ function CalendarGapMarker({
   };
   onToggle: () => void;
 }) {
-  const gapTooltip = useHoverTooltip(100);
+  const gapTooltip = useHoverTooltip(200);
   const hiddenDaysLabel = `${gap.emptyDays} hidden day${
     gap.emptyDays === 1 ? "" : "s"
   }`;

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -490,8 +490,8 @@ function PdfViewerContent({
   const { open, isMobile } = useSidebar();
   const [query, setQuery] = useState("");
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
-  const searchTooltip = useHoverTooltip(100);
-  const thumbnailsTooltip = useHoverTooltip(100);
+  const searchTooltip = useHoverTooltip(200);
+  const thumbnailsTooltip = useHoverTooltip(200);
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState(pdftitle || "");
   const nameInputRef = useRef<HTMLInputElement>(null);

--- a/components/PublicNote.tsx
+++ b/components/PublicNote.tsx
@@ -49,7 +49,7 @@ export default function PublicNote({
   const isMobile = useMediaQuery({ maxWidth: 640 });
   const [open, setOpen] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(150);
   const copyTooltip = useHoverTooltip(200);
 
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -124,7 +124,7 @@ function OpenInPaneButton({
   label: string;
   onOpen: () => void;
 }) {
-  const tooltip = useHoverTooltip(100);
+  const tooltip = useHoverTooltip(200);
 
   return (
     <Tooltip open={tooltip.open}>

--- a/components/home-components/HomePaneDrawer.tsx
+++ b/components/home-components/HomePaneDrawer.tsx
@@ -105,7 +105,7 @@ function HomePaneDrawer({
   const startXRef = useRef(0);
   const startWidthRef = useRef(DEFAULT_PANE_WIDTH);
   const rafRef = useRef<number>(0);
-  const closeTooltip = useHoverTooltip(100);
+  const closeTooltip = useHoverTooltip(200);
 
   useEffect(() => {
     const savedWidth = window.localStorage.getItem(PANE_WIDTH_STORAGE_KEY);

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -30,7 +30,7 @@ export default function NoteDownloadDropdown({
   className,
 }: NoteDownloadDropdownProps) {
   const { handleDownload } = useNoteDownload({ noteBody, noteTitle });
-  const tooltip = useHoverTooltip(100);
+  const tooltip = useHoverTooltip(200);
 
   const formats: {
     label: string;

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -86,7 +86,7 @@ export default function NoteSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(150);
 
   const { noteWidth, toggleWidth } = useNoteWidth();
 

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -89,7 +89,7 @@ export default function PdfSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(150);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -185,7 +185,7 @@ export default function TableSettings({
       setIsAlertOpen(false); // Close Alert after deletion
     }
   };
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(150);
   const createdAtText = formatTimestamp(table?.createdAt);
   const updatedAtText = formatTimestamp(table?.updatedAt);
   return (

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -62,7 +62,7 @@ export default function WorkingSpaceSettings({
   const [isDeleting, setIsDeleting] = useState(false);
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(150);
   const inputRef = useRef<HTMLInputElement>(null); // Ref for the input
 
   useEffect(() => {

--- a/components/table-controls.tsx
+++ b/components/table-controls.tsx
@@ -54,7 +54,7 @@ export const TableControls = ({ editor }: TableControlsProps) => {
 
   const menuRef = useRef<HTMLDivElement>(null);
   const pillRef = useRef<HTMLDivElement>(null);
-  const tooltip = useHoverTooltip();
+  const tooltip = useHoverTooltip(150);
   const focusCell = useCallback(
     (cell: HTMLElement) => {
       try {

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -178,9 +178,9 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
     setDraftTitle(title);
   }, [title]);
   const inputRef = useRef<HTMLInputElement>(null);
-  const titleTooltip = useHoverTooltip(100);
-  const toggleTooltip = useHoverTooltip(100);
-  const customTooltip = useHoverTooltip(100);
+  const titleTooltip = useHoverTooltip(200);
+  const toggleTooltip = useHoverTooltip(200);
+  const customTooltip = useHoverTooltip(200);
   const isDark = useIsDarkMode();
 
   const [style, setStyle] = useState<ToggleStyle>(DEFAULT_STYLE);


### PR DESCRIPTION
## what changed

* Increased the hover delay for tooltips across the app from `100ms` to `200ms` in places like the public note, PDF viewer, workspace tabs, calendar controls, sidebar, and toggle actions.
* Set a slightly shorter `150ms` delay for settings and editor controls where a faster response still feels useful.
* Applied the updated delays consistently across note, PDF, table, workspace, and toggle-related controls.

Some tooltips were appearing too quickly when the cursor briefly passed over controls, which could make the UI feel noisy or distracting. The updated delays give users a little more time to intentionally hover over an element before showing its tooltip.

### what's better now

* Tooltips are less likely to appear accidentally while moving around the UI.
* Hover interactions feel calmer and less distracting.
