### PR TITLE
prevent button text selection

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils";
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap app-radius-lg text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 outline-none ring-0",
+  "inline-flex items-center justify-center whitespace-nowrap app-radius-lg text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 outline-none ring-0 select-none",
   {
     // transition-all duration-300 hover:translate-x-[-4px] hover:translate-y-[-4px] hover:rounded-md hover:shadow-[4px_4px_0px_black] active:translate-x-[0px] active:translate-y-[0px] active:rounded-2xl active:shadow-none
     variants: {


### PR DESCRIPTION
## what changed
that is not cool 
<img width="270" height="75" alt="image" src="https://github.com/user-attachments/assets/e9de616c-2326-4e76-b546-249e8ea6c765" />


* Added `select-none` to the base button styles.
* This applies the behavior consistently to all button variants.


Button text can sometimes get accidentally selected when clicking, dragging, or interacting with buttons. Since button labels are interactive UI elements rather than content users need to select, text selection isn't useful here.

* Button labels can no longer be accidentally highlighted.
* Buttons feel more like proper interactive controls.
* The behavior is applied globally through the shared button component, so individual buttons don't need extra `select-none` classes.
* NO visual styling or button functionality was changed.
