### PR TITLE
prevent sidebar layout shifts for the CTA Btn

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -340,29 +340,33 @@ const SidebarHeaderSection = memo(function SidebarHeaderSection({
         <SidebarTrigger />
       </div>
       {getWorkingSpaces?.length === 0 && (
-        <Button
-          className="font-medium w-full h-9 flex justify-start items-center gap-1.5"
-          onClick={handleCreateWorkingSpace}
-        >
-          <FolderPlus size={16} /> Create Workspace
-        </Button>
+        <div className="flex h-[42px] p-[3px] w-full items-center overflow-hidden ">
+          <Button
+            className="font-medium w-full h-9 flex justify-start items-center gap-1.5"
+            onClick={handleCreateWorkingSpace}
+          >
+            <FolderPlus size={16} /> Create Workspace
+          </Button>
+        </div>
       )}
       {getWorkingSpaces?.length === 1 || getWorkingSpaces?.length === 0
         ? getWorkingSpaces.map((workingSpace) => (
-            <Button
-              key={workingSpace._id}
-              className="font-medium w-full h-9 flex justify-start items-center gap-1.5 "
-              disabled={loading}
-              onMouseDown={() => void createNoteInWorkspace(workingSpace)}
-            >
-              {loading ? (
-                <>redirecting...</>
-              ) : (
-                <>
-                  <SquarePen size={16} className=" mt-px" /> New Note
-                </>
-              )}
-            </Button>
+            <div className="flex h-[42px] p-[3px] w-full items-center overflow-hidden ">
+              <Button
+                key={workingSpace._id}
+                className="font-medium w-full h-9 flex justify-start items-center gap-1.5 "
+                disabled={loading}
+                onMouseDown={() => void createNoteInWorkspace(workingSpace)}
+              >
+                {loading ? (
+                  <>redirecting...</>
+                ) : (
+                  <>
+                    <SquarePen size={16} className=" mt-px" /> New Note
+                  </>
+                )}
+              </Button>
+            </div>
           ))
         : createNoteWorkspace && (
             <div className="flex h-[42px] p-[3px] bg-gradient-to-br from-primary/60 via-border to-muted-foreground/70 w-full items-center rounded-tl-[0.6rem] overflow-hidden ">


### PR DESCRIPTION
## what changed

* Wrapped the **Create Workspace** and **New Note** buttons in fixed-height containers.
* Added consistent `42px` height and `3px` padding around these buttons.
* Kept the same wrapper structure for the empty and single-workspace states.

When the sidebar changes from having one workspace to multiple workspaces, the button layout could change slightly because the surrounding structure wasn't consistent between states. This could cause a small layout shift when the workspace list updates.

Using the same fixed-size wrapper for these buttons keeps the sidebar structure consistent regardless of how many workspaces the user has.

##now

The sidebar should feel more stable when the number of workspaces changes. The **New Note** and **Create Workspace** buttons now occupy the same amount of space, helping prevent the UI from jumping when switching between the different workspace states.
