### PR TITLE
polish search and empty states

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -246,7 +246,7 @@ function HighlightText({ text, query }: { text: string; query?: string }) {
         part.toLowerCase() === trimmedQuery.toLowerCase() ? (
           <mark
             key={i}
-            className="bg-secondary text-secondary-foreground rounded-sm px-0.5"
+            className="text-secondary bg-secondary-foreground rounded-sm px-0.5"
           >
             {part}
           </mark>
@@ -2836,7 +2836,7 @@ function EmptySearchResults({
   onClearSearch,
 }: EmptySearchResultsProps) {
   return (
-    <Card className="bg-card/50 backdrop-blur-sm border-border">
+    <Card className="bg-transparent  border-0">
       <CardContent className="pt-12 pb-12 text-center">
         <div className="flex flex-col items-center justify-center">
           <div className="h-10 w-10 flex items-center justify-center mb-4">


### PR DESCRIPTION
## what changed
before :
<img width="1363" height="381" alt="image" src="https://github.com/user-attachments/assets/8b9df144-3427-40ee-9504-2309acea5739" />
<img width="503" height="459" alt="image" src="https://github.com/user-attachments/assets/c63a5760-83bb-4069-ba5b-926bb4e14316" />
<img width="468" height="432" alt="image" src="https://github.com/user-attachments/assets/c46cff84-e1ea-4e56-9f41-e523b22ba948" />

after : 
<img width="540" height="327" alt="image" src="https://github.com/user-attachments/assets/cc227612-b060-4338-b05f-663c80e02aa9" />
<img width="537" height="239" alt="image" src="https://github.com/user-attachments/assets/230c5f21-bd5f-40ea-ba0c-ac6d8eccb25a" />
<img width="1323" height="353" alt="image" src="https://github.com/user-attachments/assets/21356489-3ad7-4f1b-b241-dc279e037cff" />


* Updated the search result highlight styling to use the secondary text and background colors in the correct order.
* Removed the card background, border, and blur from the empty search results state.
* Kept the empty state more minimal so it doesn't look like an extra card inside the page.


The previous search highlight colors didn't have enough contrast and didn't match the intended styling. The empty search results message also felt too heavy with its card background, border, and backdrop blur.

## what’s better now

Search matches are easier to see and have a cleaner color treatment. The empty search state is also more lightweight and blends into the page better instead of looking like a separate card.
