### PR TITLE
tune tooltip hover delays

### DIFF
--- a/app/(shere)/public/document/[id]/page.tsx
+++ b/app/(shere)/public/document/[id]/page.tsx
@@ -34,8 +34,8 @@ import { Textarea } from "@/components/ui/textarea";
 export default function PublicNotePage() {
   const { resolvedTheme, setTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
-  const themeTooltip = useHoverTooltip(300);
-  const noteWidthTooltip = useHoverTooltip(300);
+  const themeTooltip = useHoverTooltip(100);
+  const noteWidthTooltip = useHoverTooltip(100);
   const { noteWidth, toggleWidth } = useNoteWidth();
   const isMobile = useMediaQuery({ maxWidth: 640 });
 

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -359,7 +359,7 @@ const CALENDAR_ZOOM_PADDING_DAYS: Record<CalendarZoom, number> = {
 };
 
 function TableTab({ table }: { table: any }) {
-  const deleteTooltip = useHoverTooltip(300);
+  const deleteTooltip = useHoverTooltip(100);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
   const [editedName, setEditedName] = useState(table.name || "Untitled");
   const [isHovered, setIsHovered] = useState(false);
@@ -1970,7 +1970,7 @@ function CalendarGapMarker({
   };
   onToggle: () => void;
 }) {
-  const gapTooltip = useHoverTooltip(300);
+  const gapTooltip = useHoverTooltip(100);
   const hiddenDaysLabel = `${gap.emptyDays} hidden day${
     gap.emptyDays === 1 ? "" : "s"
   }`;

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -490,8 +490,8 @@ function PdfViewerContent({
   const { open, isMobile } = useSidebar();
   const [query, setQuery] = useState("");
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
-  const searchTooltip = useHoverTooltip(300);
-  const thumbnailsTooltip = useHoverTooltip(300);
+  const searchTooltip = useHoverTooltip(100);
+  const thumbnailsTooltip = useHoverTooltip(100);
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState(pdftitle || "");
   const nameInputRef = useRef<HTMLInputElement>(null);

--- a/components/PublicNote.tsx
+++ b/components/PublicNote.tsx
@@ -49,8 +49,8 @@ export default function PublicNote({
   const isMobile = useMediaQuery({ maxWidth: 640 });
   const [open, setOpen] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
-  const tooltip = useHoverTooltip(300);
-  const copyTooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
+  const copyTooltip = useHoverTooltip(100);
 
   const updateNote = useMutation(api.notes.updateNote).withOptimisticUpdate(
     (local, args) => {

--- a/components/home-components/AccountSettingsDialog.tsx
+++ b/components/home-components/AccountSettingsDialog.tsx
@@ -175,7 +175,7 @@ export default function AccountSettingsDialog({
     useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [deleteConfirmationEmail, setDeleteConfirmationEmail] = useState("");
-  const removeAvatarTooltip = useHoverTooltip(300);
+  const removeAvatarTooltip = useHoverTooltip(100);
 
   useEffect(() => {
     if (!open) return;

--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -128,7 +128,7 @@ function OpenInPaneButton({
   label: string;
   onOpen: () => void;
 }) {
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(400);
 
   return (
     <Tooltip open={tooltip.open}>
@@ -501,7 +501,7 @@ interface PinnedNoteItemProps {
 
 const PinnedNoteItem = memo(
   function PinnedNoteItem({ note, pathname, open }: PinnedNoteItemProps) {
-    const titleTooltip = useHoverTooltip(300);
+    const titleTooltip = useHoverTooltip(400);
     const { openPane } = useHomePane();
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -833,7 +833,7 @@ interface PinnedUploadItemProps {
 
 const PinnedUploadItem = memo(
   function PinnedUploadItem({ pdf, pathname, open }: PinnedUploadItemProps) {
-    const titleTooltip = useHoverTooltip(300);
+    const titleTooltip = useHoverTooltip(400);
     const { openPane } = useHomePane();
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -1167,7 +1167,7 @@ function SidebarLinkFavicon({
 
 const PinnedLinkItem = memo(
   function PinnedLinkItem({ link, open }: PinnedLinkItemProps) {
-    const titleTooltip = useHoverTooltip(300);
+    const titleTooltip = useHoverTooltip(400);
     const [isHovered, setIsHovered] = useState(false);
 
     const displayTitle =
@@ -1356,7 +1356,7 @@ interface WorkspaceItemProps {
 
 const WorkspaceItem = memo(
   function WorkspaceItem({ workingSpace, pathname, open }: WorkspaceItemProps) {
-    const titleTooltip = useHoverTooltip(300);
+    const titleTooltip = useHoverTooltip(400);
     const { openPane } = useHomePane();
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -1583,7 +1583,7 @@ const WorkspacesList = memo(function WorkspacesList({
   pathname,
   open,
 }: WorkspacesListProps) {
-  const addWorkspaceTooltip = useHoverTooltip(300);
+  const addWorkspaceTooltip = useHoverTooltip(400);
 
   return (
     <SidebarGroup>

--- a/components/home-components/HomePaneDrawer.tsx
+++ b/components/home-components/HomePaneDrawer.tsx
@@ -105,7 +105,7 @@ function HomePaneDrawer({
   const startXRef = useRef(0);
   const startWidthRef = useRef(DEFAULT_PANE_WIDTH);
   const rafRef = useRef<number>(0);
-  const closeTooltip = useHoverTooltip(300);
+  const closeTooltip = useHoverTooltip(400);
 
   useEffect(() => {
     const savedWidth = window.localStorage.getItem(PANE_WIDTH_STORAGE_KEY);

--- a/components/home-components/LinkSettings.tsx
+++ b/components/home-components/LinkSettings.tsx
@@ -80,7 +80,7 @@ export default function LinkSettings({
 }: LinkSettingsProps) {
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
 
   const updateLink = useMutation(api.links.updateLink);
   const deleteLink = useMutation(api.links.deleteLink);

--- a/components/home-components/LinkSettingsSidebar.tsx
+++ b/components/home-components/LinkSettingsSidebar.tsx
@@ -67,8 +67,8 @@ export default function LinkSettingsSidebar({
     }
   };
 
-  const pinTooltip = useHoverTooltip(300);
-  const deleteTooltip = useHoverTooltip(300);
+  const pinTooltip = useHoverTooltip(100);
+  const deleteTooltip = useHoverTooltip(100);
 
   return (
     <>

--- a/components/home-components/NoteDownloadDropdown.tsx
+++ b/components/home-components/NoteDownloadDropdown.tsx
@@ -30,7 +30,7 @@ export default function NoteDownloadDropdown({
   className,
 }: NoteDownloadDropdownProps) {
   const { handleDownload } = useNoteDownload({ noteBody, noteTitle });
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
 
   const formats: {
     label: string;

--- a/components/home-components/NoteSettings.tsx
+++ b/components/home-components/NoteSettings.tsx
@@ -86,7 +86,7 @@ export default function NoteSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
 
   const { noteWidth, toggleWidth } = useNoteWidth();
 

--- a/components/home-components/NoteSettingsSidbar.tsx
+++ b/components/home-components/NoteSettingsSidbar.tsx
@@ -114,8 +114,8 @@ export default function NoteSettingsSidbar({
     });
   };
 
-  const pinTooltip = useHoverTooltip(300);
-  const deleteTooltip = useHoverTooltip(300);
+  const pinTooltip = useHoverTooltip(100);
+  const deleteTooltip = useHoverTooltip(100);
 
   return (
     <>

--- a/components/home-components/PdfSettings.tsx
+++ b/components/home-components/PdfSettings.tsx
@@ -89,7 +89,7 @@ export default function PdfSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const pdf = useQuery(api.pdfs.getPdfById, { _id: pdfId });

--- a/components/home-components/PdfSettingsSidebar.tsx
+++ b/components/home-components/PdfSettingsSidebar.tsx
@@ -47,8 +47,8 @@ export default function PdfSettingsSidebar({
     });
   };
 
-  const pinTooltip = useHoverTooltip(300);
-  const deleteTooltip = useHoverTooltip(300);
+  const pinTooltip = useHoverTooltip(100);
+  const deleteTooltip = useHoverTooltip(100);
 
   const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -185,7 +185,7 @@ export default function TableSettings({
       setIsAlertOpen(false); // Close Alert after deletion
     }
   };
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
   const createdAtText = formatTimestamp(table?.createdAt);
   const updatedAtText = formatTimestamp(table?.updatedAt);
   return (

--- a/components/home-components/WorkingSpaceSettings.tsx
+++ b/components/home-components/WorkingSpaceSettings.tsx
@@ -62,7 +62,7 @@ export default function WorkingSpaceSettings({
   const [isDeleting, setIsDeleting] = useState(false);
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
   const inputRef = useRef<HTMLInputElement>(null); // Ref for the input
 
   useEffect(() => {

--- a/components/home-components/WorkingSpaceSettingsSidbar.tsx
+++ b/components/home-components/WorkingSpaceSettingsSidbar.tsx
@@ -101,7 +101,7 @@ export default function WorkingSpaceSettingsSidbar({
 
   const tableCount = tables?.length || 0;
   const hasContent = tableCount > 0;
-  const deleteTooltip = useHoverTooltip(300);
+  const deleteTooltip = useHoverTooltip(100);
 
   return (
     <>

--- a/components/selectors/text-buttons.tsx
+++ b/components/selectors/text-buttons.tsx
@@ -35,7 +35,7 @@ function ToolbarTooltipButton({
   label: string;
   shortcut: string;
 } & ComponentProps<typeof Button>) {
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(400);
 
   return (
     <Tooltip open={tooltip.open}>

--- a/components/table-controls.tsx
+++ b/components/table-controls.tsx
@@ -54,7 +54,7 @@ export const TableControls = ({ editor }: TableControlsProps) => {
 
   const menuRef = useRef<HTMLDivElement>(null);
   const pillRef = useRef<HTMLDivElement>(null);
-  const tooltip = useHoverTooltip(300);
+  const tooltip = useHoverTooltip(100);
   const focusCell = useCallback(
     (cell: HTMLElement) => {
       try {

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -178,9 +178,9 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
     setDraftTitle(title);
   }, [title]);
   const inputRef = useRef<HTMLInputElement>(null);
-  const titleTooltip = useHoverTooltip(300);
-  const toggleTooltip = useHoverTooltip(300);
-  const customTooltip = useHoverTooltip(300);
+  const titleTooltip = useHoverTooltip(100);
+  const toggleTooltip = useHoverTooltip(100);
+  const customTooltip = useHoverTooltip(100);
   const isDark = useIsDarkMode();
 
   const [style, setStyle] = useState<ToggleStyle>(DEFAULT_STYLE);


### PR DESCRIPTION
## what changed

* Reduced most tooltip delays from `300ms` to `100ms` across settings, editors, PDF controls, tables, and public notes.
* Increased sidebar and toolbar tooltip delays from `300ms` to `400ms`.
* Applied the same timing changes to pinned notes, pinned uploads, pinned links, workspaces, and sidebar actions.
* Updated the toggle action tooltips to appear faster as well.


The previous `300ms` delay didn't feel consistent across different parts of the app. Some tooltips are attached to frequently used actions where users benefit from faster feedback, while sidebar and toolbar tooltips can stay visible a little longer before appearing.

This adjusts the timings based on how the different tooltips are actually used instead of using the same delay everywhere.

## what’s better now

Most action tooltips now appear much faster, making buttons and controls easier to understand without having to wait. At the same time, sidebar and toolbar tooltips have a slightly longer delay to avoid appearing too quickly while moving through the navigation.
