### PR TITLE
improve pdf page metadata

### DIFF
--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -798,6 +798,36 @@ export default function PdfViewerPageClient({
   const viewerHostRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (!pdf?.title) return;
+
+    const originalTitle = document.title;
+    const metaDescription = document.querySelector('meta[name="description"]');
+    const originalContent = metaDescription?.getAttribute("content");
+    const pdfTitle = pdf.title || "Untitled PDF";
+
+    document.title = `${pdfTitle} - Notevo PDF`;
+    const descriptionContent = `${pdfTitle} PDF.`;
+
+    if (metaDescription) {
+      metaDescription.setAttribute("content", descriptionContent);
+    } else {
+      const newMeta = document.createElement("meta");
+      newMeta.name = "description";
+      newMeta.content = descriptionContent;
+      document.head.appendChild(newMeta);
+    }
+
+    return () => {
+      document.title = originalTitle;
+      if (metaDescription && originalContent) {
+        metaDescription.setAttribute("content", originalContent);
+      } else if (!metaDescription) {
+        document.querySelector('meta[name="description"]')?.remove();
+      }
+    };
+  }, [pdf?.title]);
+
+  useEffect(() => {
     setIsViewerReady(false);
     const frame = window.requestAnimationFrame(() => {
       setIsViewerReady(true);

--- a/app/home/[id]/pdf/[pdfId]/page.tsx
+++ b/app/home/[id]/pdf/[pdfId]/page.tsx
@@ -1,54 +1,6 @@
-import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import type { Id } from "@/convex/_generated/dataModel";
-import { api } from "@/convex/_generated/api";
-import { generateMetadata as generateSEOMetadata } from "@/lib/seo";
-import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
-import { fetchQuery } from "convex/nextjs";
 import PdfViewerPageClient from "./PdfViewerPageClient";
-
-export async function generateMetadata({
-  params,
-  searchParams,
-}: {
-  params: Promise<{ pdfId?: string }>;
-  searchParams: Promise<{ pdfId?: string | string[] }>;
-}): Promise<Metadata> {
-  const { pdfId: routeSegment } = await params;
-  const { pdfId } = await searchParams;
-  const resolvedPdfId =
-    typeof pdfId === "string"
-      ? pdfId
-      : Array.isArray(pdfId)
-        ? pdfId[0]
-        : routeSegment;
-
-  if (!resolvedPdfId) {
-    return generateSEOMetadata({
-      title: "PDF - Notevo",
-      description: "View PDF uploads in Notevo.",
-    });
-  }
-
-  try {
-    const token = await convexAuthNextjsToken();
-    const pdf = await fetchQuery(
-      api.pdfs.getPdfById,
-      { _id: resolvedPdfId as Id<"pdfs"> },
-      { token },
-    );
-
-    return generateSEOMetadata({
-      title: `${pdf.title || "Untitled PDF"} - Notevo`,
-      description: `View ${pdf.title || "this PDF"} in Notevo.`,
-    });
-  } catch {
-    return generateSEOMetadata({
-      title: "PDF - Notevo",
-      description: "View PDF uploads in Notevo.",
-    });
-  }
-}
 
 export default async function PdfViewerPage({
   params,


### PR DESCRIPTION
## what changed

* Added dynamic document titles for PDF viewer pages using the PDF's actual title.
* Added a dynamic meta description based on the PDF title.
* Added cleanup logic to restore the original page title and description when leaving the PDF viewer.
* Removed the server-side `generateMetadata` implementation and the extra Convex/SEO dependencies it required.
* Moved the metadata handling into the PDF viewer client component.
* 
The PDF metadata was being generated on the server by fetching the PDF again just to get its title. This added extra server-side logic and dependencies to the page.

Handling the metadata directly in the viewer lets the page update its title when the PDF data is available on the client, without needing a separate metadata fetch.

PDF pages now show a more useful browser title, such as `My Document - Notevo PDF`, along with a matching description.

The page component is also much simpler since it no longer needs to fetch the PDF separately just for metadata. The metadata is cleaned up when the viewer unmounts, so it doesn't leak into other pages during client-side navigation.
