### PR TITLE
increase tooltip hover delays

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -34,8 +34,8 @@ import { Textarea } from "@/components/ui/textarea";
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
-  const themeTooltip = useHoverTooltip(200);
-  const noteWidthTooltip = useHoverTooltip(200);
+  const themeTooltip = useHoverTooltip(300);
+  const noteWidthTooltip = useHoverTooltip(300);
   const { noteWidth, toggleWidth } = useNoteWidth();
   const isMobile = useMediaQuery({ maxWidth: 640 });
 

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -353,7 +353,7 @@ const CALENDAR_ZOOM_PADDING_DAYS: Record<CalendarZoom, number> = {
 };
 
 function TableTab({ table }: { table: any }) {
-  const deleteTooltip = useHoverTooltip(200);
+  const deleteTooltip = useHoverTooltip(300);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [editedName, setEditedName] = useState(table.name || "Untitled");
   const [isHovered, setIsHovered] = useState(false);
@@ -1966,7 +1966,7 @@ function CalendarGapMarker({
   };
   onToggle: () => void;
 }) {
-  const gapTooltip = useHoverTooltip(200);
+  const gapTooltip = useHoverTooltip(300);
   const hiddenDaysLabel = `${gap.emptyDays} hidden day${
     gap.emptyDays === 1 ? "" : "s"
   }`;

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -490,8 +490,8 @@ function PdfViewerContent({
   const { open, isMobile } = useSidebar();
   const [query, setQuery] = useState("");
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
-  const searchTooltip = useHoverTooltip(200);
-  const thumbnailsTooltip = useHoverTooltip(200);
+  const searchTooltip = useHoverTooltip(300);
+  const thumbnailsTooltip = useHoverTooltip(300);
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState(pdftitle || "");
   const nameInputRef = useRef<HTMLInputElement>(null);

--- a/components/PublicNote.tsx
+++ b/components/PublicNote.tsx
@@ -49,8 +49,8 @@ export default function PublicNote({
   const isMobile = useMediaQuery({ maxWidth: 640 });
   const [open, setOpen] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
-  const tooltip = useHoverTooltip(150);
-  const copyTooltip = useHoverTooltip(200);
+  const tooltip = useHoverTooltip(300);
+  const copyTooltip = useHoverTooltip(300);
 
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
     (local, args) => {

--- a/components/home-components/AccountSettingsDialog.tsx
+++ b/components/home-components/AccountSettingsDialog.tsx
@@ -175,7 +175,7 @@ export default function AccountSettingsDialog({
     useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [deleteConfirmationEmail, setDeleteConfirmationEmail] = useState("");
-  const removeAvatarTooltip = useHoverTooltip(150);
+  const removeAvatarTooltip = useHoverTooltip(300);
 
   useEffect(() => {
     if (!open) return;

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -124,7 +124,7 @@ function OpenInPaneButton({
   label: string;
   onOpen: () => void;
 }) {
-  const tooltip = useHoverTooltip(200);
+  const tooltip = useHoverTooltip(300);
 
   return (
     <Tooltip open={tooltip.open}>

--- a/components/home-components/HomePaneDrawer.tsx
+++ b/components/home-components/HomePaneDrawer.tsx
@@ -105,7 +105,7 @@ function HomePaneDrawer({
   const startXRef = useRef(0);
   const startWidthRef = useRef(DEFAULT_PANE_WIDTH);
   const rafRef = useRef<number>(0);
-  const closeTooltip = useHoverTooltip(200);
+  const closeTooltip = useHoverTooltip(300);
 
   useEffect(() => {
     const savedWidth = window.localStorage.getItem(PANE_WIDTH_STORAGE_KEY);

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -30,7 +30,7 @@ export default function NoteDownloadDropdown({
   className,
 }: NoteDownloadDropdownProps) {
   const { handleDownload } = useNoteDownload({ noteBody, noteTitle });
-  const tooltip = useHoverTooltip(200);
+  const tooltip = useHoverTooltip(300);
 
   const formats: {
     label: string;

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -86,7 +86,7 @@ export default function NoteSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
-  const tooltip = useHoverTooltip(150);
+  const tooltip = useHoverTooltip(300);
 
   const { noteWidth, toggleWidth } = useNoteWidth();
 

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -114,8 +114,8 @@ export default function NoteSettingsSidbar({
     });
   };
 
-  const pinTooltip = useHoverTooltip(200);
-  const deleteTooltip = useHoverTooltip(200);
+  const pinTooltip = useHoverTooltip(300);
+  const deleteTooltip = useHoverTooltip(300);
 
   return (
     <>

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -89,7 +89,7 @@ export default function PdfSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
-  const tooltip = useHoverTooltip(150);
+  const tooltip = useHoverTooltip(300);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -47,8 +47,8 @@ export default function PdfSettingsSidebar({
     });
   };
 
-  const pinTooltip = useHoverTooltip(200);
-  const deleteTooltip = useHoverTooltip(200);
+  const pinTooltip = useHoverTooltip(300);
+  const deleteTooltip = useHoverTooltip(300);
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -185,7 +185,7 @@ export default function TableSettings({
       setIsAlertOpen(false); // Close Alert after deletion
     }
   };
-  const tooltip = useHoverTooltip(150);
+  const tooltip = useHoverTooltip(300);
   const createdAtText = formatTimestamp(table?.createdAt);
   const updatedAtText = formatTimestamp(table?.updatedAt);
   return (

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -62,7 +62,7 @@ export default function WorkingSpaceSettings({
   const [isDeleting, setIsDeleting] = useState(false);
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const tooltip = useHoverTooltip(150);
+  const tooltip = useHoverTooltip(300);
   const inputRef = useRef<HTMLInputElement>(null); // Ref for the input
 
   useEffect(() => {

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -101,7 +101,7 @@ export default function WorkingSpaceSettingsSidbar({
 
   const tableCount = tables?.length || 0;
   const hasContent = tableCount > 0;
-  const deleteTooltip = useHoverTooltip(200);
+  const deleteTooltip = useHoverTooltip(300);
 
   return (
     <>

--- a/components/table-controls.tsx
+++ b/components/table-controls.tsx
@@ -54,7 +54,7 @@ export const TableControls = ({ editor }: TableControlsProps) => {
 
   const menuRef = useRef<HTMLDivElement>(null);
   const pillRef = useRef<HTMLDivElement>(null);
-  const tooltip = useHoverTooltip(150);
+  const tooltip = useHoverTooltip(300);
   const focusCell = useCallback(
     (cell: HTMLElement) => {
       try {

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -178,9 +178,9 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
     setDraftTitle(title);
   }, [title]);
   const inputRef = useRef<HTMLInputElement>(null);
-  const titleTooltip = useHoverTooltip(200);
-  const toggleTooltip = useHoverTooltip(200);
-  const customTooltip = useHoverTooltip(200);
+  const titleTooltip = useHoverTooltip(300);
+  const toggleTooltip = useHoverTooltip(300);
+  const customTooltip = useHoverTooltip(300);
   const isDark = useIsDarkMode();
 
   const [style, setStyle] = useState<ToggleStyle>(DEFAULT_STYLE);


### PR DESCRIPTION
## what changed

* Increased tooltip hover delays across the app to `300ms`.
* Updated tooltips in the public note, workspace tabs, calendar controls, PDF viewer, sidebar, pane drawer, note/PDF settings, table controls, and toggle actions.
* Added the same `300ms` delay to pin/delete tooltips in the note, PDF, and workspace settings sidebars.
* Standardized the previously mixed `150ms` and `200ms` delays so the tooltip behavior is more consistent across the app.

The previous tooltip delays were still short enough for tooltips to appear while users were simply moving their cursor across the interface. Increasing the delay gives users more time to intentionally hover over a control before the tooltip appears.

### what's better now
* Accidental tooltip popups should happen less often.
* Tooltip behavior is now much more consistent across different components.