### PR TITLE
prevent breadcrumb text selection

### DIFF
--- a/components/home-components/BreadcrumbWithCustomSeparator.tsx
+++ b/components/home-components/BreadcrumbWithCustomSeparator.tsx
@@ -54,7 +54,7 @@ export default function BreadcrumbWithCustomSeparator() {
 
   return (
     <div className="py-2">
-      <Breadcrumb>
+      <Breadcrumb className=" *:select-none">
         <BreadcrumbList className="flex flex-nowrap overflow-x-auto whitespace-nowrap text-primary !gap-0.5 [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable">
           {pathSegments.map((segment, index) => {
             // Build the path up to this segment


### PR DESCRIPTION
## what changed

before : 
<img width="392" height="107" alt="image" src="https://github.com/user-attachments/assets/608366e1-4f7f-4a4e-896f-e3a3a5e96bf7" />
 this is cant be cool lol 

now : 
<img width="290" height="52" alt="image" src="https://github.com/user-attachments/assets/3da29958-cd0a-4285-a4ed-14f0c86c0e00" />


* Added `select-none` to the `Breadcrumb` component.
* Prevented users from accidentally selecting breadcrumb text while interacting with the navigation.

Breadcrumbs are primarily navigation controls, so text selection isn't particularly useful there. This helps avoid accidentally highlighting breadcrumb text when clicking, dragging, or navigating through the path.

### what's better now
* Accidental text highlighting is avoided.
