### PR TITLE
align home loading state with the new layout

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -159,7 +159,7 @@ export default function HomePageClient() {
                 }`}
               </>
             ) : (
-              <SkeletonTextAnimation className=" mx-0 min-w-52 h-10" />
+              <SkeletonTextAnimation className=" mx-0 min-w-60 h-14" />
             )}
           </h1>
           <p className="text-white/90 text-md ">

--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -1,70 +1,87 @@
 import MaxWContainer from "@/components/ui/MaxWContainer";
-
-function Skeleton({ className = "" }: { className?: string }) {
-  return <div className={`bg-border rounded-md animate-pulse ${className}`} />;
-}
+import SkeletonTextAnimation from "@/components/ui/SkeletonTextAnimation";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 function WorkspaceCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[330px] min-h-[230px] rounded-lg border border-border bg-card overflow-hidden flex flex-col">
-      <div className="p-6 pb-3">
+    <Card className="relative overflow-hidden bg-card border-border flex-shrink-0 w-[330px] min-h-[230px] flex flex-col">
+      <CardHeader className="pb-3 relative">
         <Skeleton className="h-5 w-3/4" />
-      </div>
-      <div className="px-6 flex-1">
+      </CardHeader>
+      <CardContent className="flex-grow flex-1">
         <div className="h-full flex items-center justify-center">
-          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 app-radius-md" />
         </div>
-      </div>
-      <div className="px-6 py-4 flex justify-between items-center border-t border-border">
+      </CardContent>
+      <CardFooter className="py-4 flex justify-between items-center border-t border-border">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-9 w-12" />
-      </div>
-    </div>
+      </CardFooter>
+    </Card>
   );
 }
 
 function NoteCardSkeleton() {
   return (
-    <div className="flex-shrink-0 w-[330px] h-[230px] rounded-lg border border-border bg-card overflow-hidden flex flex-col">
-      <div className="p-6 pb-3">
+    <Card className="relative overflow-hidden bg-card border-border flex-shrink-0 w-[330px] h-[230px] flex flex-col">
+      <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 space-y-2">
             <Skeleton className="h-5 w-3/4" />
             <Skeleton className="h-3 w-1/2" />
           </div>
         </div>
-      </div>
-      <div className="px-6 pb-3 flex-1 space-y-2">
+      </CardHeader>
+      <CardContent className="flex-grow flex-1 space-y-2">
         <Skeleton className="h-3 w-full" />
         <Skeleton className="h-3 w-5/6" />
         <Skeleton className="h-3 w-4/6" />
-      </div>
-      <div className="px-6 py-4 flex justify-between items-center border-t border-border mt-auto">
+      </CardContent>
+      <CardFooter className="py-4 flex justify-between items-center border-t border-border mt-auto">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-9 w-12" />
+      </CardFooter>
+    </Card>
+  );
+}
+
+function SliderRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative w-full h-[250px] group">
+      <div className="absolute inset-0 flex gap-4 h-fit overflow-x-auto scrollbar-hide">
+        {children}
       </div>
     </div>
   );
 }
 
-function SliderRow({ children }: { children: React.ReactNode }) {
-  return <div className="flex gap-4 overflow-hidden h-[250px]">{children}</div>;
-}
-
 export default function Loading() {
   return (
-    <MaxWContainer className="relative my-5">
-      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-muted from-20% via-transparent via-70% to-muted p-8 mb-8">
-        <div className="max-w-3xl mx-auto text-center">
-          <Skeleton className="h-10 w-56 mx-auto mb-4" />
-          <Skeleton className="h-4 w-full max-w-xl mx-auto mb-2" />
-          <Skeleton className="h-4 w-5/6 max-w-lg mx-auto" />
-        </div>
+    <MaxWContainer className="relative">
+      {/* Hero Section */}
+      <div className="overflow-hidden py-6 mb-16">
+        <header className="flex flex-col justify-center items-start gap-2 relative">
+          <h1 className="text-3xl sm:text-5xl font-bold text-primary">
+            <SkeletonTextAnimation className="mx-0 min-w-52 h-10" />
+          </h1>
+          <p className="text-white/90 text-md">
+            Organize your thoughts , and manage your workspaces,
+          </p>
+        </header>
       </div>
 
-      <div className="mb-12">
-        <div className="mb-6 flex justify-between items-center">
-          <Skeleton className="h-7 w-44" />
+      {/* Workspaces Slider */}
+      <div className="mb-8">
+        <div className="mb-4 flex justify-between items-center">
+          <h2 className="text-foreground text-xl font-semibold">
+            Your Workspaces
+          </h2>
           <Skeleton className="h-9 w-36" />
         </div>
         <SliderRow>
@@ -74,20 +91,12 @@ export default function Loading() {
         </SliderRow>
       </div>
 
-      <div className="mb-12">
-        <div className="mb-6">
-          <Skeleton className="h-7 w-36" />
-        </div>
-        <SliderRow>
-          {[1, 2, 3].map((i) => (
-            <NoteCardSkeleton key={i} />
-          ))}
-        </SliderRow>
-      </div>
-
-      <div className="mb-12">
-        <div className="mb-6">
-          <Skeleton className="h-7 w-36" />
+      {/* Recent Notes Slider */}
+      <div className="mb-8">
+        <div className="mb-4">
+          <h2 className="text-foreground text-xl font-semibold">
+            Recent Notes
+          </h2>
         </div>
         <SliderRow>
           {[1, 2, 3].map((i) => (


### PR DESCRIPTION
## what changed

* Reworked the home page loading skeleton to match the current home page layout.
* Replaced the custom skeleton implementation with the shared `Skeleton` and `Card` components.
* Updated workspace and note skeleton cards to use the same card structure as the actual content.
* Updated the hero loading state to use `SkeletonTextAnimation` and match the current hero spacing and typography.
* Updated the workspace and recent notes section headers to match the real page instead of showing generic skeleton headings.
* Removed the extra loading section that no longer exists on the home page.
* Updated the slider loading container to support horizontal scrolling and better match the actual slider layout.
* Added consistent spacing and sizing for the loading sections.


The loading page was still based on the old home page design, so there was a noticeable difference between the skeleton UI and the actual page once the content loaded. It also had sections and spacing that no longer matched the current home page.

This updates the loading state to follow the same structure and components as the current home page.