### PR TITLE
tighten slider scroll button thresholds

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -297,11 +297,11 @@ function Slider({ children }: { children: React.ReactNode }) {
     const container = scrollContainerRef.current;
     if (!container) return;
     const hasOverflow = container.scrollWidth > container.clientWidth;
-    setCanScrollLeft(container.scrollLeft > 10);
+    setCanScrollLeft(container.scrollLeft > 0.2);
     setCanScrollRight(
       hasOverflow &&
         container.scrollLeft <
-          container.scrollWidth - container.clientWidth - 10,
+          container.scrollWidth - container.clientWidth - 0.2,
     );
   };
 


### PR DESCRIPTION
before : 
<img width="112" height="334" alt="image" src="https://github.com/user-attachments/assets/089a1c8c-64b0-4a9a-b11b-5a673389d5aa" />

now : 
<img width="150" height="331" alt="image" src="https://github.com/user-attachments/assets/d939d20a-42e3-4ff8-86eb-b12a2fa56392" />

lowered the scroll threshold for showing left/right arrows from 10px down to 0.2px.

the old buffer made the buttons disappear a bit too early near the edges. now they stay active until you’re basically fully scrolled, so the feedback feels more accurate.