### PR TITLE
shrink sidebar load more buttons

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -796,7 +796,7 @@ const PinnedNotesList = memo(function PinnedNotesList({
             variant="SidebarMenuButton"
             size="sm"
             onClick={() => loadMore(5)}
-            className="px-2 my-0.5 h-8 group flex-1"
+            className="px-2 my-0.5 h-7 group flex-1"
           >
             <ChevronDown size="16" className=" text-muted-foreground" />
             Show More
@@ -810,7 +810,7 @@ const PinnedNotesList = memo(function PinnedNotesList({
             variant="SidebarMenuButton"
             size="sm"
             disabled
-            className="px-2 my-0.5 h-8 group flex-1"
+            className="px-2 my-0.5 h-7 group flex-1"
           >
             <LoadingAnimation className="h-3 w-3" />
             Loading...
@@ -1095,7 +1095,7 @@ const PinnedUploadsList = memo(function PinnedUploadsList({
             variant="SidebarMenuButton"
             size="sm"
             onClick={() => loadMore(5)}
-            className="px-2 my-0.5 h-8 group flex-1"
+            className="px-2 my-0.5 h-7 group flex-1"
           >
             <ChevronDown size="16" className=" text-muted-foreground" />
             Show More
@@ -1109,7 +1109,7 @@ const PinnedUploadsList = memo(function PinnedUploadsList({
             variant="SidebarMenuButton"
             size="sm"
             disabled
-            className="px-2 my-0.5 h-8 group flex-1"
+            className="px-2 my-0.5 h-7 group flex-1"
           >
             <LoadingAnimation className="h-3 w-3" />
             Loading...


### PR DESCRIPTION
## what changed
before : 

now : 
<img width="243" height="88" alt="image" src="https://github.com/user-attachments/assets/44cc6f81-b61a-4157-add4-cc8748123cb3" />

* Reduced the height of the **Show More** and **Loading** buttons in the pinned notes section from `h-8` to `h-7`.
* Applied the same sizing adjustment to the pinned uploads section.
* Kept the existing spacing, icons, loading state, and button behavior unchanged.

The load-more controls were taking up a little more vertical space than necessary in the sidebar. Making them slightly shorter keeps the sidebar more compact without changing how they work.

* The sidebar feels more compact and balanced.

