### PR TITLE
fix workspace name truncation

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -25,7 +25,7 @@ const MAX_NAME_LENGTH = 50;
 const EMAIL_DISPLAY_REGEX = /(.{3}).*?(@.{3}).*/;
 
 export const formatWorkspaceNameForCreateSideBarBtn = (name: string) =>
-  name.length > 10 ? `${name.substring(0, 20)}...` : name;
+  name.length > 11 ? `${name.substring(0, 20)}...` : name;
 
 export const formatWorkspaceName = (name: string) =>
   name.length > MAX_NAME_LENGTH


### PR DESCRIPTION
before : 
<img width="287" height="146" alt="image" src="https://github.com/user-attachments/assets/ae76885b-64cc-4a8a-83a1-503a5a848e66" />
<img width="287" height="214" alt="image" src="https://github.com/user-attachments/assets/8fa3f17e-2538-4ed8-9329-15dc8ddb83fb" />

now : 
<img width="272" height="212" alt="image" src="https://github.com/user-attachments/assets/5cf53b15-216c-4ca4-ba30-f8e3b1f8f9b2" />
