### PR TITLE
adjust footer bottom spacing for mobile view

### DIFF
--- a/components/landingPage-components/Footer.tsx
+++ b/components/landingPage-components/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer() {
           </defs>
         </svg>
       </div>
-      <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 min-h-[60vh] pb-52 bg-[#EFEFEF]">
+      <footer className="relative w-full z-10 text-foreground mt-20 md:mt-28 min-h-[60vh] pb-[20rem] bg-[#EFEFEF]">
         <div className="max-w-6xl mx-auto py-5 px-6 md:px-12 lg:px-16">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
             <div>


### PR DESCRIPTION
before : 
<img width="494" height="419" alt="image" src="https://github.com/user-attachments/assets/222e54c4-62fb-4fc9-ae79-0ab33c11a45b" />

after the fix : 
<img width="502" height="511" alt="image" src="https://github.com/user-attachments/assets/d3c4cb96-d9e4-4552-a446-5978d4a03e94" />

The footer needed a bit more space at the bottom for mobile view to better accommodate the new oversized Notevo wordmark and its positioning. Using an explicit 20rem value gives more predictable spacing than the previous Tailwind spacing value.