### PR TITLE
improve home loading slider

### DIFF
--- a/app/home/loading.tsx
+++ b/app/home/loading.tsx
@@ -54,9 +54,10 @@ function NoteCardSkeleton() {
 function SliderRow({ children }: { children: React.ReactNode }) {
   return (
     <div className="relative w-full h-[250px] group">
-      <div className="absolute inset-0 flex gap-4 h-fit overflow-x-auto scrollbar-hide">
+      <div className="absolute inset-0 flex gap-4 h-fit overflow-x-auto scrollbar-none">
         {children}
       </div>
+      <div className="absolute -right-1 top-0 bottom-0 w-16 sm:w-20 bg-gradient-to-l from-background via-background/80 to-transparent z-[5] pointer-events-none" />
     </div>
   );
 }


### PR DESCRIPTION
## what changed

before : 
<img width="1402" height="364" alt="image" src="https://github.com/user-attachments/assets/14d188d5-47a7-403d-bd70-a9265e6bc34d" />

after : 
<img width="1437" height="406" alt="image" src="https://github.com/user-attachments/assets/fa909482-a57f-4d00-bf1c-162ec3892622" />


* Changed the loading slider from `scrollbar-hide` to `scrollbar-none` for cleaner scrollbar handling.
* Added a right-side gradient overlay to the slider that fades into the background.
* Made the gradient slightly wider on larger screens.
* Added `pointer-events-none` so the overlay doesn't interfere with scrolling or interaction.

The loading slider could look like it simply ended at the edge of the container, making it less obvious that there was more content available horizontally. The visible scrollbar also didn't fit well with the cleaner slider design.

The loading state now gives a clearer visual hint that more cards are available off-screen. The gradient creates a smoother fade at the edge instead of abruptly cutting off the cards, while keeping the scrollbar hidden for a cleaner UI.
