### PR TITLE
improve workspace name display

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -994,7 +994,9 @@ export default function WorkingSpacePageClient({
                   title="Double-click to rename"
                   className="cursor-text app-radius-md border border-transparent px-2 hover:border-muted-foreground/20"
                 >
-                  {formatWorkspaceName(workspace.name)}
+                  {workspace.name.length > 20
+                    ? `${workspace.name.slice(0, 17)}...`
+                    : workspace.name}
                 </span>
               )}
             </h1>


### PR DESCRIPTION
## what changed

before : 
<img width="447" height="256" alt="image" src="https://github.com/user-attachments/assets/e20aab8b-c80b-49f9-b14f-9fef26229549" />

after : 
<img width="421" height="311" alt="image" src="https://github.com/user-attachments/assets/bf366be4-d947-4db1-aef1-24bb728390ea" />


* Added a 20-character limit to displayed workspace names.
* Workspace names longer than 20 characters are now shortened to the first 17 characters followed by `...`.
* Kept shorter workspace names unchanged.


Long workspace names can take up too much space in the workspace header and make the layout feel crowded. Limiting the displayed name keeps the header cleaner while still showing enough of the name to recognize the workspace.

Workspace titles are more consistent and take up less space, especially when users have long workspace names. The full name is still stored as normal, so this only affects how the name is displayed in the header.
