### PR TITLE
make footer shadow responsive

### DIFF
--- a/components/landingPage-components/Footer.tsx
+++ b/components/landingPage-components/Footer.tsx
@@ -164,7 +164,7 @@ export default function Footer() {
       </footer>
       <h1
         style={{
-          textShadow: "14px 14px 0 #644A40",
+          textShadow: "2vh 2vh 0 #644A40",
         }}
         className="z-50 text-primary/30 inline-block text-nowrap text-[60vh] absolute -bottom-0 right-0 align-bottom text-center pointer-events-none select-none w-full font-bold tracking-tight leading-[30vh] -indent-[10vh]"
       >


### PR DESCRIPTION

before : 
<img width="1693" height="654" alt="image" src="https://github.com/user-attachments/assets/c2d05121-c80f-4ec5-9fa2-99112cc9b99f" />

after : 
<img width="1696" height="656" alt="image" src="https://github.com/user-attachments/assets/b7a902e4-ab83-45a5-b1bf-3dee8f3a5df7" />

The shadow was using a fixed pixel value, so it could look too large or too small depending on the screen size. Using vh makes the shadow scale with the viewport along with the large 60vh wordmark.