### PR TITLE
polish toggle actions and media spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1073,7 +1073,7 @@ hr {
   position: relative;
   width: 100% !important;
   max-width: 100% !important;
-  margin: 1.5rem 0 !important;
+  margin: 0.5rem 0 !important;
   padding: 0 !important;
 }
 
@@ -1083,7 +1083,7 @@ hr {
   aspect-ratio: 16 / 9 !important;
   border-radius: 12px !important;
   border: 1px solid hsl(var(--muted)) !important;
-  display: block !important;
+  display: inline-block !important;
   max-width: 100% !important;
 }
 

--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -82,7 +82,7 @@ function hexToRgba(hex: string, opacityPercent: number) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-const MAX_BG_OPACITY = 70;
+const MAX_BG_OPACITY = 30;
 
 function getReadableTextColor(
   hex: string,
@@ -261,7 +261,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
     >
       <div
         contentEditable={false}
-        className="flex min-h-10 items-center gap-0 px-2 py-1.5"
+        className="flex min-h-10 items-center gap-0 px-1.5 py-1.5"
       >
         <Tooltip open={toggleTooltip.open} disableHoverableContent>
           <TooltipTrigger asChild>
@@ -269,7 +269,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               type="button"
               variant="Trigger"
               size="icon"
-              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground mt-px"
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
               style={contrastStyle}
               onClick={() => {
                 updateAttributes({ open: !isOpen });


### PR DESCRIPTION
## what changed

* Reduced the default background opacity for toggle actions from `70%` to `30%`.
* Tightened the horizontal padding inside toggle actions.
* Removed the extra top margin from the toggle trigger for better vertical alignment.
* Reduced the spacing around horizontal rules from `1.5rem` to `0.5rem`.
* Changed embedded media from `block` to `inline-block` display.

The toggle action background was too strong and could make the content feel visually heavy. Lowering the opacity keeps the background visible while making the content easier to read.

The toggle's internal spacing was also slightly too large, so tightening the padding and removing the extra margin makes the trigger feel more compact and aligned.

The editor's horizontal rules had too much vertical spacing around them, while media elements being forced to `block` could create unnecessary layout spacing.

## now

Toggle actions now have a lighter, cleaner appearance with less visual weight and tighter spacing. The editor also feels more compact around horizontal rules and embedded media, making the overall content layout less spaced out.
