### PR TITLE
polish home page hero

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -142,9 +142,9 @@ export default function HomePageClient() {
   return (
     <MaxWContainer className="relative">
       {/* Hero Section */}
-      <div className="overflow-hidden py-2 mb-16">
+      <div className="overflow-hidden py-6 mb-16">
         <header className="flex flex-col justify-center items-start gap-2 relative">
-          <h1 className="text-3xl sm:text-4xl font-bold text-primary">
+          <h1 className="text-3xl sm:text-5xl font-bold text-primary">
             {viewer?.name ? (
               <>
                 Hello,{" "}


### PR DESCRIPTION
## what changed

before : 
<img width="1451" height="589" alt="image" src="https://github.com/user-attachments/assets/f1382c0c-da9a-41cc-b179-1a6a937526c5" />

after : 
<img width="1462" height="558" alt="image" src="https://github.com/user-attachments/assets/3800d793-bd14-42e2-9bd9-65d95e268a01" />


* Increased the vertical padding of the home page hero section from `py-2` to `py-6`.
* Increased the hero heading size from `text-4xl` to `text-5xl` on larger screens.


The hero section felt a little too compressed, and the main greeting didn't have enough visual presence compared to the rest of the page. Adding more vertical space gives the header some breathing room, while the larger heading makes it feel more prominent.

The home page hero has a stronger visual hierarchy and feels less cramped. The greeting is easier to notice, especially on larger screens, while the additional spacing gives the top of the page a more balanced layout.
