### PR TITLE
refresh landing page footer

### DIFF
--- a/components/landingPage-components/Footer.tsx
+++ b/components/landingPage-components/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer() {
           </defs>
         </svg>
       </div>
-      <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 pb-48 bg-[#EFEFEF]">
+      <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 min-h-[60vh] pb-52 bg-[#EFEFEF]">
         <div className="max-w-6xl mx-auto py-5 px-6 md:px-12 lg:px-16">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
             <div>
@@ -162,8 +162,13 @@ export default function Footer() {
           </div>
         </div>
       </footer>
-      <h1 className="z-50 bg-gradient-to-b from-primary/30 from-60% to-100% to-transparent text-transparent bg-clip-text inline-block text-nowrap  text-[200px] absolute -bottom-6 right-0 align-bottom text-center pointer-events-none select-none w-full overflow-hidden font-bold tracking-tighter leading-[9rem] -indent-8">
-        Notes Without The Hassle
+      <h1
+        style={{
+          textShadow: "14px 14px 0 #644A40",
+        }}
+        className="z-50 text-primary/30 inline-block text-nowrap text-[60vh] absolute -bottom-0 right-0 align-bottom text-center pointer-events-none select-none w-full font-bold tracking-tight leading-[30vh] -indent-[10vh]"
+      >
+        Notevo
       </h1>
     </div>
   );


### PR DESCRIPTION
## why

before : 
<img width="1716" height="626" alt="image" src="https://github.com/user-attachments/assets/0fb2fe20-2e27-485e-96cf-7861524c8bb1" />
<img width="1705" height="264" alt="image" src="https://github.com/user-attachments/assets/d98dac30-d81c-466c-ac77-0e43f19e3782" />

now : 
<img width="1698" height="697" alt="image" src="https://github.com/user-attachments/assets/4c33f750-6a06-4a91-984d-9fec8d18dc9f" />
<img width="1721" height="678" alt="image" src="https://github.com/user-attachments/assets/9abc8d05-ca07-4454-b920-7184eab732b3" />


The previous footer used a large tagline as its main visual element, but it didn't emphasize the Notevo brand as strongly. The new design uses the Notevo name itself as the main decorative element and gives the footer more vertical space to make the ending of the landing page feel more intentional.

#### what's better now

* The viewport-based sizing makes the decoration scale better with different screen sizes.
* The text shadow adds more depth without needing additional elements.
* The increased footer height gives the section more breathing room and makes the overall landing page feel less cramped.
