### PR TITLE
improve error and not found pages padding and alignment

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -26,9 +26,9 @@ export default function Error({
       : "An unexpected error occurred. Please try again.";
 
   return (
-    <section className="relative flex min-h-svh flex-col items-center justify-center bg-background p-6 overflow-hidden">
+    <section className="relative flex min-h-svh flex-col items-center justify-center bg-background overflow-hidden">
       <MaxWContainer className="flex flex-col items-center justify-center gap-3 *:text-center relative px-4 sm:px-6 lg:px-8">
-        <div className=" gap-2 flex justify-center items-center ">
+        <div className=" px-2 w-full gap-2 flex justify-start items-center ">
           <Image
             src={imgsrc}
             alt="Notevo Logo"
@@ -36,12 +36,12 @@ export default function Error({
             width={20}
             height={20}
           />
-          <p className="text-sm text-foreground">Notevo.me</p>
+          <p className="text-base text-foreground font-semibold">Notevo.me</p>
         </div>
-        <Card className="overflow-hidden bg-card border-border ">
-          <CardContent className="relative pt-4 pb-16">
+        <Card className="overflow-hidden bg-card border-border min-w-[300px] max-w-2xl w-full">
+          <CardContent className="relative pt-4 pb-16 ">
             <div className="flex flex-col justify-center">
-              <div className="  flex flex-col items-center justify-center gap-4 text-center">
+              <div className=" flex flex-col items-center justify-center gap-4 text-center">
                 <h2 className="text-3xl md:text-6xl text-muted-foreground font-bold">
                   Something went wrong!
                 </h2>
@@ -50,7 +50,7 @@ export default function Error({
                 </p>
               </div>
             </div>
-            <Button className=" absolute bottom-0 right-0 w-auto mt-4 h-9">
+            <Button className=" absolute bottom-0 right-0 w-auto mt-4 h-9 px-6">
               <Link href="/">Try again</Link>
             </Button>
           </CardContent>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,9 +7,9 @@ import { Card, CardContent } from "@/components/ui/card";
 
 export default function NotFound() {
   return (
-    <section className="relative flex min-h-svh flex-col items-center justify-center bg-background  p-6 md:p-10 overflow-hidden">
+    <section className="relative flex min-h-svh flex-col items-center justify-center bg-background overflow-hidden">
       <MaxWContainer className="flex flex-col items-center justify-center gap-4 *:text-center relative px-4 sm:px-6 lg:px-8">
-        <div className=" gap-2 flex justify-center items-center ">
+        <div className=" px-2 w-full gap-2 flex justify-start items-center ">
           <Image
             src={imgsrc}
             alt="Notevo Logo"
@@ -17,19 +17,19 @@ export default function NotFound() {
             width={20}
             height={20}
           />
-          <p className="text-sm text-foreground">Notevo.me</p>
+          <p className="text-base text-foreground font-semibold">Notevo.me</p>
         </div>
-        <Card className="overflow-hidden bg-card border-border">
+        <Card className="overflow-hidden bg-card border-border min-w-[300px] max-w-2xl w-full">
           <CardContent className="relative pt-4 pb-16">
             <div className="flex flex-col items-center justify-center gap-4 text-center">
-              <h2 className="text-3xl md:text-7xl text-muted-foreground font-bold">
+              <h2 className="text-5xl md:text-7xl text-muted-foreground font-bold">
                 404 Not Found
               </h2>
               <p className="text-muted-foreground text-sm md:text-base font-medium px-2 py-1">
                 Could not find requested resource
               </p>
             </div>
-            <Button className=" absolute bottom-0 right-0 w-auto mt-4 h-9">
+            <Button className=" absolute bottom-0 right-0 w-auto mt-4 h-9 px-6">
               <Link href="/">Return Home</Link>
             </Button>
           </CardContent>
@@ -44,7 +44,7 @@ export default function NotFound() {
             >
               support@notevo.me
             </Link>{" "}
-            and we'll help you out. <br /> but for now Return Home
+            and we'll help you out. but for now Return Home
           </p>
         </div>
       </MaxWContainer>


### PR DESCRIPTION
## what changed
before : 
<img width="874" height="460" alt="image" src="https://github.com/user-attachments/assets/09ab3572-0e01-4437-a6a7-74e1e88cc7c9" />
<img width="745" height="374" alt="image" src="https://github.com/user-attachments/assets/5a05de15-1017-4736-8d5f-df795d84e666" />

now : 
<img width="697" height="442" alt="image" src="https://github.com/user-attachments/assets/52d1fe93-ea88-4569-ac0c-beb3ebd304da" />
<img width="822" height="432" alt="image" src="https://github.com/user-attachments/assets/fa9056a8-bac5-4ed8-8f48-da28ffb1d74d" />

* Removed the extra page-level padding so the error and 404 layouts can use the available space more consistently.
* Updated the Notevo branding at the top to be slightly larger, bolder, and left-aligned.
* Made the error and 404 cards responsive with a `300px` minimum width and `2xl` maximum width.
* Increased the 404 heading size on smaller screens.
* Added more horizontal padding to the action buttons.
* Cleaned up the support message on the 404 page by removing the unnecessary line break.

The error and not-found pages had slightly different spacing and sizing behavior, which made them feel less consistent. The cards also didn't have a defined width range, so their size could vary more than necessary depending on the content.

These changes make the two pages follow a more consistent layout while giving the content and actions a little more room.
