### PR TITLE
expand utility and content tests

### DIFF
--- a/lib/generateSlug.test.ts
+++ b/lib/generateSlug.test.ts
@@ -2,15 +2,20 @@ import { describe, expect, it } from "vitest";
 import { generateSlug } from "./generateSlug";
 
 describe("generateSlug", () => {
-  it("lowercases and replaces non-alphanumerics with hyphens", () => {
-    expect(generateSlug("Hello, World!")).toBe("hello-world");
-    expect(generateSlug("  Hello   World  ")).toBe("hello-world");
-    expect(generateSlug("A_B+C")).toBe("a-b-c");
+  it.each([
+    ["Hello, World!", "hello-world"],
+    ["  Hello   World  ", "hello-world"],
+    ["A_B+C", "a-b-c"],
+    ["Release Notes 2026", "release-notes-2026"],
+  ])("normalizes %s into a URL slug", (input, expected) => {
+    expect(generateSlug(input)).toBe(expected);
   });
 
-  it("trims leading/trailing hyphens", () => {
-    expect(generateSlug("---Hello---")).toBe("hello");
-    expect(generateSlug("   ")).toBe("");
+  it.each([
+    ["---Hello---", "hello"],
+    ["   ", ""],
+    ["!!!", ""],
+  ])("trims generated separators for %s", (input, expected) => {
+    expect(generateSlug(input)).toBe(expected);
   });
 });
-

--- a/lib/link-platform.test.ts
+++ b/lib/link-platform.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultLinkTitle,
+  detectLinkPlatform,
+  enrichMetadataForPlatform,
+  extractYoutubeVideoId,
+  normalizeLinkUrl,
+  platformLabel,
+  youtubeThumbnailUrl,
+} from "./link-platform";
+
+describe("normalizeLinkUrl", () => {
+  it.each([
+    ["example.com", "https://example.com"],
+    [" https://example.com/path ", "https://example.com/path"],
+    ["http://example.com", "http://example.com"],
+    ["", ""],
+  ])("normalizes %s", (input, expected) => {
+    expect(normalizeLinkUrl(input)).toBe(expected);
+  });
+});
+
+describe("detectLinkPlatform", () => {
+  it.each([
+    ["https://youtu.be/abc123", "youtube"],
+    ["youtube.com/watch?v=abc123", "youtube"],
+    ["https://x.com/notevo", "x"],
+    ["https://twitter.com/notevo", "x"],
+    ["https://www.linkedin.com/company/notevo", "linkedin"],
+    ["https://instagram.com/notevo", "instagram"],
+    ["https://example.com/article", "generic"],
+    ["not a url", "generic"],
+  ] as const)("detects %s as %s", (url, platform) => {
+    expect(detectLinkPlatform(url)).toBe(platform);
+  });
+});
+
+describe("youtube helpers", () => {
+  it.each([
+    ["https://youtu.be/video-id", "video-id"],
+    ["https://www.youtube.com/watch?v=watch-id", "watch-id"],
+    ["https://youtube.com/embed/embed-id", "embed-id"],
+    ["https://youtube.com/shorts/short-id", "short-id"],
+    ["https://example.com/watch?v=nope", null],
+    ["not a url", null],
+  ])("extracts YouTube video ids from %s", (url, expected) => {
+    expect(extractYoutubeVideoId(url)).toBe(expected);
+  });
+
+  it("builds a high quality YouTube thumbnail URL", () => {
+    expect(youtubeThumbnailUrl("abc123")).toBe(
+      "https://img.youtube.com/vi/abc123/hqdefault.jpg",
+    );
+  });
+
+  it("adds YouTube embed metadata without overwriting an existing thumbnail", () => {
+    expect(enrichMetadataForPlatform("youtu.be/abc123", "youtube", {})).toEqual({
+      embedVideoId: "abc123",
+      thumbnailUrl: "https://img.youtube.com/vi/abc123/hqdefault.jpg",
+    });
+
+    expect(
+      enrichMetadataForPlatform("youtu.be/abc123", "youtube", {
+        thumbnailUrl: "https://cdn.example.com/thumb.png",
+      }),
+    ).toEqual({
+      embedVideoId: "abc123",
+      thumbnailUrl: "https://cdn.example.com/thumb.png",
+    });
+  });
+
+  it("leaves non-YouTube metadata unchanged", () => {
+    const metadata = { siteName: "Example" };
+    expect(enrichMetadataForPlatform("https://example.com", "generic", metadata)).toBe(
+      metadata,
+    );
+  });
+});
+
+describe("link display labels", () => {
+  it.each([
+    ["youtube", "YouTube"],
+    ["x", "X"],
+    ["linkedin", "LinkedIn"],
+    ["instagram", "Instagram"],
+    ["generic", "Link"],
+  ] as const)("labels %s links", (platform, label) => {
+    expect(platformLabel(platform)).toBe(label);
+  });
+
+  it("prefers metadata when building default link titles", () => {
+    expect(
+      buildDefaultLinkTitle("https://example.com/post", "generic", {
+        siteName: "Example News",
+      }),
+    ).toBe("Example News");
+    expect(
+      buildDefaultLinkTitle("https://youtube.com/watch?v=abc", "youtube", {
+        authorName: "Notevo",
+      }),
+    ).toBe("Notevo");
+  });
+
+  it("falls back to a hostname or generic title", () => {
+    expect(buildDefaultLinkTitle("https://www.example.com/post", "generic")).toBe(
+      "example.com",
+    );
+    expect(buildDefaultLinkTitle("not a url", "generic")).toBe("Saved link");
+  });
+});

--- a/lib/parse-tiptap-content.test.ts
+++ b/lib/parse-tiptap-content.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   extractTextFromTiptap,
   getEmptyTiptapDoc,
@@ -7,7 +7,7 @@ import {
 } from "./parse-tiptap-content";
 
 describe("truncateText", () => {
-  it("returns empty string for empty input", () => {
+  it("returns an empty string for empty input", () => {
     expect(truncateText("")).toBe("");
   });
 
@@ -21,31 +21,13 @@ describe("truncateText", () => {
 });
 
 describe("extractTextFromTiptap", () => {
-  it("returns empty string for null/undefined", () => {
+  it("returns an empty string for nullish content", () => {
     expect(extractTextFromTiptap(null)).toBe("");
     expect(extractTextFromTiptap(undefined)).toBe("");
   });
 
   it("returns raw string when input is a non-JSON string", () => {
     expect(extractTextFromTiptap("plain text")).toBe("plain text");
-  });
-
-  it("extracts text from a basic TipTap JSON structure", () => {
-    const doc = {
-      type: "doc",
-      content: [
-        {
-          type: "paragraph",
-          content: [{ type: "text", text: "Hello" }],
-        },
-        {
-          type: "paragraph",
-          content: [{ type: "text", text: "World" }],
-        },
-      ],
-    };
-
-    expect(extractTextFromTiptap(doc)).toBe("HelloWorld");
   });
 
   it("handles a JSON string input that parses to TipTap content", () => {
@@ -57,20 +39,82 @@ describe("extractTextFromTiptap", () => {
     expect(extractTextFromTiptap(asString)).toBe("Hi");
   });
 
-  it("renders placeholders for nodes without text/content (e.g. image)", () => {
+  it("extracts text from paragraph and heading nodes", () => {
     const doc = {
       type: "doc",
-      content: [{ type: "image" }],
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello" }],
+        },
+        {
+          type: "heading",
+          content: [{ type: "text", text: "World" }],
+        },
+      ],
     };
 
-    expect(extractTextFromTiptap(doc)).toBe("[Image]");
+    expect(extractTextFromTiptap(doc)).toBe("HelloWorld");
+  });
+
+  it("renders placeholders for rich nodes without text content", () => {
+    const doc = {
+      type: "doc",
+      content: [{ type: "image" }, { type: "codeBlock" }],
+    };
+
+    expect(extractTextFromTiptap(doc)).toBe("[Image][Code Block]");
+  });
+
+  it("adds list markers for list item content", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ text: "Task" }] }],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(extractTextFromTiptap(doc)).toBe("- Task");
+  });
+
+  it("returns a fallback preview when extraction throws", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const content = {
+      get content() {
+        throw new Error("broken content");
+      },
+    };
+
+    expect(extractTextFromTiptap(content)).toBe(
+      "Unable to display content preview",
+    );
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });
 
 describe("parseTiptapContent", () => {
-  it("returns an empty doc for empty input", () => {
+  it("returns an empty TipTap doc for empty input", () => {
     expect(parseTiptapContent(undefined)).toEqual(getEmptyTiptapDoc());
     expect(parseTiptapContent("")).toEqual(getEmptyTiptapDoc());
+  });
+
+  it("returns a fresh empty doc each time", () => {
+    const firstDoc = getEmptyTiptapDoc();
+    firstDoc.content?.push({ type: "heading" });
+
+    expect(getEmptyTiptapDoc()).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
   });
 
   it("normalizes array content into a TipTap doc", () => {
@@ -80,14 +124,31 @@ describe("parseTiptapContent", () => {
     });
   });
 
-  it("falls back when the parsed value is not a TipTap doc", () => {
-    expect(parseTiptapContent('{"foo":"bar"}')).toEqual(getEmptyTiptapDoc());
+  it("parses valid JSON string docs", () => {
+    expect(parseTiptapContent('{"type":"doc","content":[{"type":"heading"}]}')).toEqual({
+      type: "doc",
+      content: [{ type: "heading" }],
+    });
   });
 
-  it("fills in a missing content array on doc nodes", () => {
+  it("uses the provided fallback for invalid JSON and unsupported objects", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fallback = { type: "doc", content: [{ type: "heading" }] };
+
+    expect(parseTiptapContent("{", fallback)).toBe(fallback);
+    expect(parseTiptapContent({ foo: "bar" }, fallback)).toBe(fallback);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("fills in an empty paragraph when doc content is missing or empty", () => {
     expect(parseTiptapContent({ type: "doc" })).toEqual({
       type: "doc",
-      content: [],
+      content: [{ type: "paragraph" }],
+    });
+    expect(parseTiptapContent({ type: "doc", content: [] })).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph" }],
     });
   });
 });

--- a/lib/parse-tiptap-content.ts
+++ b/lib/parse-tiptap-content.ts
@@ -99,6 +99,10 @@ function extractFromNodes(nodes: any[]): string {
         return node.text;
       }
 
+      if (node.type === "listItem") {
+        return node.content ? `- ${extractFromNodes(node.content)}` : "";
+      }
+
       if (node.content && Array.isArray(node.content)) {
         return extractFromNodes(node.content);
       }
@@ -118,8 +122,6 @@ function extractFromNodes(nodes: any[]): string {
           case "bulletList":
           case "orderedList":
             return node.content ? extractFromNodes(node.content) : "";
-          case "listItem":
-            return node.content ? `- ${extractFromNodes(node.content)}` : "";
           default:
             return node.content ? extractFromNodes(node.content) : "";
         }

--- a/lib/parseSlug.test.ts
+++ b/lib/parseSlug.test.ts
@@ -2,14 +2,23 @@ import { describe, expect, it } from "vitest";
 import { parseSlug } from "./parseSlug";
 
 describe("parseSlug", () => {
-  it("removes a trailing numeric suffix like -123", () => {
-    expect(parseSlug("my-workspace-123")).toBe("My Workspace");
-    expect(parseSlug("my-workspace-0")).toBe("My Workspace");
+  it.each([
+    ["my-workspace-123", "My Workspace"],
+    ["my-workspace-0", "My Workspace"],
+    ["project-plan-2026", "Project Plan"],
+  ])("removes a trailing numeric suffix from %s", (slug, expected) => {
+    expect(parseSlug(slug)).toBe(expected);
   });
 
-  it("keeps digits that are not a trailing numeric suffix", () => {
-    expect(parseSlug("note2-test")).toBe("Note2 Test");
-    expect(parseSlug("note-2-test")).toBe("Note 2 Test");
+  it.each([
+    ["note2-test", "Note2 Test"],
+    ["note-2-test", "Note 2 Test"],
+    ["v2-launch-plan-alpha", "V2 Launch Plan Alpha"],
+  ])("keeps non-trailing digits in %s", (slug, expected) => {
+    expect(parseSlug(slug)).toBe(expected);
+  });
+
+  it("converts hyphen-separated words into title case", () => {
+    expect(parseSlug("team-meeting-notes")).toBe("Team Meeting Notes");
   });
 });
-

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,36 +1,97 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   cn,
+  formatNoteTimestamp,
+  formatTableName,
   formatUserEmail,
   formatUserName,
   formatUserNoteTitle,
   formatWorkspaceName,
+  formatWorkspaceNameForCreateSideBarBtn,
 } from "./utils";
 
-describe("utils formatting", () => {
-  it("cn merges class names", () => {
-    expect(cn("p-2", false && "hidden", "p-4")).toBe("p-4");
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
   });
+};
 
-  it("formatWorkspaceName truncates to 50 chars", () => {
-    const name = "a".repeat(60);
-    expect(formatWorkspaceName(name)).toBe(`${"a".repeat(50)}...`);
-  });
-
-  it("formatUserName formats first name and last initial", () => {
-    expect(formatUserName("John Smith")).toBe("John S.");
-    expect(formatUserName("John")).toBe("John.");
-    expect(formatUserName(undefined)).toBeNull();
-  });
-
-  it("formatUserEmail masks the middle of the email", () => {
-    expect(formatUserEmail("abcdef@example.com")).toBe("abc...@exa");
-  });
-
-  it("formatUserNoteTitle truncates based on viewport width", () => {
-    // jsdom defaults; set explicitly for determinism
-    Object.defineProperty(window, "innerWidth", { value: 500, writable: true });
-    expect(formatUserNoteTitle("a".repeat(30))).toBe(`${"a".repeat(23)}…`);
+describe("cn", () => {
+  it("merges conditional classes and resolves Tailwind conflicts", () => {
+    expect(cn("p-2 text-sm", false && "hidden", "p-4", ["font-bold"])).toBe(
+      "text-sm p-4 font-bold",
+    );
   });
 });
 
+describe("name and email formatting", () => {
+  it("truncates workspace names for the places they appear", () => {
+    expect(formatWorkspaceName("a".repeat(51))).toBe(`${"a".repeat(50)}...`);
+    expect(formatWorkspaceNameForCreateSideBarBtn("a".repeat(21))).toBe(
+      `${"a".repeat(20)}...`,
+    );
+  });
+
+  it("keeps short workspace names unchanged", () => {
+    expect(formatWorkspaceName("Product notes")).toBe("Product notes");
+    expect(formatWorkspaceNameForCreateSideBarBtn("Inbox")).toBe("Inbox");
+  });
+
+  it("formats display names with a first name and optional last initial", () => {
+    expect(formatUserName("John Smith")).toBe("John S.");
+    expect(formatUserName("John")).toBe("John.");
+    expect(formatUserName("Longfirstname Smith")).toBe("Longfirstn... S.");
+    expect(formatUserName(undefined)).toBeNull();
+  });
+
+  it("masks the middle of valid emails and handles empty values", () => {
+    expect(formatUserEmail("abcdef@example.com")).toBe("abc...@exa");
+    expect(formatUserEmail(undefined)).toBe("");
+  });
+});
+
+describe("responsive labels", () => {
+  beforeEach(() => {
+    setViewportWidth(1280);
+  });
+
+  it.each([
+    { width: 500, visibleChars: 23 },
+    { width: 800, visibleChars: 35 },
+    { width: 1280, visibleChars: 60 },
+  ])("truncates note titles for a $width px viewport", ({ width, visibleChars }) => {
+    setViewportWidth(width);
+    expect(formatUserNoteTitle("a".repeat(80))).toBe(
+      `${"a".repeat(visibleChars)}…`,
+    );
+  });
+
+  it.each([
+    { width: 500, visibleChars: 10 },
+    { width: 800, visibleChars: 15 },
+    { width: 1280, visibleChars: 20 },
+  ])("truncates table names for a $width px viewport", ({ width, visibleChars }) => {
+    setViewportWidth(width);
+    expect(formatTableName("a".repeat(30))).toBe(
+      `${"a".repeat(visibleChars)}...`,
+    );
+  });
+
+  it("returns empty strings for empty responsive labels", () => {
+    expect(formatUserNoteTitle("")).toBe("");
+    expect(formatTableName("")).toBe("");
+  });
+});
+
+describe("date formatting", () => {
+  it("formats timestamps as compact calendar dates", () => {
+    expect(formatNoteTimestamp(Date.UTC(2026, 0, 2))).toMatch(/^Jan 2, 2026$/);
+  });
+
+  it("returns an empty string when no timestamp is available", () => {
+    expect(formatNoteTimestamp()).toBe("");
+    expect(formatNoteTimestamp(0)).toBe("");
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 // Mock Next.js router
 vi.mock('next/navigation', () => ({


### PR DESCRIPTION
## what changed

* Expanded test coverage across the slug, TipTap content, and utility helpers.
* Added more edge cases for slug generation, including numbers, separators, and empty results.
* Added TipTap tests for JSON string input, headings, images, code blocks, list items, and extraction failures.
* Added tests for fallback behavior when parsing invalid or unsupported TipTap content.
* Added more coverage for workspace names, user names, emails, note titles, table names, and timestamps.
* Added responsive viewport tests to make sure note titles and table names truncate correctly on mobile, tablet, and desktop.
* Improved the Vitest setup to automatically clean up rendered components and clear mocks after every test.


A lot of the utility and content parsing logic had limited coverage, especially around edge cases and different types of input. This makes it easier for small changes to formatting, parsing, or slug generation to introduce regressions without being caught.

The tests now cover more realistic inputs and failure cases, including malformed content and different viewport sizes.

## what’s better now

The core utility functions have much stronger regression coverage, so changes to formatting and TipTap parsing are easier to verify.

The tests are also more maintainable now by using `it.each` for similar cases instead of repeating the same test structure. Responsive formatting behavior is explicitly tested across different screen sizes, and the shared Vitest cleanup prevents state and mocks from leaking between tests.

This should make the test suite more reliable and give us better confidence when changing these shared utilities.
